### PR TITLE
fix(seo): trailing slash 일관성 정리 + apex redirect 1-hop 보장

### DIFF
--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] "원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] "원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di.md
@@ -19,7 +19,7 @@ slug: 'typescript-project-service-di-design'
 
 > **어떻게 하면 이런 로직을 재활용하기 쉽게 만들 수 없을까? 지난번 API도 구조적으로 설계했는데 이것도 그렇게 할 수 있지 않을까?**
 
-[이전글](https://blog.sangwook.dev/posts/typescript-project-api-di-design)에서는 Type-Safe Http class을 설계하고 Type을 구조적으로 설계하는 것에 대해 이야기했습니다.  
+[이전글](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)에서는 Type-Safe Http class을 설계하고 Type을 구조적으로 설계하는 것에 대해 이야기했습니다.  
 해당 글에서는 서버 API Type을 설계하고 제네릭을 활용한 HTTP 클래스를 통해 타입 안전성을 확보하는 방법을 다루었습니다.  
 특히 DI을 활용하여 HTTP 클라이언트를 추상화하고 테스트하기 쉬운 코드를 작성하는 방법을 설명했습니다.
 
@@ -744,9 +744,9 @@ export const Dashboard = ({ id }: Pick<User, 'id'>) => {
 
 ### 🔗 관련 시리즈
 
-1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design)
-2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design)
-3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design)
-4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design)
+1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design/)
+2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design/)
+3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)
+4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design/)
 5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](현재 글)
-6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design)
+6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design/)

--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] "원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] "원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략.md
@@ -19,7 +19,7 @@ slug: 'typescript-project-service-design'
 
 > **어떻게 하면 이런 로직을 재활용하기 쉽게 만들 수 없을까? 지난번 API도 구조적으로 설계 했는대 이것도 그렇게 할 수 있지 않을까?**
 
-[이전글](https://blog.sangwook.dev/posts/typescript-project-api-design)에서는 Type-Safe Http class을 설계하고
+[이전글](https://blog.sangwook.dev/posts/typescript-project-api-design/)에서는 Type-Safe Http class을 설계하고
 Type을 구조적으로 설계하는 것에 대해 이야기 했습니다.
 
 이번글에서는 프론트에서 쓰이는 비즈니스 로직을 분리하는 부분에 관하여 이야기해 볼까 합니다.
@@ -512,9 +512,9 @@ export const Dashboard = ({ userId }: { userId: string }) => {
 
 ### 🔗 관련 시리즈
 
-1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design)
-2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design)
-3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design)
+1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design/)
+2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design/)
+3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)
 4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](현재 글)
-5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design)
-6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design)
+5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)
+6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design/)

--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] Type 설계의 시작: 견고한 서버 API Type 설계하기 With DI.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] Type 설계의 시작: 견고한 서버 API Type 설계하기 With DI.md
@@ -447,9 +447,9 @@ describe('UserServerImpl', () => {
 
 ### 🔗 관련 시리즈
 
-1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design)
-2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design)
+1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design/)
+2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design/)
 3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](현재 글)
-4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design)
-5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design)
-6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design)
+4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design/)
+5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)
+6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design/)

--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] Type 설계의 시작: 견고한 서버 API Type 설계하기.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] Type 설계의 시작: 견고한 서버 API Type 설계하기.md
@@ -484,9 +484,9 @@ describe('User API', () => {
 
 ### 🔗 관련 시리즈
 
-1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design)
+1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design/)
 2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](현재 글)
-3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design)
-4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design)
-5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design)
-6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design)
+3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)
+4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design/)
+5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)
+6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design/)

--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] 당신의 Type, 어디까지 연결되어 있나요?.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] 당신의 Type, 어디까지 연결되어 있나요?.md
@@ -276,13 +276,13 @@ export const UserProfile: React.FC<UserProfileProps> = ({ userId }) => {
 >
 > - **대상**: 개인 프로젝트, 프로토타입, 소규모 팀 (2-3명)
 > - **특징**: 빠른 구현, 낮은 진입장벽, 직관적
-> - **👉 [함수형 접근 버전 보기](https://blog.sangwook.dev/posts/typescript-project-api-design)**
+> - **👉 [함수형 접근 버전 보기](https://blog.sangwook.dev/posts/typescript-project-api-design/)**
 >
 > ### 🏗️ 확장 가능한 DI 기반 접근 (현재 글)
 >
 > - **대상**: 팀 프로젝트, 장기 운영, 복잡한 요구사항
 > - **특징**: 테스트 용이성, 환경별 설정, 유지보수성
-> - **👉 [DI 기반 버전 보기](https://blog.sangwook.dev/posts/typescript-project-api-di-design)**
+> - **👉 [DI 기반 버전 보기](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)**
 >
 > **🤔 어떤 걸 선택해야 할지 모르겠다면?**
 >
@@ -294,8 +294,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({ userId }) => {
 ### 🔗 관련 시리즈
 
 1. [당신의 Type, 어디까지 연결되어 있나요?](현재 글)
-2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design)
-3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design)
-4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design)
-5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design)
-6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design)
+2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design/)
+3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)
+4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design/)
+5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)
+6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](https://blog.sangwook.dev/posts/typescript-project-domain-design/)

--- a/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] 🥉 "같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기.md
+++ b/apps/blog/posts/[Typescript로 설계하는 프로젝트]/[Typescript로 설계하는 프로젝트] 🥉 "같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기.md
@@ -22,7 +22,7 @@ slug: 'typescript-project-domain-design'
 
 **이런 상황, 어떻게 해결하시겠어요?**
 
-[지난 글](https://blog.sangwook.dev/posts/typescript-project-service-di-design)에서는 Service Layer를 통해 비즈니스
+[지난 글](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)에서는 Service Layer를 통해 비즈니스
 로직을 분리하고 재사용 가능한 구조를 만드는 방법을 다뤘습니다.
 
 하지만 실제 프로젝트에서는 이런 상황을 만나게 됩니다.
@@ -117,7 +117,7 @@ export const canUserUploadFile = (user: User): boolean => {
 >
 > **[나]**: 지금까지 우리가 HTTP API 설계, Service Layer 설계를 하면서 계속 `@/shared`에서 타입을 import 해왔잖아요?
 >
-> **[독자]**: 맞아요! [HTTP 설계 글](https://blog.sangwook.dev/posts/typescript-project-api-design)에서 이런 코드 봤죠.
+> **[독자]**: 맞아요! [HTTP 설계 글](https://blog.sangwook.dev/posts/typescript-project-api-design/)에서 이런 코드 봤죠.
 >
 > ```typescript
 > // 📁 apps/react/src/server/user/types.ts
@@ -157,7 +157,7 @@ export const canUserUploadFile = (user: User): boolean => {
 
 이런 문제를 해결하기 위해 `shared/domain` 디렉토리에 핵심 엔티티들을 중앙 집중화하여 정의합니다.  
 이를 통해 모든 레이어에서 동일한 타입을 사용하게 되어 일관성을 보장할 수 있습니다.  
-> [Service Layer 글](https://blog.sangwook.dev/posts/typescript-project-service-di-design)에서 보았듯이, Service
+> [Service Layer 글](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)에서 보았듯이, Service
 > 레이어에서 비즈니스 로직을 처리할 때도 중앙 집중화된 타입을 활용하여 로직의 재사용성과 테스트 용이성을 확보할 수 있습니다.
 
 > #### 여러 레이어에서의 타입 활용 패턴
@@ -561,11 +561,11 @@ export class User {
 
 ### 🔗 관련 시리즈
 
-1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design)
-2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design)
-3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design)
-4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design)
-5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design)
+1. [당신의 Type, 어디까지 연결되어 있나요?](https://blog.sangwook.dev/posts/typescript-project-design/)
+2. [Type 설계의 시작: 견고한 서버 API Type 설계하기](https://blog.sangwook.dev/posts/typescript-project-api-design/)
+3. [Type 설계의 시작: 견고한 서버 API Type 설계하기 With Di](https://blog.sangwook.dev/posts/typescript-project-api-di-design/)
+4. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략](https://blog.sangwook.dev/posts/typescript-project-service-design/)
+5. ["원래 있던 기능이니 금방 하시죠?" 당하지 않는 Service Layer 설계 전략 With Di](https://blog.sangwook.dev/posts/typescript-project-service-di-design/)
 6. ["같은 로직 또 복사했어요?" Domain 모델로 책임 분리하기](현재 글)
 
 ---

--- a/apps/blog/web/src/app/about/page.tsx
+++ b/apps/blog/web/src/app/about/page.tsx
@@ -230,7 +230,7 @@ export default function AboutPage() {
                   ))}
                 </div>
                 <Link
-                  href="/posts/2025-retrospect"
+                  href="/posts/2025-retrospect/"
                   className={css({
                     fontSize: 'xs',
                     color: 'ink.500',

--- a/apps/blog/web/src/app/admin/analytics/[slug]/PostDetailClient.tsx
+++ b/apps/blog/web/src/app/admin/analytics/[slug]/PostDetailClient.tsx
@@ -127,7 +127,7 @@ function PostDetailContent() {
             {post.title}
           </h2>
           <Link
-            href={`/posts/${encodePostSlug(post.slug)}`}
+            href={`/posts/${encodePostSlug(post.slug)}/`}
             target="_blank"
             onClick={e => e.stopPropagation()}
             className={css({

--- a/apps/blog/web/src/app/admin/components/PostAccordion.tsx
+++ b/apps/blog/web/src/app/admin/components/PostAccordion.tsx
@@ -122,7 +122,7 @@ export function PostAccordion({ post }: Props) {
             <BarChart3 size={14} />
           </Link>
           <Link
-            href={`/posts/${encodePostSlug(post.slug)}`}
+            href={`/posts/${encodePostSlug(post.slug)}/`}
             target="_blank"
             onClick={e => e.stopPropagation()}
             className={css({

--- a/apps/blog/web/src/app/admin/page.tsx
+++ b/apps/blog/web/src/app/admin/page.tsx
@@ -154,7 +154,7 @@ function AdminOverviewContent() {
             {topPosts.map((post, i) => (
               <Link
                 key={post.slug}
-                href={`/posts/${encodePostSlug(post.slug)}`}
+                href={`/posts/${encodePostSlug(post.slug)}/`}
                 target="_blank"
                 className={css({
                   display: 'flex',
@@ -241,7 +241,7 @@ function AdminOverviewContent() {
             {recentPosts.map((post, i) => (
               <Link
                 key={post.slug}
-                href={`/posts/${encodePostSlug(post.slug)}`}
+                href={`/posts/${encodePostSlug(post.slug)}/`}
                 target="_blank"
                 className={css({
                   display: 'flex',

--- a/apps/blog/web/src/app/posts/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/posts/[...slug]/page.tsx
@@ -46,12 +46,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: `${post.title} | Frontend Lab`,
     description,
     alternates: {
-      canonical: `/posts/${slug}`,
+      canonical: `/posts/${slug}/`,
     },
     openGraph: {
       title: post.title,
       description,
-      url: `/posts/${slug}`,
+      url: `/posts/${slug}/`,
       siteName: 'Frontend Lab Blog',
       type: 'article',
       publishedTime: post.date || undefined,

--- a/apps/blog/web/src/app/privacy/page.tsx
+++ b/apps/blog/web/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title: '개인정보처리방침 | Frontend Lab',
   description: 'Frontend Lab 블로그의 개인정보처리방침입니다.',
   alternates: {
-    canonical: '/privacy',
+    canonical: '/privacy/',
   },
   robots: {
     index: false,

--- a/apps/next.js/next.config.ts
+++ b/apps/next.js/next.config.ts
@@ -1,11 +1,17 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  trailingSlash: true,
   async redirects() {
     return [
       {
-        source: '/:path*',
-        destination: 'https://blog.sangwook.dev/:path*',
+        source: '/',
+        destination: 'https://blog.sangwook.dev/',
+        permanent: true,
+      },
+      {
+        source: '/:path+',
+        destination: 'https://blog.sangwook.dev/:path+/',
         permanent: true,
       },
     ];


### PR DESCRIPTION
## Summary

GSC(Google Search Console)에서 색인 0개 / "크롤링됨 - 색인 안 됨" 9건 / 404 4건이 잡힌 원인을 추적한 결과, **canonical · OG URL · 내부 Link · 글 본문 링크의 trailing slash 처리가 sitemap canonical(`/posts/foo/`)과 어긋나** 있었음. 추가로 apex 도메인(`sangwook.dev`) redirect가 `trailingSlash` 미설정으로 hop이 최대 3단계까지 발생.

핵심 영향: canonical이 자기 자신을 가리키지 못하고 redirect되는 URL을 가리켜 Google이 색인을 보류했을 가능성이 큼.

## Changes

### 1. apex redirect 1-hop 보장 — `apps/next.js/next.config.ts`
- `trailingSlash: true` 추가
- redirect 룰을 root와 `:path+`로 분리하고 destination에 명시적 `/` 추가
  - 결과: `sangwook.dev/foo/` → `blog.sangwook.dev/foo/` **단일 308 hop** (이전 3 hops)

### 2. canonical / OpenGraph URL 정렬
- `posts/[...slug]/page.tsx`: `canonical`, `openGraph.url`을 `/posts/${slug}/`로
- `privacy/page.tsx`: canonical을 `/privacy/`로

### 3. 내부 `<Link href>` 정렬
- `about/page.tsx`: `/posts/2025-retrospect/`
- `admin/page.tsx` (2곳), `admin/components/PostAccordion.tsx`, `admin/analytics/[slug]/PostDetailClient.tsx`: 모두 `/`로 끝나도록

### 4. TypeScript 시리즈 markdown 본문 internal link 37곳 일괄 정리
- 6개 markdown 파일 — `[Typescript로 설계하는 프로젝트]/` 폴더
- bundler 시리즈는 이미 slash가 있어 변경 없음

## Test plan

- [ ] Vercel preview deploy 성공
- [ ] preview에서 `https://sangwook.dev/posts/foo/` → `https://blog.sangwook.dev/posts/foo/` **1 hop** 확인 (`curl -sI -L`)
- [ ] 글 상세 페이지 HTML에서 `<link rel="canonical" href="https://blog.sangwook.dev/posts/foo/">` (slash 포함) 확인
- [ ] OpenGraph `<meta property="og:url">`도 slash 포함 확인
- [ ] 머지 후 GitHub Pages 배포 완료
- [ ] GSC "찾을 수 없음(404)" 화면에서 **유효성 검사 시작** 클릭 → 4개 URL 재크롤링 트리거
- [ ] GSC "리디렉션 오류" 화면에서도 **유효성 검사 시작** 클릭

## Follow-ups (이번 PR 범위 밖)
- 핵심 글 5–7개 GSC URL 검사 도구로 수동 색인 요청 (오늘)
- 외부 백링크 만들기 (GitHub README, LinkedIn 등) — 신규 도메인 권위 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)