### PR TITLE
blog: 글쓰기 DX 도구와 검색·미리보기·MDX 헬퍼 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ pnpm check-types
 
 # Blog-specific commands
 pnpm blog-build  # Build blog application
+
+# 블로그 글쓰기 도구 (apps/blog/web 디렉토리에서 실행)
+pnpm new-post "글 제목" --series bundler --tags a,b      # 새 포스트 스캐폴딩
+pnpm new-post "예약글" --scheduled "2026-05-01T09:00+09:00"  # 예약 발행 글
+pnpm lint:posts                                          # frontmatter 검증 (필수 필드, 끊긴 이미지, 중복 slug 등)
 ```
 
 ## Key Design Patterns
@@ -213,24 +218,37 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
 #### 콘텐츠 파이프라인
 
 1. **콘텐츠 작성**: `apps/blog/posts/` 디렉토리에 Markdown 파일 작성
+   - 새 포스트는 `pnpm new-post "제목"` 스캐폴딩 CLI로 시작 권장 (frontmatter 자동 생성)
    - Frontmatter: `title`, `date`, `slug`, `excerpt`, `thumbnail`, `tags`, `published`, `status`, `scheduledDate`
-   - 폴더 구조로 시리즈(series) 자동 분류
+   - 폴더 구조로 시리즈(series) 자동 분류 — `posts/{series}/` 폴더에 `_series.yml`을 두면 표시명/설명/order 정의 가능
 2. **콘텐츠 공개 제어** (`isPostVisible()` 헬퍼로 판단):
    - `published: true` (기존 방식, 하위호환)
    - `status: 'published'` — 공개
    - `status: 'draft'` — 비공개 (빌드에서 제외)
    - `status: 'scheduled'` — **주의**: 반드시 `scheduledDate` (예: `scheduledDate: '2026-03-16T09:00:00+09:00'`) 값을 함께 명시해야 합니다. 누락 시 항상 비공개 처리됩니다.
    - `isPostVisible()` 로직은 `posts.ts`, `generate-sitemap.mjs`, `generate-rss.mjs`에 동일하게 적용
-3. **빌드 전 처리** (`prebuild`):
-   - `sync-posts.mjs`: 포스트 디렉토리의 이미지/미디어 파일을 `public/posts/`에 복사
-   - `generate-sitemap.mjs`: 발행된 글 목록으로 `sitemap.xml` 생성
-   - `generate-rss.mjs`: RSS 피드(`rss.xml`) 생성
-   - `generate-search-index.ts`: 검색용 JSON 인덱스(`search-index.json`) 생성
+3. **빌드 전 처리** (`prebuild` → `scripts/build-content.ts` 통합 진입점):
+   - `validate-posts.ts`: frontmatter 필수 필드, `scheduled` ↔ `scheduledDate` 정합성, 끊긴 이미지, 중복 slug 검사 (prebuild에서만 실행, predev에서는 skip)
+   - `sync-posts.mjs`: 포스트 디렉토리의 이미지/미디어 파일을 `public/posts/`에 복사 (mtime 기반 incremental — 변경분만 복사)
+   - `generate-sitemap.ts`: 발행된 글 목록으로 `sitemap.xml` 생성
+   - `generate-rss.ts`: RSS 피드(`rss.xml`) 생성
+   - `generate-search-index.ts`: 검색용 JSON 인덱스(`search-index.json`) 생성 — 본문 미리보기(`contentPreview`) 포함
+   - `generate-llms-full.ts`: AI/LLM용 통합 텍스트(`llms-full.txt`) 생성
 4. **정적 빌드**: `next build` → `out/` 디렉토리에 정적 파일 생성
 5. **배포**: GitHub Actions → GitHub Pages
    - `main` 브랜치 push 시 자동 빌드
    - **매일 KST 09:00 (UTC 00:00) cron 자동 빌드** — 예약 발행 글 공개용
    - 수동 트리거(`workflow_dispatch`) 지원
+
+#### 글쓰기 도구 (Authoring DX)
+
+| 도구 | 설명 |
+| :--- | :--- |
+| `pnpm new-post "제목"` | 새 포스트 스캐폴딩. `--series`, `--tags`, `--scheduled`, `--slug`, `--status` 옵션 지원. 한글 제목/파일명 그대로 사용 가능 |
+| `pnpm lint:posts` | frontmatter 검증. 정책: frontmatter delimiter(`---`)가 없는 파일은 메타 노트로 간주하고 조용히 skip |
+| `/preview/[...slug]` 라우트 | dev 환경에서만 동작하는 draft·scheduled 글 미리보기. prod 빌드는 placeholder 1개(`__disabled__`) + 즉시 `notFound`로 차단 |
+| `_series.yml` | 시리즈 폴더에 두면 시리즈 nav가 `order` 기준 chronological 정렬 + 표시명을 폴더명 대신 사용 |
+| `<callout type="warning\|info\|tip\|danger">` | 마크다운 헬퍼 컴포넌트 (raw HTML로 작성). `<figure>` + `<figcaption>`, `<file-tree>`도 지원 |
 
 #### 클라이언트 사이드 기능 (런타임)
 
@@ -267,6 +285,8 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
 | `.env.local`                        | 로컬 개발용 환경변수 (GA, Supabase local 등) |
 | `supabase/config.toml`              | 로컬 Supabase 설정 (Auth, DB, Storage 등)    |
 | `.github/workflows/deploy-blog.yml` | CI/CD 배포 워크플로우                        |
+| `apps/blog/posts/{series}/_series.yml` | (선택) 시리즈 표시명·설명·order 메타     |
+| `apps/blog/web/scripts/build-content.ts` | predev/prebuild 통합 진입점 (validate/sync/sitemap/rss/search/llms) |
 
 ## Prerequisites
 

--- a/apps/blog/posts/bundler/_series.yml
+++ b/apps/blog/posts/bundler/_series.yml
@@ -1,0 +1,8 @@
+title: 누가 시키지도 않았는데 번들러 만들기
+description: JavaScript 번들러를 처음부터 직접 만들어보는 시리즈
+order:
+  - no-one-asked-library-bundler-00-prologue
+  - no-one-asked-library-bundler-01-concept
+  - no-one-asked-library-bundler-02-ast-graph
+  - no-one-asked-library-bundler-03-bundling-scope
+  - no-one-asked-library-bundler-04-sourcemap

--- a/apps/blog/web/domain/post/index.ts
+++ b/apps/blog/web/domain/post/index.ts
@@ -7,4 +7,5 @@ export * from './types';
 export * from './visibility';
 export * from './thumbnail';
 export * from './service';
+export * from './series';
 export * from './utils';

--- a/apps/blog/web/domain/post/series.ts
+++ b/apps/blog/web/domain/post/series.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+
+const postsDirectory = join(process.cwd(), '..', 'posts');
+
+export interface SeriesMeta {
+  name: string;
+  title?: string;
+  description?: string;
+  order?: string[];
+}
+
+const _metaCache = new Map<string, SeriesMeta | null>();
+
+export function getSeriesMeta(seriesName: string): SeriesMeta | null {
+  if (process.env.NODE_ENV !== 'development' && _metaCache.has(seriesName)) {
+    return _metaCache.get(seriesName) ?? null;
+  }
+
+  const candidates = ['_series.yml', '_series.yaml'].map(name =>
+    join(postsDirectory, seriesName, name),
+  );
+  const filePath = candidates.find(p => existsSync(p)) ?? null;
+
+  if (!filePath) {
+    _metaCache.set(seriesName, null);
+    return null;
+  }
+
+  const raw = readFileSync(filePath, 'utf8');
+  const { data } = matter(`---\n${raw}\n---\n`);
+
+  const meta: SeriesMeta = {
+    name: seriesName,
+    title: typeof data.title === 'string' ? data.title : undefined,
+    description:
+      typeof data.description === 'string' ? data.description : undefined,
+    order: Array.isArray(data.order)
+      ? data.order.filter((s): s is string => typeof s === 'string')
+      : undefined,
+  };
+
+  _metaCache.set(seriesName, meta);
+  return meta;
+}
+
+export function clearSeriesMetaCache(): void {
+  _metaCache.clear();
+}

--- a/apps/blog/web/domain/post/service.ts
+++ b/apps/blog/web/domain/post/service.ts
@@ -1,5 +1,6 @@
 import { readAllPosts } from './repository';
 import { isPostVisible } from './visibility';
+import { getSeriesMeta } from './series';
 import type {
   PostData,
   PostNavItem,
@@ -47,6 +48,13 @@ export function getAllPostSummaries(): PostSummary[] {
  */
 export function getAllPostsIncludingHidden(): PostData[] {
   return readAllPosts();
+}
+
+/**
+ * 미리보기/관리용: draft, scheduled 포함 slug로 포스트를 조회합니다.
+ */
+export function getPostBySlugIncludingHidden(slug: string): PostData | null {
+  return readAllPosts().find(post => post.slug === slug) ?? null;
 }
 
 let _postsBySlugMap: Map<string, PostData> | null = null;
@@ -118,6 +126,9 @@ export function getAdjacentPosts(
 
 /**
  * 같은 시리즈 내의 이전/다음 포스트를 반환합니다.
+ *
+ * `_series.yml`의 `order` 필드가 있으면 그 순서대로 정렬하고,
+ * 시리즈 표시명도 메타의 `title`로 대체합니다.
  */
 export function getSeriesAdjacentPosts(currentSlug: string): {
   prev: PostNavItem | null;
@@ -130,12 +141,47 @@ export function getSeriesAdjacentPosts(currentSlug: string): {
     return { prev: null, next: null, seriesName: null };
   }
 
+  const meta = getSeriesMeta(currentPost.series);
+  const displayName = meta?.title ?? currentPost.series;
+
+  if (meta?.order && meta.order.length > 0) {
+    const seriesPosts = getAllPosts().filter(
+      p => p.series === currentPost.series,
+    );
+    const orderMap = new Map(meta.order.map((slug, i) => [slug, i]));
+    const ordered = [...seriesPosts].sort((a, b) => {
+      const aRank =
+        orderMap.get(a.slug) ??
+        orderMap.get(a.originalSlug) ??
+        Number.POSITIVE_INFINITY;
+      const bRank =
+        orderMap.get(b.slug) ??
+        orderMap.get(b.originalSlug) ??
+        Number.POSITIVE_INFINITY;
+      if (aRank === bRank) {
+        return (a.date ?? '').localeCompare(b.date ?? '');
+      }
+      return aRank - bRank;
+    });
+    const idx = ordered.findIndex(p => p.slug === currentSlug);
+    if (idx === -1) {
+      return { prev: null, next: null, seriesName: displayName };
+    }
+    const prevPost = idx > 0 ? ordered[idx - 1] : null;
+    const nextPost = idx < ordered.length - 1 ? ordered[idx + 1] : null;
+    return {
+      prev: prevPost ? { slug: prevPost.slug, title: prevPost.title } : null,
+      next: nextPost ? { slug: nextPost.slug, title: nextPost.title } : null,
+      seriesName: displayName,
+    };
+  }
+
   const adjacent = getAdjacentPosts(currentSlug, {
     filterSeries: currentPost.series,
   });
 
   return {
     ...adjacent,
-    seriesName: currentPost.series,
+    seriesName: displayName,
   };
 }

--- a/apps/blog/web/lib/hooks/useRecentViews.ts
+++ b/apps/blog/web/lib/hooks/useRecentViews.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+
+const KEY = 'blog_recent_views';
+const MAX = 5;
+
+export interface RecentView {
+  slug: string;
+  title: string;
+  viewedAt: number;
+}
+
+function safeParse(raw: string | null): RecentView[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is RecentView =>
+        item != null &&
+        typeof item === 'object' &&
+        typeof item.slug === 'string' &&
+        typeof item.title === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function getRecentViews(): RecentView[] {
+  if (typeof window === 'undefined') return [];
+  return safeParse(window.localStorage.getItem(KEY));
+}
+
+export function recordRecentView(slug: string, title: string): void {
+  if (typeof window === 'undefined') return;
+  const list = safeParse(window.localStorage.getItem(KEY));
+  const filtered = list.filter(item => item.slug !== slug);
+  filtered.unshift({ slug, title, viewedAt: Date.now() });
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(filtered.slice(0, MAX)));
+  } catch {
+    // localStorage 한도/사적 모드 등 — 조용히 무시
+  }
+}
+
+export function useRecordRecentView(
+  slug: string | null,
+  title: string,
+): void {
+  useEffect(() => {
+    if (!slug) return;
+    recordRecentView(slug, title);
+  }, [slug, title]);
+}

--- a/apps/blog/web/lib/hooks/useViewCount.ts
+++ b/apps/blog/web/lib/hooks/useViewCount.ts
@@ -3,7 +3,7 @@ import { client } from '../client';
 
 const VIEW_COOLDOWN_HOURS = 6;
 
-export const useViewCount = (slug: string) => {
+export const useViewCount = (slug: string | null) => {
   useEffect(() => {
     if (!slug) return;
 

--- a/apps/blog/web/lib/posts.ts
+++ b/apps/blog/web/lib/posts.ts
@@ -15,6 +15,7 @@ export {
   getAllPostSummaries,
   getAllPostsIncludingHidden,
   getPostBySlug,
+  getPostBySlugIncludingHidden,
   getAllPostSlugs,
   getAdjacentPosts,
   getSeriesAdjacentPosts,

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "node sync-posts.mjs && npx tsx generate-sitemap.ts && npx tsx generate-rss.ts && npx tsx scripts/generate-search-index.ts && npx tsx scripts/generate-llms-full.ts",
+    "predev": "npx tsx scripts/build-content.ts --skip-validate",
     "dev": "pnpm supabase-start && next dev",
-    "prebuild": "node sync-posts.mjs && npx tsx generate-sitemap.ts && npx tsx generate-rss.ts && npx tsx scripts/generate-search-index.ts && npx tsx scripts/generate-llms-full.ts",
+    "prebuild": "npx tsx scripts/build-content.ts",
     "build": "pnpm prebuild && next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:posts": "npx tsx scripts/validate-posts.ts",
+    "new-post": "npx tsx scripts/new-post.ts",
     "supabase-stop": "supabase stop --all --no-backup --debug",
     "supabase-start": "pnpm supabase-stop && pnpm supabase start"
   },

--- a/apps/blog/web/public/admin-posts-index.json
+++ b/apps/blog/web/public/admin-posts-index.json
@@ -1,10 +1,14 @@
 [
   {
     "slug": "typescript-domain-modeling-without-optional",
-    "title": "[Typescript로 설계하는 프로젝트] id?: string을 버려라. ID의 존재가 곧 상태다.",
+    "title": "[Typescript로 설계하는 프로젝트] id?: string을 버려라. 상태가 다르면 타입도 달라야 한다.",
     "date": "2026-03-16",
-    "excerpt": "1. 프롤로그: 우리가 숨 쉬듯 작성하는 \"거짓말\" 주니어 개발자: \"OO님, Post 타입에서 id가 없다고 에디터에서 빨간 줄이 뜨는데, 새 글 작성할 땐 서버 id가 없으니까 그냥 ? 붙여도 될까요?\" 프론트엔드 개발을 하다 보면 슬랙이나 코드 리뷰에서 심심치 않게 보게 되는 질문...",
-    "tags": ["TypeScript", "Architecture", "Data Modeling"],
+    "excerpt": "1. 프롤로그: 우리가 숨 쉬듯 작성하는 \"거짓말\" 팀원: \"OO님, Post 타입에서 id가 없다고 에디터에서 빨간 줄이 뜨는데, 새 글 작성할 땐 서버 id가 없으니까 그냥 ? 붙여도 될까요?\" 프론트엔드 개발을 하다 보면 슬랙이나 코드 리뷰에서 심심치 않게 보게 되는 질문입니다. ...",
+    "tags": [
+      "TypeScript",
+      "Architecture",
+      "Data Modeling"
+    ],
     "series": "[Typescript로 설계하는 프로젝트]",
     "status": "published",
     "scheduledDate": null
@@ -31,7 +35,14 @@
     "title": "[누가 시키지도 않았는데 번들러 만들기] 3. 번들링과 스코프: 파일 합치기의 기술",
     "date": "2026-02-23",
     "excerpt": "단순히 파일을 합치는 것과 번들링은 다릅니다. 변수 충돌을 막기 위한 함수 스코프 전략과 브라우저를 위한 런타임 구현 과정을 깊이 있게 다룹니다.",
-    "tags": ["bundler", "javascript", "iife", "scope", "cjs", "ast"],
+    "tags": [
+      "bundler",
+      "javascript",
+      "iife",
+      "scope",
+      "cjs",
+      "ast"
+    ],
     "series": "bundler",
     "status": "published",
     "scheduledDate": null
@@ -41,7 +52,14 @@
     "title": "[누가 시키지도 않았는데 번들러 만들기] 2. 코드를 데이터로 보는 법 (AST Graph)",
     "date": "2026-02-17",
     "excerpt": "정규표현식으로 import 문을 찾으려다 실패한 경험, 그리고 AST 추상 구문 트리를 통해 코드를 데이터로 바라보는 관점을 소개합니다. 파일 시스템을 그래프로 변환하는 과정을 직접 구현해봅니다.",
-    "tags": ["bundler", "javascript", "ast", "graph", "dfs", "algorithm"],
+    "tags": [
+      "bundler",
+      "javascript",
+      "ast",
+      "graph",
+      "dfs",
+      "algorithm"
+    ],
     "series": "bundler",
     "status": "published",
     "scheduledDate": null
@@ -68,7 +86,13 @@
     "title": "[누가 시키지도 않았는데 번들러 만들기] 1. 개념과 도구: 번들러의 등장 배경",
     "date": "2026-02-02",
     "excerpt": "코드를 번들링해야 하는 기술적 이유와 자바스크립트 모듈 시스템의 발전 과정을 살펴봅니다. 또한 번들러 구현의 기반이 되는 Magic String 라이브러리를 소개합니다.",
-    "tags": ["bundler", "javascript", "history", "esm", "magic-string"],
+    "tags": [
+      "bundler",
+      "javascript",
+      "history",
+      "esm",
+      "magic-string"
+    ],
     "series": "bundler",
     "status": "published",
     "scheduledDate": null
@@ -115,7 +139,14 @@
     "title": "하루 만에 끝날 줄 알았던 디자인 시스템 배포가 3주 걸린 이유",
     "date": "2025-11-30",
     "excerpt": "하루 만에 끝날 줄 알았던 NPM 배포가 3주 걸린 이유 프롤로그: \"별거 아니겠지\"의 착각 타팀 기획자님이 내 자리로 다가왔다. \"개발자님, 저희 팀에서도 그 디자인 시스템 쓸 수 있을까요? 버튼이랑 인풋 컴포넌트가 정말 예쁘던데...\" 당시 디자인 시스템은 완성해둔 참이었다. 모노레...",
-    "tags": ["NPM", "디자인 시스템", "배포", "Panda CSS", "tsup", "빌드"],
+    "tags": [
+      "NPM",
+      "디자인 시스템",
+      "배포",
+      "Panda CSS",
+      "tsup",
+      "빌드"
+    ],
     "series": "design-system-lib-deploy",
     "status": "published",
     "scheduledDate": null

--- a/apps/blog/web/public/llms-full.txt
+++ b/apps/blog/web/public/llms-full.txt
@@ -47,7 +47,7 @@
 
 "회원 구조가 바뀌었습니다. 552개 파일을 수정해야 합니다." 보통은 이렇게 됩니다 - 어디를 수정해야 하는지 찾느라 1주 - 수정하다가 놓친 곳 때문에 버그 발생 - 회귀 테스트에 또 1주 - QA에서 엣지 케이스 발견 - 결국 한 달... 하지만 우리는 2주 만에, 사이드 이펙트 ......
 
-### [[Typescript로 설계하는 프로젝트] id?: string을 버려라. 상태가 다르면 타입도 달라야 한다.](https://blog.sangwook.dev/posts/typescript-domain-modeling-without-optional/) (2026-03-16T00:00:00.000Z)
+### [[Typescript로 설계하는 프로젝트] id?: string을 버려라. 상태가 다르면 타입도 달라야 한다.](https://blog.sangwook.dev/posts/typescript-domain-modeling-without-optional/) (2026-03-16)
 
 1. 프롤로그: 우리가 숨 쉬듯 작성하는 "거짓말" 팀원: "OO님, Post 타입에서 id가 없다고 에디터에서 빨간 줄이 뜨는데, 새 글 작성할 땐 서버 id가 없으니까 그냥 ? 붙여도 될까요?" 프론트엔드 개발을 하다 보면 슬랙이나 코드 리뷰에서 심심치 않게 보게 되는 질문입니다. ...... Tags: TypeScript, Architecture, Data Modeling.
 

--- a/apps/blog/web/public/rss.xml
+++ b/apps/blog/web/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://blog.sangwook.dev</link>
     <description>프론트엔드 기술 실험과 깊이 있는 학습 내용을 공유하는 공간입니다.</description>
     <language>ko</language>
-    <lastBuildDate>Mon, 16 Mar 2026 12:27:54 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 30 Apr 2026 12:18:15 GMT</lastBuildDate>
     <atom:link href="https://blog.sangwook.dev/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Typescript로 설계하는 프로젝트] id?: string을 버려라. 상태가 다르면 타입도 달라야 한다.</title>

--- a/apps/blog/web/public/sitemap.xml
+++ b/apps/blog/web/public/sitemap.xml
@@ -2,17 +2,17 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://blog.sangwook.dev/</loc>
-    <lastmod>2026-03-16</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/</loc>
-    <lastmod>2026-03-16</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/about/</loc>
-    <lastmod>2026-03-16</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <priority>0.7</priority>
   </url>
   
@@ -24,27 +24,27 @@
   <url>
     <loc>https://blog.sangwook.dev/posts/no-one-asked-library-bundler-04-sourcemap/</loc>
     <lastmod>2026-03-03</lastmod>
-    <priority>0.6</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/no-one-asked-library-bundler-03-bundling-scope/</loc>
     <lastmod>2026-02-23</lastmod>
-    <priority>0.6</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/no-one-asked-library-bundler-02-ast-graph/</loc>
     <lastmod>2026-02-17</lastmod>
-    <priority>0.6</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/no-one-asked-library-bundler-00-prologue/</loc>
     <lastmod>2026-02-02</lastmod>
-    <priority>0.6</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/no-one-asked-library-bundler-01-concept/</loc>
     <lastmod>2026-02-02</lastmod>
-    <priority>0.6</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/payment-system-architecture/</loc>
@@ -79,7 +79,7 @@
   <url>
     <loc>https://blog.sangwook.dev/posts/ai-opensource-contribution/</loc>
     <lastmod>2025-09-07</lastmod>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/feconf-2025-lightning-speaker/</loc>
@@ -89,12 +89,12 @@
   <url>
     <loc>https://blog.sangwook.dev/posts/nodejs-contribution/</loc>
     <lastmod>2025-08-10</lastmod>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/nextjs-contributor/</loc>
     <lastmod>2025-08-05</lastmod>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/react-component-context-api-dropzone/</loc>
@@ -154,7 +154,7 @@
   <url>
     <loc>https://blog.sangwook.dev/posts/first-open-source-contribution/</loc>
     <lastmod>2025-04-22</lastmod>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://blog.sangwook.dev/posts/aws-ecs-rollback/</loc>

--- a/apps/blog/web/scripts/build-content.ts
+++ b/apps/blog/web/scripts/build-content.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+interface Step {
+  label: string;
+  cmd: string;
+  args: string[];
+  optional?: boolean;
+}
+
+function parseFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+const skipValidate = parseFlag('skip-validate');
+const force = parseFlag('force');
+
+const steps: Step[] = [
+  ...(skipValidate
+    ? []
+    : [
+        {
+          label: 'validate-posts',
+          cmd: 'tsx',
+          args: ['scripts/validate-posts.ts'],
+        },
+      ]),
+  {
+    label: 'sync-posts',
+    cmd: 'node',
+    args: ['sync-posts.mjs', ...(force ? ['--force'] : [])],
+  },
+  { label: 'sitemap', cmd: 'tsx', args: ['generate-sitemap.ts'] },
+  { label: 'rss', cmd: 'tsx', args: ['generate-rss.ts'] },
+  { label: 'search-index', cmd: 'tsx', args: ['scripts/generate-search-index.ts'] },
+  { label: 'llms-full', cmd: 'tsx', args: ['scripts/generate-llms-full.ts'] },
+];
+
+const start = Date.now();
+console.log(`▶ build-content: ${steps.length}개 단계 실행`);
+
+for (const step of steps) {
+  const stepStart = Date.now();
+  process.stdout.write(`\n› [${step.label}] `);
+  const result = spawnSync('npx', [step.cmd, ...step.args], {
+    cwd: root,
+    stdio: 'inherit',
+    shell: false,
+  });
+  const elapsed = ((Date.now() - stepStart) / 1000).toFixed(2);
+  if (result.status !== 0) {
+    console.error(`✖ [${step.label}] 실패 (${elapsed}s, exit ${result.status})`);
+    process.exit(result.status ?? 1);
+  }
+  console.log(`✓ [${step.label}] ${elapsed}s`);
+}
+
+const total = ((Date.now() - start) / 1000).toFixed(2);
+console.log(`\n✓ build-content 완료: ${total}s`);

--- a/apps/blog/web/scripts/generate-search-index.ts
+++ b/apps/blog/web/scripts/generate-search-index.ts
@@ -4,6 +4,19 @@ import { getAllPosts, getAllPostsIncludingHidden } from '../lib/posts';
 
 const outputPath = join(process.cwd(), 'public', 'search-index.json');
 
+const CONTENT_PREVIEW_CHARS = 1500;
+
+function toPlainText(content: string): string {
+  return content
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#*`_>~]/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // 공개 포스트용 검색 인덱스 (프론트엔드 검색용)
 const publicPosts = getAllPosts().map(p => ({
   slug: p.slug,
@@ -12,6 +25,7 @@ const publicPosts = getAllPosts().map(p => ({
   excerpt: p.excerpt || '',
   tags: p.tags || [],
   series: p.series || null,
+  contentPreview: toPlainText(p.content).slice(0, CONTENT_PREVIEW_CHARS),
 }));
 
 writeFileSync(outputPath, JSON.stringify(publicPosts, null, 2), 'utf8');

--- a/apps/blog/web/scripts/new-post.ts
+++ b/apps/blog/web/scripts/new-post.ts
@@ -1,0 +1,176 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const POSTS_DIR = resolve(process.cwd(), '..', 'posts');
+
+interface Options {
+  title?: string;
+  series?: string;
+  status: 'draft' | 'published' | 'scheduled';
+  scheduledDate?: string;
+  slug?: string;
+  tags: string[];
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = { status: 'draft', tags: [] };
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      let key: string;
+      let value: string;
+      if (eq !== -1) {
+        key = arg.slice(2, eq);
+        value = arg.slice(eq + 1);
+      } else {
+        key = arg.slice(2);
+        value = argv[++i] ?? '';
+      }
+      switch (key) {
+        case 'title':
+          opts.title = value;
+          break;
+        case 'series':
+          opts.series = value;
+          break;
+        case 'status':
+          if (value !== 'draft' && value !== 'published' && value !== 'scheduled') {
+            throw new Error(`status는 draft|published|scheduled 중 하나여야 합니다.`);
+          }
+          opts.status = value;
+          break;
+        case 'scheduled':
+        case 'scheduledDate':
+          opts.scheduledDate = value;
+          opts.status = 'scheduled';
+          break;
+        case 'slug':
+          opts.slug = value;
+          break;
+        case 'tags':
+          opts.tags = value.split(',').map(t => t.trim()).filter(Boolean);
+          break;
+        default:
+          throw new Error(`알 수 없는 옵션: --${key}`);
+      }
+    } else if (arg.startsWith('-')) {
+      const key = arg.slice(1);
+      const value = argv[++i] ?? '';
+      switch (key) {
+        case 't': opts.title = value; break;
+        case 's': opts.series = value; break;
+        default: throw new Error(`알 수 없는 옵션: -${key}`);
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (!opts.title && positional.length > 0) {
+    opts.title = positional[0];
+  }
+
+  return opts;
+}
+
+function todayKST(): string {
+  const now = new Date();
+  const kstMs = now.getTime() + 9 * 60 * 60 * 1000;
+  const kst = new Date(kstMs);
+  return kst.toISOString().split('T')[0];
+}
+
+function safeFilename(title: string): string {
+  return title.replace(/[/\\\0]/g, '-').trim();
+}
+
+function buildFrontmatter(opts: Required<Pick<Options, 'title' | 'status' | 'tags'>> & Pick<Options, 'slug' | 'scheduledDate'>): string {
+  const lines = ['---'];
+  lines.push(`title: '${opts.title.replace(/'/g, "''")}'`);
+  lines.push(`date: ${todayKST()}`);
+  lines.push(`status: ${opts.status}`);
+  if (opts.scheduledDate) {
+    lines.push(`scheduledDate: '${opts.scheduledDate}'`);
+  }
+  if (opts.slug) {
+    lines.push(`slug: ${opts.slug}`);
+  }
+  lines.push(`excerpt: ''`);
+  lines.push(`tags: [${opts.tags.join(', ')}]`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${opts.title}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function printUsage() {
+  console.log(`사용법:
+  pnpm new-post "글 제목" [옵션]
+
+옵션:
+  --series <name>          시리즈 폴더 (예: bundler)
+  --status <s>             draft | published | scheduled (기본 draft)
+  --scheduled <iso>        예약 발행 일시. 자동으로 status: scheduled 적용
+  --slug <slug>            URL용 영문 slug (선택)
+  --tags <a,b,c>           쉼표 구분 태그
+
+예시:
+  pnpm new-post "번들러 만들기 3편" --series bundler --tags bundler,build
+  pnpm new-post "릴리스 노트" --scheduled "2026-05-01T09:00:00+09:00"
+`);
+}
+
+function main() {
+  let opts: Options;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(`✖ ${(e as Error).message}\n`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!opts.title) {
+    printUsage();
+    process.exit(1);
+  }
+
+  if (opts.status === 'scheduled' && !opts.scheduledDate) {
+    console.error('✖ status: scheduled에는 --scheduled <ISO 날짜>가 필요합니다.');
+    process.exit(1);
+  }
+
+  const targetDir = opts.series ? join(POSTS_DIR, opts.series) : POSTS_DIR;
+  if (!existsSync(targetDir)) {
+    mkdirSync(targetDir, { recursive: true });
+  }
+
+  const fileName = `${safeFilename(opts.title)}.md`;
+  const targetPath = join(targetDir, fileName);
+
+  if (existsSync(targetPath)) {
+    console.error(`✖ 이미 존재합니다: ${targetPath}`);
+    process.exit(1);
+  }
+
+  const frontmatter = buildFrontmatter({
+    title: opts.title,
+    status: opts.status,
+    tags: opts.tags,
+    slug: opts.slug,
+    scheduledDate: opts.scheduledDate,
+  });
+
+  writeFileSync(targetPath, frontmatter, 'utf8');
+  const rel = targetPath.replace(`${POSTS_DIR}/`, '');
+  console.log(`✓ 새 포스트 생성됨: posts/${rel}`);
+  console.log(`  status: ${opts.status}`);
+  if (opts.series) console.log(`  series: ${opts.series}`);
+  if (opts.scheduledDate) console.log(`  scheduledDate: ${opts.scheduledDate}`);
+}
+
+main();

--- a/apps/blog/web/scripts/new-post.ts
+++ b/apps/blog/web/scripts/new-post.ts
@@ -77,10 +77,9 @@ function parseArgs(argv: string[]): Options {
 }
 
 function todayKST(): string {
-  const now = new Date();
-  const kstMs = now.getTime() + 9 * 60 * 60 * 1000;
-  const kst = new Date(kstMs);
-  return kst.toISOString().split('T')[0];
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+  }).format(new Date());
 }
 
 function safeFilename(title: string): string {

--- a/apps/blog/web/scripts/validate-posts.ts
+++ b/apps/blog/web/scripts/validate-posts.ts
@@ -1,0 +1,295 @@
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, relative, resolve, dirname, posix } from 'node:path';
+import matter from 'gray-matter';
+
+const POSTS_DIR = resolve(process.cwd(), '..', 'posts');
+const VALID_STATUSES = ['published', 'draft', 'scheduled'] as const;
+
+type Severity = 'error' | 'warning';
+
+interface Issue {
+  file: string;
+  line: number | null;
+  severity: Severity;
+  rule: string;
+  message: string;
+}
+
+interface PostRecord {
+  absPath: string;
+  relPath: string;
+  data: Record<string, unknown>;
+  content: string;
+}
+
+function collectMarkdownFiles(dir: string, results: string[] = []): string[] {
+  for (const item of readdirSync(dir)) {
+    const full = join(dir, item);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      collectMarkdownFiles(full, results);
+      continue;
+    }
+    if (item.endsWith('.md') || item.endsWith('.mdx')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function findFrontmatterLine(raw: string, key: string): number | null {
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return null;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return null;
+    const m = lines[i].match(/^(\w+)\s*:/);
+    if (m && m[1] === key) return i + 1;
+  }
+  return null;
+}
+
+function isMetaFile(absPath: string): boolean {
+  const name = absPath.split('/').pop() ?? '';
+  return ['PLAN.md', 'THUMBNAIL_LOG.md', 'STUDY_LOG.md'].includes(name);
+}
+
+function hasFrontmatter(raw: string): boolean {
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return false;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return true;
+  }
+  return false;
+}
+
+function validatePost(record: PostRecord, raw: string): Issue[] {
+  const { data, relPath, absPath } = record;
+  const issues: Issue[] = [];
+
+  const hasAnyVisibilityField =
+    'status' in data || 'published' in data || 'slug' in data;
+  if (!hasAnyVisibilityField) {
+    issues.push({
+      file: relPath,
+      line: 1,
+      severity: 'warning',
+      rule: 'meta-file-skipped',
+      message:
+        '`status`, `published`, `slug` 중 어느 것도 없어 빌드에서 제외됩니다. 메타 파일이면 무시해도 됩니다.',
+    });
+    return issues;
+  }
+
+  if (!data.title || typeof data.title !== 'string') {
+    issues.push({
+      file: relPath,
+      line: findFrontmatterLine(raw, 'title'),
+      severity: 'error',
+      rule: 'missing-title',
+      message: '`title` 필드가 필요합니다.',
+    });
+  }
+
+  if (data.date != null) {
+    const dateValid =
+      data.date instanceof Date ||
+      (typeof data.date === 'string' && !Number.isNaN(Date.parse(data.date)));
+    if (!dateValid) {
+      issues.push({
+        file: relPath,
+        line: findFrontmatterLine(raw, 'date'),
+        severity: 'error',
+        rule: 'invalid-date',
+        message: `\`date\`가 유효한 날짜가 아닙니다: ${String(data.date)}`,
+      });
+    }
+  }
+
+  if ('status' in data) {
+    if (
+      typeof data.status !== 'string' ||
+      !VALID_STATUSES.includes(data.status as (typeof VALID_STATUSES)[number])
+    ) {
+      issues.push({
+        file: relPath,
+        line: findFrontmatterLine(raw, 'status'),
+        severity: 'error',
+        rule: 'invalid-status',
+        message: `\`status\`는 ${VALID_STATUSES.join(', ')} 중 하나여야 합니다.`,
+      });
+    }
+  }
+
+  if (data.status === 'scheduled') {
+    if (typeof data.scheduledDate !== 'string') {
+      issues.push({
+        file: relPath,
+        line: findFrontmatterLine(raw, 'status'),
+        severity: 'error',
+        rule: 'scheduled-without-date',
+        message:
+          '`status: scheduled`인 경우 `scheduledDate` 필드가 필수입니다. 누락 시 항상 비공개 처리됩니다.',
+      });
+    } else if (Number.isNaN(Date.parse(data.scheduledDate))) {
+      issues.push({
+        file: relPath,
+        line: findFrontmatterLine(raw, 'scheduledDate'),
+        severity: 'error',
+        rule: 'invalid-scheduled-date',
+        message: `\`scheduledDate\`가 유효한 날짜가 아닙니다: ${data.scheduledDate}`,
+      });
+    }
+  }
+
+  if ('tags' in data && !Array.isArray(data.tags)) {
+    issues.push({
+      file: relPath,
+      line: findFrontmatterLine(raw, 'tags'),
+      severity: 'error',
+      rule: 'invalid-tags',
+      message: '`tags`는 배열이어야 합니다. 예: `tags: [bundler, build]`',
+    });
+  }
+
+  if ('thumbnail' in data && typeof data.thumbnail === 'string') {
+    const thumb = data.thumbnail;
+    if (!/^https?:\/\//.test(thumb) && !thumb.startsWith('/')) {
+      const resolved = resolve(dirname(absPath), thumb);
+      if (!existsSync(resolved)) {
+        issues.push({
+          file: relPath,
+          line: findFrontmatterLine(raw, 'thumbnail'),
+          severity: 'error',
+          rule: 'missing-thumbnail',
+          message: `썸네일 파일을 찾을 수 없습니다: ${thumb}`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+function frontmatterOffset(raw: string): number {
+  const lines = raw.split('\n');
+  if (lines[0]?.trim() !== '---') return 0;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return i + 1;
+  }
+  return 0;
+}
+
+function validateImageReferences(record: PostRecord, raw: string): Issue[] {
+  const { content, absPath, relPath } = record;
+  const issues: Issue[] = [];
+  const imageRegex = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  const offset = frontmatterOffset(raw);
+
+  let match: RegExpExecArray | null;
+  while ((match = imageRegex.exec(content)) !== null) {
+    const ref = match[1];
+    if (
+      /^https?:\/\//.test(ref) ||
+      ref.startsWith('/') ||
+      ref.startsWith('data:')
+    ) {
+      continue;
+    }
+
+    const cleanRef = decodeURIComponent(ref.split('#')[0].split('?')[0]);
+    const resolved = resolve(dirname(absPath), cleanRef);
+    if (!existsSync(resolved)) {
+      const lineInContent = content.slice(0, match.index).split('\n').length;
+      issues.push({
+        file: relPath,
+        line: offset + lineInContent,
+        severity: 'error',
+        rule: 'missing-image',
+        message: `이미지 파일을 찾을 수 없습니다: ${cleanRef}`,
+      });
+    }
+  }
+  return issues;
+}
+
+function detectDuplicateSlugs(records: PostRecord[]): Issue[] {
+  const slugMap = new Map<string, string[]>();
+  for (const r of records) {
+    const explicit = typeof r.data.slug === 'string' ? r.data.slug : null;
+    if (!explicit) continue;
+    const arr = slugMap.get(explicit) ?? [];
+    arr.push(r.relPath);
+    slugMap.set(explicit, arr);
+  }
+
+  const issues: Issue[] = [];
+  for (const [slug, files] of slugMap.entries()) {
+    if (files.length < 2) continue;
+    for (const file of files) {
+      issues.push({
+        file,
+        line: null,
+        severity: 'error',
+        rule: 'duplicate-slug',
+        message: `slug \`${slug}\`이(가) 다른 글과 중복됩니다: ${files.filter(f => f !== file).join(', ')}`,
+      });
+    }
+  }
+  return issues;
+}
+
+function format(issue: Issue): string {
+  const tag = issue.severity === 'error' ? '✖' : '⚠';
+  const loc = issue.line ? `${issue.file}:${issue.line}` : issue.file;
+  return `  ${tag} ${loc}\n    [${issue.rule}] ${issue.message}`;
+}
+
+function main() {
+  const allFiles = collectMarkdownFiles(POSTS_DIR);
+  const records: PostRecord[] = [];
+  const allIssues: Issue[] = [];
+
+  for (const absPath of allFiles) {
+    if (isMetaFile(absPath)) continue;
+    const raw = readFileSync(absPath, 'utf8');
+    if (!hasFrontmatter(raw)) continue;
+    const { data, content } = matter(raw);
+    const relPath = posix.normalize(relative(POSTS_DIR, absPath));
+    const record: PostRecord = { absPath, relPath, data, content };
+    records.push(record);
+    allIssues.push(...validatePost(record, raw));
+    allIssues.push(...validateImageReferences(record, raw));
+  }
+
+  allIssues.push(...detectDuplicateSlugs(records));
+
+  if (allIssues.length === 0) {
+    console.log(`✓ ${records.length}개 포스트 검증 통과`);
+    process.exit(0);
+  }
+
+  const errors = allIssues.filter(i => i.severity === 'error');
+  const warnings = allIssues.filter(i => i.severity === 'warning');
+
+  console.log(
+    `\n포스트 검증 결과: ${records.length}개 검사, 에러 ${errors.length}건, 경고 ${warnings.length}건\n`,
+  );
+
+  const grouped = new Map<string, Issue[]>();
+  for (const issue of allIssues) {
+    const arr = grouped.get(issue.file) ?? [];
+    arr.push(issue);
+    grouped.set(issue.file, arr);
+  }
+  for (const [file, issues] of grouped.entries()) {
+    console.log(file);
+    for (const issue of issues) {
+      console.log(format(issue));
+    }
+    console.log('');
+  }
+
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/apps/blog/web/scripts/validate-posts.ts
+++ b/apps/blog/web/scripts/validate-posts.ts
@@ -212,14 +212,19 @@ function validateImageReferences(record: PostRecord, raw: string): Issue[] {
   return issues;
 }
 
+// 명시 slug가 없으면 파일경로(확장자 제거)를 기본 slug로 사용 — repository.ts의 rawSlug 규칙과 동일
+function deriveDefaultSlug(relPath: string): string {
+  return relPath.replace(/\.(md|mdx)$/, '');
+}
+
 function detectDuplicateSlugs(records: PostRecord[]): Issue[] {
   const slugMap = new Map<string, string[]>();
   for (const r of records) {
     const explicit = typeof r.data.slug === 'string' ? r.data.slug : null;
-    if (!explicit) continue;
-    const arr = slugMap.get(explicit) ?? [];
+    const effective = explicit ?? deriveDefaultSlug(r.relPath);
+    const arr = slugMap.get(effective) ?? [];
     arr.push(r.relPath);
-    slugMap.set(explicit, arr);
+    slugMap.set(effective, arr);
   }
 
   const issues: Issue[] = [];
@@ -231,7 +236,7 @@ function detectDuplicateSlugs(records: PostRecord[]): Issue[] {
         line: null,
         severity: 'error',
         rule: 'duplicate-slug',
-        message: `slug \`${slug}\`이(가) 다른 글과 중복됩니다: ${files.filter(f => f !== file).join(', ')}`,
+        message: `slug \`${slug}\`이(가) 다른 글과 충돌합니다 (명시 slug ↔ 파일명 기반 slug 포함 검사): ${files.filter(f => f !== file).join(', ')}`,
       });
     }
   }

--- a/apps/blog/web/src/app/admin/analytics/[slug]/PostDetailClient.tsx
+++ b/apps/blog/web/src/app/admin/analytics/[slug]/PostDetailClient.tsx
@@ -66,6 +66,7 @@ function PostDetailContent() {
     endDate,
     setEndDate,
     filteredTrends,
+    autoFellBackToAll,
   } = useDateFilter(post.trends);
 
   const trendData = filteredTrends.map(d => {
@@ -467,15 +468,34 @@ function PostDetailContent() {
             gap: '1rem',
           })}
         >
-          <h3
+          <div
             className={css({
-              fontSize: '1.125rem',
-              fontWeight: 'bold',
-              color: '#111827',
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: '0.75rem',
+              flexWrap: 'wrap',
             })}
           >
-            📈 일별 조회수 추이
-          </h3>
+            <h3
+              className={css({
+                fontSize: '1.125rem',
+                fontWeight: 'bold',
+                color: '#111827',
+              })}
+            >
+              📈 일별 조회수 추이
+            </h3>
+            {autoFellBackToAll && (
+              <span
+                className={css({
+                  fontSize: '0.75rem',
+                  color: '#9ca3af',
+                })}
+              >
+                최근 30일 데이터가 없어 전체 기간으로 표시 중
+              </span>
+            )}
+          </div>
           <DateRangeControls
             filterType={filterType}
             setFilterType={setFilterType}

--- a/apps/blog/web/src/app/admin/analytics/[slug]/page.tsx
+++ b/apps/blog/web/src/app/admin/analytics/[slug]/page.tsx
@@ -1,10 +1,12 @@
-import { getAllPostSlugs } from '@/lib/posts';
+import { getAllPostsIncludingHidden } from '@/lib/posts';
 import PostDetailClient from './PostDetailClient';
 
+// admin은 인증된 본인만 접근하는 페이지이므로 draft·scheduled 글까지 모두 정적 라우트로 생성합니다.
+// 그렇지 않으면 draft가 published로 promote되거나 scheduled가 cron 사이에 활성화될 때
+// admin 리스트엔 보이지만 detail 페이지는 GitHub Pages에서 404가 됩니다.
 export function generateStaticParams() {
-  const slugs = getAllPostSlugs();
-  return slugs.map(slug => ({
-    slug,
+  return getAllPostsIncludingHidden().map(post => ({
+    slug: post.slug,
   }));
 }
 

--- a/apps/blog/web/src/app/admin/components/DateRangeControls.tsx
+++ b/apps/blog/web/src/app/admin/components/DateRangeControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { css } from '@design-system/ui-lib/css';
 
 export type FilterType = 'all' | '7days' | '30days' | 'custom';
@@ -8,9 +8,35 @@ export type FilterType = 'all' | '7days' | '30days' | 'custom';
 export function useDateFilter(
   trends: { view_date: string; view_count: number }[],
 ) {
-  const [filterType, setFilterType] = useState<FilterType>('30days');
+  const [filterType, setFilterTypeRaw] = useState<FilterType>('30days');
   const [startDate, setStartDate] = useState<string>('');
   const [endDate, setEndDate] = useState<string>('');
+  // 30일 default가 빈 결과를 만들 때 자동으로 'all'로 fallback했는지 표시
+  const [autoFellBackToAll, setAutoFellBackToAll] = useState(false);
+
+  const setFilterType = (val: FilterType) => {
+    setFilterTypeRaw(val);
+    setAutoFellBackToAll(false);
+  };
+
+  // 데이터가 있는데 default 30일에 0건 매칭이면 'all'로 1회 자동 전환
+  useEffect(() => {
+    if (filterType !== '30days') return;
+    if (autoFellBackToAll) return;
+    if (!trends || trends.length === 0) return;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const cutoff = new Date(today);
+    cutoff.setDate(today.getDate() - 30);
+    const cutoffStr = cutoff.toISOString().split('T')[0];
+
+    const hasRecent = trends.some(t => t.view_date >= cutoffStr);
+    if (!hasRecent) {
+      setFilterTypeRaw('all');
+      setAutoFellBackToAll(true);
+    }
+  }, [trends, filterType, autoFellBackToAll]);
 
   const filteredTrends = useMemo(() => {
     if (!trends || trends.length === 0) return [];
@@ -52,6 +78,7 @@ export function useDateFilter(
     endDate,
     setEndDate,
     filteredTrends,
+    autoFellBackToAll,
   };
 }
 

--- a/apps/blog/web/src/app/layout.tsx
+++ b/apps/blog/web/src/app/layout.tsx
@@ -10,7 +10,9 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://blog.sangwook.dev'),
   alternates: {
     types: {
-      'application/rss+xml': '/rss.xml',
+      'application/rss+xml': [
+        { url: '/rss.xml', title: 'Frontend Lab RSS Feed' },
+      ],
     },
   },
   title: 'Frontend Lab | 프론트엔드 실험실',
@@ -80,6 +82,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko">
+      <head>
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Frontend Lab RSS Feed"
+          href="/rss.xml"
+        />
+      </head>
       <body>
         <Providers>
           <Layout>{children}</Layout>

--- a/apps/blog/web/src/app/layout.tsx
+++ b/apps/blog/web/src/app/layout.tsx
@@ -8,13 +8,8 @@ import type { ReactNode } from 'react';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://blog.sangwook.dev'),
-  alternates: {
-    types: {
-      'application/rss+xml': [
-        { url: '/rss.xml', title: 'Frontend Lab RSS Feed' },
-      ],
-    },
-  },
+  // RSS alternate link는 RootLayout의 <head>에 직접 추가합니다
+  // (Next 16 metadata.alternates.types로는 출력되지 않는 문제 회피)
   title: 'Frontend Lab | 프론트엔드 실험실',
   description:
     'React, TypeScript, 번들러 아키텍처부터 오픈소스 기여까지. 프론트엔드 엔지니어 한상욱이 직접 실험하고 기록하는 공간입니다. 설계 패턴, 성능 최적화, 오픈소스 기여 노하우를 다룹니다.',

--- a/apps/blog/web/src/app/posts/[...slug]/PostClient.tsx
+++ b/apps/blog/web/src/app/posts/[...slug]/PostClient.tsx
@@ -11,6 +11,7 @@ import { SsgoiTransition } from '@ssgoi/react';
 import type { PostData } from '@/lib/posts';
 import GiscusComments from '@/src/components/GiscusComments';
 import { useViewCount } from '@/lib/hooks/useViewCount';
+import { useRecordRecentView } from '@/lib/hooks/useRecentViews';
 import { ReadingProgressBar } from '@/src/components/mobile/ReadingProgressBar';
 import { BackToTop } from '@/src/components/mobile/BackToTop';
 import { MobileTOC } from '@/src/components/mobile/MobileTOC';
@@ -18,15 +19,21 @@ import { ShareButton } from '@/src/components/mobile/ShareButton';
 import { DesktopTOC } from '@/src/components/desktop/DesktopTOC';
 import { CodeBlock } from '@/src/components/post/CodeBlock';
 import { MarkdownImage } from '@/src/components/post/MarkdownImage';
+import { Callout } from '@/src/components/post/markdown/Callout';
+import { Figure } from '@/src/components/post/markdown/Figure';
+import { FileTree } from '@/src/components/post/markdown/FileTree';
 
 export default function PostClient({
   post,
   thumbnailUrl,
+  previewMode = false,
 }: {
   post: PostData;
   thumbnailUrl?: string;
+  previewMode?: boolean;
 }) {
-  useViewCount(post.slug);
+  useViewCount(previewMode ? null : post.slug);
+  useRecordRecentView(previewMode ? null : post.slug, post.title);
   return (
     <>
       <ReadingProgressBar />
@@ -387,7 +394,10 @@ export default function PostClient({
                       </li>
                     );
                   },
-                }}
+                  callout: Callout,
+                  'file-tree': FileTree,
+                  figure: Figure,
+                } as React.ComponentProps<typeof ReactMarkdown>['components']}
               >
                 {post.content}
               </ReactMarkdown>

--- a/apps/blog/web/src/app/preview/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/preview/[...slug]/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation';
+import {
+  getAllPostsIncludingHidden,
+  getPostBySlugIncludingHidden,
+} from '@/lib/posts';
+import { resolveThumbnailUrl } from '@/domain/post/thumbnail';
+import PostClient from '@/src/app/posts/[...slug]/PostClient';
+import { PreviewBanner } from '@/src/components/preview/PreviewBanner';
+
+interface Props {
+  params: Promise<{
+    slug: string[];
+  }>;
+}
+
+export const dynamic = 'force-static';
+
+export async function generateStaticParams() {
+  if (process.env.NODE_ENV !== 'development') {
+    return [{ slug: ['__disabled__'] }];
+  }
+  return getAllPostsIncludingHidden().map(post => ({
+    slug: post.slug.split('/'),
+  }));
+}
+
+export const metadata = {
+  title: 'Preview',
+  robots: { index: false, follow: false },
+};
+
+export default async function PreviewPage({ params }: Props) {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  const resolvedParams = await params;
+  const slug = decodeURIComponent(resolvedParams.slug.join('/'));
+  const post = getPostBySlugIncludingHidden(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const thumbnailUrl = resolveThumbnailUrl(post);
+  const status = post.status ?? 'published';
+
+  return (
+    <>
+      <PreviewBanner status={status} scheduledDate={post.scheduledDate} />
+      <PostClient
+        post={post}
+        thumbnailUrl={post.thumbnail ? thumbnailUrl : undefined}
+        previewMode
+      />
+    </>
+  );
+}

--- a/apps/blog/web/src/components/post/markdown/Callout.tsx
+++ b/apps/blog/web/src/components/post/markdown/Callout.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from 'react';
+import { css } from '@design-system/ui-lib/css';
+
+type CalloutType = 'info' | 'tip' | 'warning' | 'danger';
+
+const STYLES: Record<
+  CalloutType,
+  { wrapper: string; icon: string; label: string }
+> = {
+  info: {
+    wrapper: css({
+      bg: 'blue.50',
+      borderLeftWidth: '4px',
+      borderLeftColor: 'blue.400',
+      color: 'blue.900',
+    }),
+    icon: 'ℹ️',
+    label: 'Info',
+  },
+  tip: {
+    wrapper: css({
+      bg: 'green.50',
+      borderLeftWidth: '4px',
+      borderLeftColor: 'green.500',
+      color: 'green.900',
+    }),
+    icon: '💡',
+    label: 'Tip',
+  },
+  warning: {
+    wrapper: css({
+      bg: 'amber.50',
+      borderLeftWidth: '4px',
+      borderLeftColor: 'amber.500',
+      color: 'amber.900',
+    }),
+    icon: '⚠️',
+    label: 'Warning',
+  },
+  danger: {
+    wrapper: css({
+      bg: 'red.50',
+      borderLeftWidth: '4px',
+      borderLeftColor: 'red.500',
+      color: 'red.900',
+    }),
+    icon: '🚨',
+    label: 'Danger',
+  },
+};
+
+function isCalloutType(value: unknown): value is CalloutType {
+  return (
+    typeof value === 'string' &&
+    (value === 'info' || value === 'tip' || value === 'warning' || value === 'danger')
+  );
+}
+
+interface CalloutProps {
+  type?: string;
+  title?: string;
+  children?: ReactNode;
+}
+
+export function Callout({ type, title, children }: CalloutProps) {
+  const variant = isCalloutType(type) ? type : 'info';
+  const { wrapper, icon, label } = STYLES[variant];
+
+  return (
+    <aside
+      className={`${wrapper} ${css({
+        rounded: 'md',
+        my: '6',
+        px: '5',
+        py: '4',
+        display: 'flex',
+        gap: '3',
+        alignItems: 'flex-start',
+      })}`}
+    >
+      <span aria-hidden className={css({ fontSize: 'lg', lineHeight: '1.4' })}>
+        {icon}
+      </span>
+      <div className={css({ flex: 1, minW: 0, '& > *:last-child': { mb: 0 } })}>
+        <div
+          className={css({
+            fontWeight: 'bold',
+            fontSize: 'sm',
+            mb: '1',
+            letterSpacing: 'wide',
+          })}
+        >
+          {title ?? label}
+        </div>
+        {children}
+      </div>
+    </aside>
+  );
+}

--- a/apps/blog/web/src/components/post/markdown/Figure.tsx
+++ b/apps/blog/web/src/components/post/markdown/Figure.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { css } from '@design-system/ui-lib/css';
+
+interface FigureProps {
+  children?: ReactNode;
+}
+
+export function Figure({ children }: FigureProps) {
+  return (
+    <figure
+      className={css({
+        my: '8',
+        textAlign: 'center',
+        '& img': {
+          mx: 'auto',
+          mb: '0',
+        },
+        '& figcaption': {
+          mt: '3',
+          fontSize: 'sm',
+          color: 'ink.500',
+          fontStyle: 'italic',
+        },
+      })}
+    >
+      {children}
+    </figure>
+  );
+}

--- a/apps/blog/web/src/components/post/markdown/FileTree.tsx
+++ b/apps/blog/web/src/components/post/markdown/FileTree.tsx
@@ -1,0 +1,108 @@
+import { Children } from 'react';
+import type { ReactNode } from 'react';
+import { css } from '@design-system/ui-lib/css';
+
+interface FileTreeProps {
+  children?: ReactNode;
+}
+
+function extractText(children: ReactNode): string {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  if (!children) return '';
+  if (Array.isArray(children)) {
+    return children.map(extractText).join('');
+  }
+  if (
+    typeof children === 'object' &&
+    'props' in children &&
+    children.props &&
+    typeof children.props === 'object' &&
+    'children' in children.props
+  ) {
+    return extractText((children.props as { children: ReactNode }).children);
+  }
+  return '';
+}
+
+interface Line {
+  depth: number;
+  name: string;
+  isDir: boolean;
+}
+
+function parseLines(raw: string): Line[] {
+  return raw
+    .split('\n')
+    .map(line => line.replace(/\s+$/, ''))
+    .filter(line => line.trim().length > 0)
+    .map(line => {
+      const indentMatch = line.match(/^(\s*)/);
+      const indent = indentMatch ? indentMatch[1].length : 0;
+      const depth = Math.floor(indent / 2);
+      const trimmed = line.trim();
+      const isDir = trimmed.endsWith('/');
+      const name = isDir ? trimmed.slice(0, -1) : trimmed;
+      return { depth, name, isDir };
+    });
+}
+
+function renderTreeLine(line: Line, isLast: boolean, ancestorContinues: boolean[]): string {
+  const branches = ancestorContinues
+    .map(c => (c ? '│  ' : '   '))
+    .join('');
+  const connector = isLast ? '└─ ' : '├─ ';
+  return `${branches}${connector}${line.name}${line.isDir ? '/' : ''}`;
+}
+
+export function FileTree({ children }: FileTreeProps) {
+  const text = Children.toArray(children).map(extractText).join('\n');
+  const lines = parseLines(text);
+
+  const rendered: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const ancestorContinues: boolean[] = [];
+    for (let d = 0; d < line.depth; d++) {
+      let hasMoreSibling = false;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].depth < d) break;
+        if (lines[j].depth === d) {
+          hasMoreSibling = true;
+          break;
+        }
+      }
+      ancestorContinues.push(hasMoreSibling);
+    }
+    let isLast = true;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].depth < line.depth) break;
+      if (lines[j].depth === line.depth) {
+        isLast = false;
+        break;
+      }
+    }
+    rendered.push(renderTreeLine(line, isLast, ancestorContinues));
+  }
+
+  return (
+    <pre
+      className={css({
+        bg: 'ink.50',
+        border: '1px solid',
+        borderColor: 'ink.border',
+        rounded: 'lg',
+        px: '5',
+        py: '4',
+        my: '6',
+        fontSize: 'sm',
+        lineHeight: '1.7',
+        color: 'ink.700',
+        overflow: 'auto',
+        fontFamily: 'mono',
+      })}
+    >
+      {rendered.join('\n')}
+    </pre>
+  );
+}

--- a/apps/blog/web/src/components/post/markdown/FileTree.tsx
+++ b/apps/blog/web/src/components/post/markdown/FileTree.tsx
@@ -1,4 +1,4 @@
-import { Children } from 'react';
+import { Children, isValidElement } from 'react';
 import type { ReactNode } from 'react';
 import { css } from '@design-system/ui-lib/css';
 
@@ -9,18 +9,12 @@ interface FileTreeProps {
 function extractText(children: ReactNode): string {
   if (typeof children === 'string') return children;
   if (typeof children === 'number') return String(children);
-  if (!children) return '';
+  if (children == null || typeof children === 'boolean') return '';
   if (Array.isArray(children)) {
     return children.map(extractText).join('');
   }
-  if (
-    typeof children === 'object' &&
-    'props' in children &&
-    children.props &&
-    typeof children.props === 'object' &&
-    'children' in children.props
-  ) {
-    return extractText((children.props as { children: ReactNode }).children);
+  if (isValidElement<{ children?: ReactNode }>(children)) {
+    return extractText(children.props.children);
   }
   return '';
 }
@@ -31,16 +25,18 @@ interface Line {
   isDir: boolean;
 }
 
+// 2-space 들여쓰기 컨벤션 (탭은 2-space 단위로 정규화)
 function parseLines(raw: string): Line[] {
   return raw
     .split('\n')
     .map(line => line.replace(/\s+$/, ''))
     .filter(line => line.trim().length > 0)
     .map(line => {
-      const indentMatch = line.match(/^(\s*)/);
+      const normalized = line.replace(/^\t+/, m => '  '.repeat(m.length));
+      const indentMatch = normalized.match(/^( *)/);
       const indent = indentMatch ? indentMatch[1].length : 0;
       const depth = Math.floor(indent / 2);
-      const trimmed = line.trim();
+      const trimmed = normalized.trim();
       const isDir = trimmed.endsWith('/');
       const name = isDir ? trimmed.slice(0, -1) : trimmed;
       return { depth, name, isDir };

--- a/apps/blog/web/src/components/preview/PreviewBanner.tsx
+++ b/apps/blog/web/src/components/preview/PreviewBanner.tsx
@@ -1,0 +1,37 @@
+import { css } from '@design-system/ui-lib/css';
+import type { PostStatus } from '@/domain/post/types';
+
+interface Props {
+  status: PostStatus;
+  scheduledDate?: string;
+}
+
+export function PreviewBanner({ status, scheduledDate }: Props) {
+  const label =
+    status === 'draft'
+      ? 'Draft Preview — 비공개 (status: draft)'
+      : status === 'scheduled'
+        ? `Scheduled Preview — 예약 발행 (${scheduledDate ?? '날짜 없음'})`
+        : 'Published Preview';
+
+  return (
+    <div
+      role="status"
+      className={css({
+        position: 'sticky',
+        top: 0,
+        zIndex: 100,
+        bg: 'amber.500',
+        color: 'black',
+        textAlign: 'center',
+        py: '2',
+        px: '4',
+        fontSize: 'sm',
+        fontWeight: 'semibold',
+        boxShadow: 'sm',
+      })}
+    >
+      🔒 {label} — 이 페이지는 dev 환경에서만 노출됩니다
+    </div>
+  );
+}

--- a/apps/blog/web/src/components/search/SearchDialog.tsx
+++ b/apps/blog/web/src/components/search/SearchDialog.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { css } from '@design-system/ui-lib/css';
-import { Search, X } from 'lucide-react';
+import { Search, X, Clock } from 'lucide-react';
+import { getRecentViews, type RecentView } from '@/lib/hooks/useRecentViews';
 
 interface SearchPost {
   slug: string;
@@ -12,6 +13,46 @@ interface SearchPost {
   excerpt: string;
   tags: string[];
   series: string | null;
+  contentPreview?: string;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function highlight(text: string, query: string): ReactNode {
+  if (!query.trim() || !text) return text;
+  const regex = new RegExp(`(${escapeRegex(query)})`, 'gi');
+  const parts = text.split(regex);
+  return parts.map((part, i) =>
+    regex.test(part) ? (
+      <mark
+        key={i}
+        className={css({
+          bg: 'amber.100',
+          color: 'amber.900',
+          px: '0.5',
+          rounded: 'sm',
+        })}
+      >
+        {part}
+      </mark>
+    ) : (
+      <span key={i}>{part}</span>
+    ),
+  );
+}
+
+function pickContentSnippet(content: string, query: string, radius = 60): string {
+  if (!content) return '';
+  if (!query.trim()) return content.slice(0, 140);
+  const idx = content.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return content.slice(0, 140);
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(content.length, idx + query.length + radius);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < content.length ? '…' : '';
+  return `${prefix}${content.slice(start, end)}${suffix}`;
 }
 
 export const SearchDialog = () => {
@@ -20,18 +61,39 @@ export const SearchDialog = () => {
   const [posts, setPosts] = useState<SearchPost[]>([]);
   const [filteredPosts, setFilteredPosts] = useState<SearchPost[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [recentViews, setRecentViews] = useState<RecentView[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
-  // 다이얼로그 열릴 때 데이터 로드 (Lazy Load)
+  const showRecentViews = !query.trim() && recentViews.length > 0;
+  const recentAsPosts = useMemo<SearchPost[]>(() => {
+    if (!showRecentViews) return [];
+    return recentViews.map(rv => {
+      const found = posts.find(p => p.slug === rv.slug);
+      return (
+        found ?? {
+          slug: rv.slug,
+          title: rv.title,
+          date: null,
+          excerpt: '',
+          tags: [],
+          series: null,
+        }
+      );
+    });
+  }, [showRecentViews, recentViews, posts]);
+
+  // 다이얼로그 열릴 때 데이터 로드 (Lazy Load) + 최근 본 글 갱신
   useEffect(() => {
-    if (isOpen && posts.length === 0) {
+    if (!isOpen) return;
+    if (posts.length === 0) {
       fetch('/search-index.json')
         .then(res => res.json())
         .then((data: SearchPost[]) => setPosts(data))
         .catch(err => console.error('Failed to load search index:', err));
     }
+    setRecentViews(getRecentViews());
   }, [isOpen]);
 
   // Cmd+K / Ctrl+K 단축키
@@ -67,7 +129,7 @@ export const SearchDialog = () => {
   // 검색 필터링
   useEffect(() => {
     if (!query.trim()) {
-      setFilteredPosts(posts.slice(0, 10));
+      setFilteredPosts(recentAsPosts.length > 0 ? recentAsPosts : posts.slice(0, 10));
       setSelectedIndex(0);
       return;
     }
@@ -78,11 +140,13 @@ export const SearchDialog = () => {
         post.title.toLowerCase().includes(lowerQuery) ||
         post.excerpt.toLowerCase().includes(lowerQuery) ||
         post.tags.some(tag => tag.toLowerCase().includes(lowerQuery)) ||
-        (post.series && post.series.toLowerCase().includes(lowerQuery)),
+        (post.series && post.series.toLowerCase().includes(lowerQuery)) ||
+        (post.contentPreview &&
+          post.contentPreview.toLowerCase().includes(lowerQuery)),
     );
     setFilteredPosts(results.slice(0, 10));
     setSelectedIndex(0);
-  }, [query, posts]);
+  }, [query, posts, recentAsPosts]);
 
   const handleSelect = useCallback(
     (slug: string) => {
@@ -263,7 +327,6 @@ export const SearchDialog = () => {
 
           {/* 검색 결과 */}
           <div
-            ref={listRef}
             className={css({
               flex: 1,
               overflowY: 'auto',
@@ -271,90 +334,116 @@ export const SearchDialog = () => {
               WebkitOverflowScrolling: 'touch',
             })}
           >
-            {filteredPosts.length === 0 ? (
-              <p
+            {showRecentViews && (
+              <div
                 className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '2',
                   px: '4',
-                  py: '8',
-                  textAlign: 'center',
-                  color: 'gray.400',
-                  fontSize: 'sm',
+                  py: '2',
+                  fontSize: 'xs',
+                  fontWeight: 'semibold',
+                  color: 'gray.500',
+                  letterSpacing: 'wide',
+                  textTransform: 'uppercase',
                 })}
               >
-                {query ? '검색 결과가 없습니다' : '포스트를 검색해보세요'}
-              </p>
-            ) : (
-              filteredPosts.map((post, index) => (
-                <button
-                  key={post.slug}
-                  onClick={() => handleSelect(post.slug)}
+                <Clock size={12} /> 최근 본 글
+              </div>
+            )}
+            <div ref={listRef}>
+              {filteredPosts.length === 0 ? (
+                <p
                   className={css({
-                    display: 'block',
-                    w: 'full',
-                    textAlign: 'left',
                     px: '4',
-                    py: { base: '4', md: '3' },
-                    cursor: 'pointer',
-                    bg: index === selectedIndex ? 'blue.50' : 'transparent',
-                    _hover: { bg: 'gray.50' },
-                    _active: { bg: 'blue.50' },
-                    transition: 'background 0.1s',
-                    border: 'none',
-                    borderBottomWidth: { base: '1px', md: '0' },
-                    borderColor: 'gray.50',
+                    py: '8',
+                    textAlign: 'center',
+                    color: 'gray.400',
+                    fontSize: 'sm',
                   })}
                 >
-                  <p
-                    className={css({
-                      fontSize: 'sm',
-                      fontWeight: 'medium',
-                      color: 'gray.900',
-                      lineClamp: 1,
-                    })}
-                  >
-                    {post.title}
-                  </p>
-                  <p
-                    className={css({
-                      fontSize: 'xs',
-                      color: 'gray.500',
-                      mt: '1',
-                      lineClamp: 1,
-                    })}
-                  >
-                    {post.date && <span>{post.date} · </span>}
-                    {post.series && <span>📚 {post.series} · </span>}
-                    {post.excerpt}
-                  </p>
-                  {post.tags.length > 0 && (
-                    <div
+                  {query ? '검색 결과가 없습니다' : '포스트를 검색해보세요'}
+                </p>
+              ) : (
+                filteredPosts.map((post, index) => {
+                  const snippet =
+                    query.trim() && post.contentPreview
+                      ? pickContentSnippet(post.contentPreview, query)
+                      : post.excerpt;
+                  return (
+                    <button
+                      key={post.slug}
+                      onClick={() => handleSelect(post.slug)}
                       className={css({
-                        display: 'flex',
-                        gap: '1',
-                        mt: '1.5',
-                        flexWrap: 'wrap',
+                        display: 'block',
+                        w: 'full',
+                        textAlign: 'left',
+                        px: '4',
+                        py: { base: '4', md: '3' },
+                        cursor: 'pointer',
+                        bg: index === selectedIndex ? 'blue.50' : 'transparent',
+                        _hover: { bg: 'gray.50' },
+                        _active: { bg: 'blue.50' },
+                        transition: 'background 0.1s',
+                        border: 'none',
+                        borderBottomWidth: { base: '1px', md: '0' },
+                        borderColor: 'gray.50',
                       })}
                     >
-                      {post.tags.slice(0, 3).map(tag => (
-                        <span
-                          key={tag}
+                      <p
+                        className={css({
+                          fontSize: 'sm',
+                          fontWeight: 'medium',
+                          color: 'gray.900',
+                          lineClamp: 1,
+                        })}
+                      >
+                        {highlight(post.title, query)}
+                      </p>
+                      <p
+                        className={css({
+                          fontSize: 'xs',
+                          color: 'gray.500',
+                          mt: '1',
+                          lineClamp: 2,
+                        })}
+                      >
+                        {post.date && <span>{post.date} · </span>}
+                        {post.series && <span>📚 {post.series} · </span>}
+                        {highlight(snippet, query)}
+                      </p>
+                      {post.tags.length > 0 && (
+                        <div
                           className={css({
-                            fontSize: '2xs',
-                            px: '1.5',
-                            py: '0.5',
-                            bg: 'gray.100',
-                            color: 'gray.600',
-                            rounded: 'md',
+                            display: 'flex',
+                            gap: '1',
+                            mt: '1.5',
+                            flexWrap: 'wrap',
                           })}
                         >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </button>
-              ))
-            )}
+                          {post.tags.slice(0, 3).map(tag => (
+                            <span
+                              key={tag}
+                              className={css({
+                                fontSize: '2xs',
+                                px: '1.5',
+                                py: '0.5',
+                                bg: 'gray.100',
+                                color: 'gray.600',
+                                rounded: 'md',
+                              })}
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </button>
+                  );
+                })
+              )}
+            </div>
           </div>
 
           {/* 하단 힌트 — 데스크탑만 */}

--- a/apps/blog/web/sync-posts.mjs
+++ b/apps/blog/web/sync-posts.mjs
@@ -1,5 +1,12 @@
-import { cpSync, rmSync, mkdirSync, existsSync, lstatSync } from 'node:fs';
-import { join, resolve, extname } from 'node:path';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -17,28 +24,96 @@ const ALLOWED_EXTENSIONS = [
   '.mp4',
 ];
 
+const FORCE = process.argv.includes('--force');
+
+function listMediaFiles(dir, results = []) {
+  if (!existsSync(dir)) return results;
+  for (const item of readdirSync(dir)) {
+    const full = join(dir, item);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      listMediaFiles(full, results);
+      continue;
+    }
+    if (ALLOWED_EXTENSIONS.includes(extname(item).toLowerCase())) {
+      results.push({ full, mtimeMs: stat.mtimeMs, size: stat.size });
+    }
+  }
+  return results;
+}
+
+function syncIncremental() {
+  const sourceFiles = listMediaFiles(POSTS_SOURCE_DIR);
+  const sourceRelSet = new Set(
+    sourceFiles.map(f => relative(POSTS_SOURCE_DIR, f.full)),
+  );
+
+  let copied = 0;
+  let skipped = 0;
+  let removed = 0;
+
+  for (const src of sourceFiles) {
+    const rel = relative(POSTS_SOURCE_DIR, src.full);
+    const dst = join(POSTS_TARGET_DIR, rel);
+
+    let needsCopy = true;
+    if (existsSync(dst)) {
+      const dstStat = statSync(dst);
+      if (dstStat.size === src.size && dstStat.mtimeMs >= src.mtimeMs) {
+        needsCopy = false;
+      }
+    }
+
+    if (needsCopy) {
+      mkdirSync(dirname(dst), { recursive: true });
+      copyFileSync(src.full, dst);
+      copied++;
+    } else {
+      skipped++;
+    }
+  }
+
+  if (existsSync(POSTS_TARGET_DIR)) {
+    const targetFiles = listMediaFiles(POSTS_TARGET_DIR);
+    for (const t of targetFiles) {
+      const rel = relative(POSTS_TARGET_DIR, t.full);
+      if (!sourceRelSet.has(rel)) {
+        rmSync(t.full);
+        removed++;
+      }
+    }
+  }
+
+  console.log(
+    `Synced posts media: ${copied} copied, ${skipped} unchanged, ${removed} removed`,
+  );
+}
+
+function syncFull() {
+  if (existsSync(POSTS_TARGET_DIR)) {
+    rmSync(POSTS_TARGET_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(POSTS_TARGET_DIR, { recursive: true });
+  const sourceFiles = listMediaFiles(POSTS_SOURCE_DIR);
+  for (const src of sourceFiles) {
+    const rel = relative(POSTS_SOURCE_DIR, src.full);
+    const dst = join(POSTS_TARGET_DIR, rel);
+    mkdirSync(dirname(dst), { recursive: true });
+    copyFileSync(src.full, dst);
+  }
+  console.log(`Full sync: ${sourceFiles.length} files copied`);
+}
+
 console.log(
   `Syncing images from ${POSTS_SOURCE_DIR} to ${POSTS_TARGET_DIR}...`,
 );
 
-if (existsSync(POSTS_TARGET_DIR)) {
-  console.log('Cleaning target directory...');
-  rmSync(POSTS_TARGET_DIR, { recursive: true, force: true });
-}
-
-mkdirSync(POSTS_TARGET_DIR, { recursive: true });
-
 try {
-  cpSync(POSTS_SOURCE_DIR, POSTS_TARGET_DIR, {
-    recursive: true,
-    filter: source => {
-      if (lstatSync(source).isDirectory()) {
-        return true;
-      }
-      return ALLOWED_EXTENSIONS.includes(extname(source).toLowerCase());
-    },
-  });
-  console.log('Successfully synced images.');
+  if (FORCE || !existsSync(POSTS_TARGET_DIR)) {
+    syncFull();
+  } else {
+    syncIncremental();
+  }
 } catch (error) {
   console.error('Failed to sync images:', error);
   process.exit(1);


### PR DESCRIPTION
## Summary

블로그에 **글쓰기 DX 도구 5종**과 **독자용 검색/RSS 개선**을 함께 도입했습니다.

### 글쓰기 DX
- **`pnpm new-post "제목" --series ... --tags ...`** — frontmatter 자동 생성 (`scripts/new-post.ts`)
- **`pnpm lint:posts`** — 필수 필드, `scheduled` ↔ `scheduledDate` 정합성, 끊긴 이미지, 중복 slug 검사 (`scripts/validate-posts.ts`)
- **`/preview/[...slug]`** 라우트 — dev에서 draft·scheduled 글 본문 미리보기 (prod 빌드는 `__disabled__` placeholder만 + 즉시 `notFound`)
- **`<callout>`, `<figure>`, `<file-tree>`** — 마크다운 헬퍼 컴포넌트
- **`_series.yml`** — 시리즈 폴더에 두면 표시명/설명/order 정의 가능. 시리즈 nav가 order 기준 chronological 정렬
- **`scripts/build-content.ts`** — predev/prebuild 통합 진입점, sync-posts는 mtime 비교로 변경분만 복사

### 독자 UX
- **검색 다이얼로그**: contentPreview 본문 검색, 검색어 `<mark>` 하이라이트, "최근 본 글" 섹션(localStorage)
- **RSS link**: `<link rel="alternate" type="application/rss+xml" title="..." href="/rss.xml">`을 RootLayout head에 직접 박음 (Next 16 metadata API에서 출력 안 됨 확인)

## Test plan

- [ ] `pnpm --filter @blog/web new-post "테스트" --series bundler --tags a,b` → `posts/bundler/테스트.md` 생성 확인
- [ ] `pnpm --filter @blog/web lint:posts` → 통과 (현재 경고 3건은 frontmatter만 있고 status 미지정인 메타 글)
- [ ] dev 서버에서 `/preview/{draft-slug}/` 접근 → 노란 PreviewBanner + 본문 표시
- [ ] 마크다운에 `<callout type=\"warning\">…</callout>`, `<figure>…<figcaption>…</figcaption></figure>`, `<file-tree>…</file-tree>` 추가 → 정상 렌더
- [ ] bundler 시리즈 글 진입 → 시리즈 nav가 `_series.yml`의 order(00→04) 순서로 동작
- [ ] Cmd+K 검색 → query 비면 "최근 본 글" 표시 / query 입력 시 본문 매칭 + 매칭 부분 하이라이트
- [ ] `next build` 결과 HTML head에 `<link rel=\"alternate\" type=\"application/rss+xml\" …>` 포함

## 보류 항목

- **CodeTabs**: react-markdown(+rehype-raw)에서 자식 노드를 깔끔하게 탭으로 분리하기 어려워 이번 PR엔 제외. 필요 시 (a) `@next/mdx`로 MDX 직접 평가 전환, (b) attribute 기반 단순 데이터 형태 중 선택 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)