### PR TITLE
test(blog): 콘텐츠 파이프라인 회귀 테스트 + lefthook 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ concurrency:
   # push 이벤트에서는 빈 값이라 github.ref(refs/heads/chore/foo)로 fallback.
   # 결과적으로 같은 브랜치의 PR/push가 동일 그룹에 묶여 CI 중복 실행을 방지합니다.
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  # feature 브랜치에 짧은 간격으로 여러 push가 쌓이는 경우, 이전 in-progress run을
-  # 취소해 누적을 방지합니다. main push도 동일 적용 — 어차피 최신 commit만 검증되면 충분.
-  cancel-in-progress: true
+  # feature 브랜치/PR은 짧은 간격으로 push가 쌓일 수 있어 이전 run을 취소.
+  # 단, main push는 머지 기록 보호 차원에서 취소하지 않고 모두 완주시킵니다.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 
 on:
+  # 모든 브랜치 push에서 CI 실행 (lefthook이 로컬에서 잡지 못한 경우의 안전망).
+  # PR과 main push가 동시 트리거되어 중복 실행될 수 있으나 아래 concurrency 그룹에서 정리됩니다.
   pull_request:
-    branches: [main]
   push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -51,6 +51,9 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Lint blog posts (frontmatter)
+        run: pnpm --filter @blog/web lint:posts
 
       - name: Format check
         run: pnpm format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: CI
 
 on:
   # 모든 브랜치 push에서 CI 실행 (lefthook이 로컬에서 잡지 못한 경우의 안전망).
-  # PR과 main push가 동시 트리거되어 중복 실행될 수 있으나 아래 concurrency 그룹에서 정리됩니다.
+  # PR과 push가 같은 commit에 동시 트리거되어도 아래 concurrency 그룹에서 한 번만 실행됩니다.
   pull_request:
   push:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # github.head_ref는 PR 이벤트에서만 source 브랜치 이름(예: chore/foo)을 갖고,
+  # push 이벤트에서는 빈 값이라 github.ref(refs/heads/chore/foo)로 fallback.
+  # 결과적으로 같은 브랜치의 PR/push가 동일 그룹에 묶여 CI 중복 실행을 방지합니다.
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ concurrency:
   # push 이벤트에서는 빈 값이라 github.ref(refs/heads/chore/foo)로 fallback.
   # 결과적으로 같은 브랜치의 PR/push가 동일 그룹에 묶여 CI 중복 실행을 방지합니다.
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # feature 브랜치에 짧은 간격으로 여러 push가 쌓이는 경우, 이전 in-progress run을
+  # 취소해 누적을 방지합니다. main push도 동일 적용 — 어차피 최신 commit만 검증되면 충분.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -59,13 +59,17 @@ test('contract: 모든 글은 readMin >= 1', () => {
   );
 });
 
-test('contract: 공개 글(getAllPosts)은 isPostVisible 기준 일치', () => {
+test('contract: 공개 글(getAllPosts)은 isPostVisible 기준 일치 (slug 집합 비교)', () => {
+  // count만 비교하면 "잘못된 글이 잘못된 글로 대체"되는 필터 버그를 놓침.
+  // slug 집합을 정렬해서 deepEqual로 비교해야 실제 동등성을 검증할 수 있음.
   const all = getAllPostsIncludingHidden();
   const visible = getAllPosts();
   const expected = all.filter(p =>
     isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }),
   );
-  assert.equal(visible.length, expected.length);
+  const visibleSlugs = visible.map(p => p.slug).sort();
+  const expectedSlugs = expected.map(p => p.slug).sort();
+  assert.deepEqual(visibleSlugs, expectedSlugs);
 });
 
 test('contract: getAllPosts는 date 내림차순', () => {

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -32,8 +32,12 @@ test('contract: 글이 1개 이상 존재 (블로그 동작의 최소 조건)', 
 
 test('contract: 모든 글은 unique slug 보유', () => {
   const posts = getAllPostsIncludingHidden();
-  const slugs = posts.map(p => p.slug);
-  const dup = slugs.filter((s, i) => slugs.indexOf(s) !== i);
+  const seen = new Set<string>();
+  const dup: string[] = [];
+  for (const p of posts) {
+    if (seen.has(p.slug)) dup.push(p.slug);
+    else seen.add(p.slug);
+  }
   assert.deepEqual(dup, [], `중복 slug 발견: ${dup.join(', ')}`);
 });
 

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -1,0 +1,198 @@
+/**
+ * 실제 `apps/blog/posts/` 디렉토리를 읽어
+ * - 도메인 계약(공개 글의 필수 필드 등)
+ * - 빌드 산출물(sitemap/rss/search-index/llms-full)의 핵심 불변식
+ * 을 잠그는 회귀 테스트입니다.
+ *
+ * 리팩토링/리디자인 시 데이터 형태가 깨지지 않았는지 빠르게 검출하는 가드레일.
+ * 콘텐츠 개수 자체는 잠그지 않습니다(글이 추가/숨김되는 정상 변경에 깨지면 안 됨).
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getAllPosts, getAllPostsIncludingHidden } from './service';
+import { isPostVisible } from './visibility';
+import { buildSitemapXml } from '../../generate-sitemap';
+import { buildRssXml } from '../../generate-rss';
+import {
+  buildAdminPostsIndex,
+  buildPublicSearchIndex,
+  CONTENT_PREVIEW_CHARS,
+} from '../../scripts/generate-search-index';
+import { buildLlmsFullText } from '../../scripts/generate-llms-full';
+import { SITE_URL } from '../../lib/constants';
+
+const TODAY = '2026-05-16';
+
+test('contract: 글이 1개 이상 존재 (블로그 동작의 최소 조건)', () => {
+  const posts = getAllPostsIncludingHidden();
+  assert.ok(posts.length > 0, 'apps/blog/posts/ 에 1개 이상의 글이 있어야 함');
+});
+
+test('contract: 모든 글은 unique slug 보유', () => {
+  const posts = getAllPostsIncludingHidden();
+  const slugs = posts.map(p => p.slug);
+  const dup = slugs.filter((s, i) => slugs.indexOf(s) !== i);
+  assert.deepEqual(dup, [], `중복 slug 발견: ${dup.join(', ')}`);
+});
+
+test('contract: 모든 글은 title 보유', () => {
+  const posts = getAllPostsIncludingHidden();
+  const missing = posts.filter(p => !p.title || typeof p.title !== 'string');
+  assert.equal(
+    missing.length,
+    0,
+    `title 누락: ${missing.map(p => p.slug).join(', ')}`,
+  );
+});
+
+test('contract: 모든 글은 readMin >= 1', () => {
+  const posts = getAllPostsIncludingHidden();
+  const invalid = posts.filter(
+    p => !Number.isFinite(p.readMin) || p.readMin < 1,
+  );
+  assert.equal(
+    invalid.length,
+    0,
+    `readMin 비정상: ${invalid.map(p => `${p.slug}(${p.readMin})`).join(', ')}`,
+  );
+});
+
+test('contract: 공개 글(getAllPosts)은 isPostVisible 기준 일치', () => {
+  const all = getAllPostsIncludingHidden();
+  const visible = getAllPosts();
+  const expected = all.filter(p =>
+    isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }),
+  );
+  assert.equal(visible.length, expected.length);
+});
+
+test('contract: getAllPosts는 date 내림차순', () => {
+  const posts = getAllPosts();
+  for (let i = 0; i + 1 < posts.length; i++) {
+    const a = posts[i].date ?? '';
+    const b = posts[i + 1].date ?? '';
+    // a >= b 여야 함 (null/undefined는 최하위로 정렬됨)
+    if (a && b) {
+      assert.ok(
+        new Date(a).getTime() >= new Date(b).getTime(),
+        `정렬 위배: ${posts[i].slug}(${a}) < ${posts[i + 1].slug}(${b})`,
+      );
+    }
+  }
+});
+
+test('contract: status 값이 유효 enum 범위', () => {
+  const valid = new Set(['published', 'draft', 'scheduled']);
+  const posts = getAllPostsIncludingHidden();
+  const invalid = posts.filter(p => p.status && !valid.has(p.status));
+  assert.equal(invalid.length, 0);
+});
+
+test('contract: scheduled 상태면 scheduledDate가 ISO 파싱 가능', () => {
+  const posts = getAllPostsIncludingHidden();
+  for (const p of posts) {
+    if (p.status === 'scheduled') {
+      assert.ok(p.scheduledDate, `${p.slug}: scheduled인데 scheduledDate 없음`);
+      assert.ok(
+        !Number.isNaN(Date.parse(p.scheduledDate!)),
+        `${p.slug}: scheduledDate 파싱 불가 (${p.scheduledDate})`,
+      );
+    }
+  }
+});
+
+// ---------- 빌드 산출물 회귀 ----------
+
+test('sitemap: 모든 공개 글이 sitemap에 포함됨', () => {
+  const posts = getAllPosts();
+  const xml = buildSitemapXml(posts, TODAY);
+  for (const p of posts) {
+    assert.ok(
+      xml.includes(
+        `/posts/${encodeURIComponent(p.slug).replace(/%2F/g, '/')}/`,
+      ),
+      `sitemap 누락: ${p.slug}`,
+    );
+  }
+});
+
+test('sitemap: draft/미래 scheduled 글은 sitemap에 없음', () => {
+  const xml = buildSitemapXml(getAllPosts(), TODAY);
+  const hidden = getAllPostsIncludingHidden().filter(
+    p => !isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }),
+  );
+  for (const p of hidden) {
+    assert.ok(
+      !xml.includes(`/posts/${p.slug}/`),
+      `숨김 글이 sitemap에 노출: ${p.slug}`,
+    );
+  }
+});
+
+test('sitemap: 모든 loc은 절대 URL', () => {
+  const xml = buildSitemapXml(getAllPosts(), TODAY);
+  const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+  assert.ok(locs.length > 0);
+  for (const loc of locs) {
+    assert.ok(loc.startsWith(SITE_URL), `절대 URL 위배: ${loc}`);
+  }
+});
+
+test('rss: 모든 공개 글이 RSS item으로 등장', () => {
+  const posts = getAllPosts();
+  const xml = buildRssXml(posts, { now: new Date(TODAY) });
+  const itemCount = (xml.match(/<item>/g) || []).length;
+  assert.equal(itemCount, posts.length);
+});
+
+test('rss: 모든 link/guid가 SITE_URL prefix', () => {
+  const xml = buildRssXml(getAllPosts(), { now: new Date(TODAY) });
+  const links = [...xml.matchAll(/<link>([^<]+)<\/link>/g)].map(m => m[1]);
+  for (const link of links) {
+    assert.ok(link.startsWith(SITE_URL), `RSS link 비절대: ${link}`);
+  }
+});
+
+test('search-index: 공개 글 개수와 일치', () => {
+  const posts = getAllPosts();
+  const idx = buildPublicSearchIndex(posts);
+  assert.equal(idx.length, posts.length);
+});
+
+test('search-index: 모든 entry는 필수 키 보유', () => {
+  const idx = buildPublicSearchIndex(getAllPosts());
+  for (const e of idx) {
+    assert.ok(typeof e.slug === 'string' && e.slug.length > 0);
+    assert.ok(typeof e.title === 'string' && e.title.length > 0);
+    assert.ok(Array.isArray(e.tags));
+    assert.ok(typeof e.contentPreview === 'string');
+    assert.ok(e.contentPreview.length <= CONTENT_PREVIEW_CHARS);
+  }
+});
+
+test('search-index(admin): draft/scheduled 포함하여 전체 글 인덱싱', () => {
+  const all = getAllPostsIncludingHidden();
+  const idx = buildAdminPostsIndex(all);
+  assert.equal(idx.length, all.length);
+  // 적어도 1개의 status 값이 admin index에 존재
+  for (const e of idx) {
+    assert.ok(['published', 'draft', 'scheduled'].includes(e.status));
+  }
+});
+
+test('llms-full: 모든 공개 글 제목이 본문에 등장', () => {
+  const posts = getAllPosts();
+  const text = buildLlmsFullText(posts);
+  for (const p of posts) {
+    assert.ok(
+      text.includes(`### [${p.title}]`),
+      `llms-full 누락: ${p.slug} (${p.title})`,
+    );
+  }
+});
+
+test('llms-full: Total posts 카운트가 실제 공개 글 수와 일치', () => {
+  const posts = getAllPosts();
+  const text = buildLlmsFullText(posts);
+  assert.ok(text.includes(`Total posts: ${posts.length}+ articles`));
+});

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -124,8 +124,11 @@ test('sitemap: draft/미래 scheduled 글은 sitemap에 없음', () => {
     p => !isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }),
   );
   for (const p of hidden) {
+    // 한글/특수문자 slug의 hidden 글이 sitemap에 잘못 포함됐을 때 false pass 방지를 위해
+    // public 검사와 동일한 인코딩 규칙으로 비교합니다 (디렉토리 구분자 / 는 보존).
+    const encodedSlug = encodeURIComponent(p.slug).replace(/%2F/g, '/');
     assert.ok(
-      !xml.includes(`/posts/${p.slug}/`),
+      !xml.includes(`/posts/${encodedSlug}/`),
       `숨김 글이 sitemap에 노출: ${p.slug}`,
     );
   }

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -21,7 +21,9 @@ import {
 import { buildLlmsFullText } from '../../scripts/generate-llms-full';
 import { SITE_URL } from '../../lib/constants';
 
-const TODAY = '2026-05-16';
+// sitemap lastmod 비교용 — 동적으로 현재 날짜 사용. 하드코딩 시 미래 scheduledDate를
+// 가진 글이 공개되었을 때 contract 테스트가 false failure를 내는 문제를 회피.
+const TODAY = new Date().toISOString().split('T')[0];
 
 test('contract: 글이 1개 이상 존재 (블로그 동작의 최소 조건)', () => {
   const posts = getAllPostsIncludingHidden();

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildRssXml, escapeXml } from './generate-rss';
+import type { RssPost } from './generate-rss';
+
+const NOW = new Date('2026-05-16T00:00:00Z');
+const SITE = 'https://example.dev';
+const NAME = 'Test Blog';
+const DESC = '테스트용 설명';
+
+function makePost(over: Partial<RssPost> = {}): RssPost {
+  return {
+    slug: 'hello-world',
+    title: 'Hello',
+    date: '2026-05-09',
+    excerpt: undefined,
+    ...over,
+  };
+}
+
+const OPTS = {
+  siteUrl: SITE,
+  siteName: NAME,
+  siteDescription: DESC,
+  now: NOW,
+};
+
+test('escapeXml: &, <, >, ", \' 모두 엔티티로 치환', () => {
+  assert.equal(
+    escapeXml(`<a href="x">"hi" & 'bye' </a>`),
+    `&lt;a href=&quot;x&quot;&gt;&quot;hi&quot; &amp; &apos;bye&apos; &lt;/a&gt;`,
+  );
+});
+
+test('escapeXml: & 이중 인코딩 방지 (입력 그대로의 & 처리)', () => {
+  // 현재 동작: &amp;가 들어와도 다시 & → &amp; 로 인코딩됨 (동작 잠금)
+  assert.equal(escapeXml('A & B'), 'A &amp; B');
+});
+
+test('rss: 헤더와 channel 구조 포함', () => {
+  const xml = buildRssXml([], OPTS);
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'));
+  assert.ok(xml.includes('<rss version="2.0"'));
+  assert.ok(xml.includes('<channel>'));
+  assert.ok(xml.includes(`<link>${SITE}</link>`));
+  assert.ok(xml.includes(`<description>${DESC}</description>`));
+  assert.ok(xml.includes('<language>ko</language>'));
+  assert.ok(xml.trimEnd().endsWith('</rss>'));
+});
+
+test('rss: lastBuildDate가 now.toUTCString()', () => {
+  const xml = buildRssXml([], OPTS);
+  assert.ok(
+    xml.includes(`<lastBuildDate>${NOW.toUTCString()}</lastBuildDate>`),
+  );
+});
+
+test('rss: atom:link self 참조', () => {
+  const xml = buildRssXml([], OPTS);
+  assert.ok(
+    xml.includes(
+      `<atom:link href="${SITE}/rss.xml" rel="self" type="application/rss+xml"/>`,
+    ),
+  );
+});
+
+test('rss: 포스트 개수만큼 <item> 블록', () => {
+  const posts = [
+    makePost({ slug: 'a' }),
+    makePost({ slug: 'b' }),
+    makePost({ slug: 'c' }),
+  ];
+  const xml = buildRssXml(posts, OPTS);
+  assert.equal((xml.match(/<item>/g) || []).length, 3);
+});
+
+test('rss: 각 item은 title/link/guid/pubDate 포함', () => {
+  const xml = buildRssXml([makePost({ slug: 'a', title: 'A' })], OPTS);
+  assert.ok(xml.includes('<title>A</title>'));
+  assert.ok(xml.includes(`<link>${SITE}/posts/a/</link>`));
+  assert.ok(xml.includes(`<guid isPermaLink="true">${SITE}/posts/a/</guid>`));
+  assert.ok(xml.includes('<pubDate>'));
+});
+
+test('rss: title에 특수문자가 있으면 escape', () => {
+  const xml = buildRssXml(
+    [makePost({ slug: 'a', title: '<test> & "quoted"' })],
+    OPTS,
+  );
+  assert.ok(
+    xml.includes('<title>&lt;test&gt; &amp; &quot;quoted&quot;</title>'),
+  );
+});
+
+test('rss: slug의 특수문자는 URL 인코딩됨', () => {
+  const xml = buildRssXml([makePost({ slug: '한글-slug' })], OPTS);
+  assert.ok(xml.includes(encodeURIComponent('한글-slug')));
+});
+
+test('rss: pubDate가 date 기준', () => {
+  const xml = buildRssXml([makePost({ slug: 'a', date: '2026-05-09' })], OPTS);
+  const expected = new Date('2026-05-09').toUTCString();
+  assert.ok(xml.includes(`<pubDate>${expected}</pubDate>`));
+});
+
+test('rss: date 없으면 now.toUTCString() fallback', () => {
+  const xml = buildRssXml([makePost({ slug: 'a', date: null })], OPTS);
+  // item의 pubDate가 now와 같아야 함
+  const match = xml.match(/<item>[\s\S]*?<pubDate>([^<]+)<\/pubDate>/);
+  assert.ok(match);
+  assert.equal(match[1], NOW.toUTCString());
+});
+
+test('rss: excerpt가 있으면 <description> 추가, 없으면 생략', () => {
+  const withExcerpt = buildRssXml(
+    [makePost({ slug: 'a', excerpt: '요약' })],
+    OPTS,
+  );
+  assert.ok(
+    /<item>[\s\S]*?<description>요약<\/description>[\s\S]*?<\/item>/.test(
+      withExcerpt,
+    ),
+  );
+
+  const withoutExcerpt = buildRssXml([makePost({ slug: 'a' })], OPTS);
+  // item 내부에는 description이 없어야 함 (channel 레벨은 별개)
+  const itemBlock = withoutExcerpt.match(/<item>[\s\S]*?<\/item>/)?.[0] ?? '';
+  assert.ok(!itemBlock.includes('<description>'));
+});
+
+test('rss: excerpt도 escape됨', () => {
+  const xml = buildRssXml([makePost({ slug: 'a', excerpt: 'a & b' })], OPTS);
+  assert.ok(xml.includes('<description>a &amp; b</description>'));
+});

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -58,6 +58,17 @@ test('rss: lastBuildDate가 now.toUTCString()', () => {
   );
 });
 
+test('rss: siteDescription에 。이 있으면 channel title은 첫 문장만 사용', () => {
+  const xml = buildRssXml([], {
+    ...OPTS,
+    siteDescription: '첫 문장。두 번째 문장',
+  });
+  // channel <title>은 split 결과의 첫 토큰만 사용
+  assert.ok(xml.includes('<title>Test Blog | 첫 문장</title>'));
+  // 단, channel <description>은 원본을 그대로 유지
+  assert.ok(xml.includes('<description>첫 문장。두 번째 문장</description>'));
+});
+
 test('rss: atom:link self 참조', () => {
   const xml = buildRssXml([], OPTS);
   assert.ok(

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -32,8 +32,11 @@ test('escapeXml: &, <, >, ", \' 모두 엔티티로 치환', () => {
   );
 });
 
-test('escapeXml: & 이중 인코딩 방지 (입력 그대로의 & 처리)', () => {
-  // 현재 동작: &amp;가 들어와도 다시 & → &amp; 로 인코딩됨 (동작 잠금)
+test('escapeXml: & 는 entity awareness 없이 항상 &amp; 로 인코딩 (동작 잠금)', () => {
+  // 현재 구현은 raw text만 입력으로 가정 — 이미 escape된 &amp;가 들어오면
+  // &amp;amp; 로 이중 인코딩됨. RSS의 title/excerpt는 frontmatter raw text라
+  // 이 가정이 성립하지만, entity-aware escape로 교체 시 이 테스트가 실패해
+  // 회귀를 감지하도록 잠가둡니다.
   assert.equal(escapeXml('A & B'), 'A &amp; B');
 });
 

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -65,13 +65,13 @@ ${rssItems}
 </rss>`;
 }
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PUBLIC_DIR = path.join(__dirname, 'public');
-
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const publicDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'public',
+  );
   const posts = getAllPosts();
   const rss = buildRssXml(posts);
-  fs.writeFileSync(path.join(PUBLIC_DIR, 'rss.xml'), rss);
+  fs.writeFileSync(path.join(publicDir, 'rss.xml'), rss);
   console.log('RSS feed generated successfully!');
 }

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -4,12 +4,9 @@ import { fileURLToPath } from 'node:url';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from './lib/constants';
 import { getAllPosts } from './domain/post/service';
 import { encodePostSlug } from './domain/post/utils';
+import type { PostSummary } from './domain/post/types';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PUBLIC_DIR = path.join(__dirname, 'public');
-
-function escapeXml(str: string): string {
+export function escapeXml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -18,31 +15,63 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-const posts = getAllPosts();
+export type RssPost = Pick<PostSummary, 'slug' | 'title' | 'date' | 'excerpt'>;
 
-const rssItems = posts
-  .map(
-    post => `    <item>
+export interface RssBuildOptions {
+  siteUrl?: string;
+  siteName?: string;
+  siteDescription?: string;
+  /** lastBuildDate / pubDate fallback 시 사용 — 테스트에서 결정성 확보용 */
+  now?: Date;
+}
+
+/**
+ * RSS XML을 생성합니다.
+ * 옵션을 주입받아 결정성을 확보합니다 (테스트에서 재현 가능하도록).
+ */
+export function buildRssXml(
+  posts: RssPost[],
+  options: RssBuildOptions = {},
+): string {
+  const {
+    siteUrl = SITE_URL,
+    siteName = SITE_NAME,
+    siteDescription = SITE_DESCRIPTION,
+    now = new Date(),
+  } = options;
+
+  const rssItems = posts
+    .map(
+      post => `    <item>
       <title>${escapeXml(post.title)}</title>
-      <link>${SITE_URL}/posts/${encodePostSlug(post.slug)}/</link>
-      <guid isPermaLink="true">${SITE_URL}/posts/${encodePostSlug(post.slug)}/</guid>
-      <pubDate>${post.date ? new Date(post.date).toUTCString() : new Date().toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}
+      <link>${siteUrl}/posts/${encodePostSlug(post.slug)}/</link>
+      <guid isPermaLink="true">${siteUrl}/posts/${encodePostSlug(post.slug)}/</guid>
+      <pubDate>${post.date ? new Date(post.date).toUTCString() : now.toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}
     </item>`,
-  )
-  .join('\n');
+    )
+    .join('\n');
 
-const rss = `<?xml version="1.0" encoding="UTF-8"?>
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>${SITE_NAME} | ${SITE_DESCRIPTION.split('。')[0]}</title>
-    <link>${SITE_URL}</link>
-    <description>${SITE_DESCRIPTION}</description>
+    <title>${siteName} | ${siteDescription.split('。')[0]}</title>
+    <link>${siteUrl}</link>
+    <description>${siteDescription}</description>
     <language>ko</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
+    <lastBuildDate>${now.toUTCString()}</lastBuildDate>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
 ${rssItems}
   </channel>
 </rss>`;
+}
 
-fs.writeFileSync(path.join(PUBLIC_DIR, 'rss.xml'), rss);
-console.log('RSS feed generated successfully!');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const posts = getAllPosts();
+  const rss = buildRssXml(posts);
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'rss.xml'), rss);
+  console.log('RSS feed generated successfully!');
+}

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -6,6 +6,11 @@ import { getAllPosts } from './domain/post/service';
 import { encodePostSlug } from './domain/post/utils';
 import type { PostSummary } from './domain/post/types';
 
+/**
+ * @internal RSS 본문에 들어가는 raw text 전용 XML 이스케이프.
+ *           모듈 외부에서는 사용을 권장하지 않으며 (entity awareness 없음 — 이미
+ *           escape된 문자열을 다시 이중 인코딩함), 테스트에서 동작 잠금 목적으로만 export.
+ */
 export function escapeXml(str: string): string {
   return str
     .replace(/&/g, '&amp;')

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildSitemapXml, getPostPriority } from './generate-sitemap';
+import type { SitemapPost } from './generate-sitemap';
+
+const TODAY = '2026-05-16';
+const SITE = 'https://example.dev';
+
+function makePost(over: Partial<SitemapPost> = {}): SitemapPost {
+  return {
+    slug: 'hello-world',
+    date: '2026-05-09',
+    updatedAt: null,
+    series: undefined,
+    ...over,
+  };
+}
+
+test('sitemap: 정적 URL 3개(루트/posts/about)가 포함됨', () => {
+  const xml = buildSitemapXml([], TODAY, SITE);
+  assert.ok(xml.includes(`<loc>${SITE}/</loc>`));
+  assert.ok(xml.includes(`<loc>${SITE}/posts/</loc>`));
+  assert.ok(xml.includes(`<loc>${SITE}/about/</loc>`));
+});
+
+test('sitemap: 포스트 entry 개수만큼 <url> 블록 추가', () => {
+  const posts = [
+    makePost({ slug: 'a' }),
+    makePost({ slug: 'b' }),
+    makePost({ slug: 'c' }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  const count = (xml.match(/<url>/g) || []).length;
+  // 정적 3 + 포스트 3
+  assert.equal(count, 6);
+});
+
+test('sitemap: slug의 특수문자가 URL 인코딩됨 (디렉토리 구분자는 보존)', () => {
+  const posts = [makePost({ slug: 'series/한글 slug' })];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  assert.ok(xml.includes('/posts/series/'));
+  assert.ok(xml.includes(encodeURIComponent('한글 slug')));
+  // 디렉토리 구분자는 보존되어 인코딩되지 않음
+  assert.ok(!xml.includes(encodeURIComponent('series/')));
+});
+
+test('sitemap: updatedAt 있으면 lastmod = updatedAt YYYY-MM-DD', () => {
+  const posts = [
+    makePost({
+      slug: 'a',
+      date: '2025-01-01',
+      updatedAt: '2026-03-10',
+    }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  assert.ok(xml.includes('<lastmod>2026-03-10</lastmod>'));
+});
+
+test('sitemap: updatedAt 없으면 lastmod = date', () => {
+  const posts = [makePost({ slug: 'a', date: '2025-12-31' })];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  assert.ok(xml.includes('<lastmod>2025-12-31</lastmod>'));
+});
+
+test('sitemap: date도 updatedAt도 없으면 lastmod = today', () => {
+  const posts = [makePost({ slug: 'a', date: null, updatedAt: null })];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  // 정적 URL의 lastmod도 today지만, 포스트의 lastmod도 today여야 함
+  assert.ok(xml.includes(`<loc>${SITE}/posts/a/</loc>`));
+  // 같은 URL 블록 내에 today가 들어가는지
+  const block = xml.match(
+    /<url>\s*<loc>https:\/\/example\.dev\/posts\/a\/<\/loc>\s*<lastmod>([^<]+)<\/lastmod>/,
+  );
+  assert.ok(block, 'post url block must exist');
+  assert.equal(block[1], TODAY);
+});
+
+test('getPostPriority: 고우선 slug는 0.8', () => {
+  assert.equal(getPostPriority({ slug: 'nodejs-contribution' }), '0.8');
+  assert.equal(
+    getPostPriority({ slug: 'first-open-source-contribution' }),
+    '0.8',
+  );
+});
+
+test('getPostPriority: 고우선 시리즈는 0.75', () => {
+  assert.equal(getPostPriority({ slug: 'x', series: 'bundler' }), '0.75');
+  assert.equal(getPostPriority({ slug: 'x', series: 'open-source' }), '0.75');
+});
+
+test('getPostPriority: 그 외는 0.6', () => {
+  assert.equal(getPostPriority({ slug: 'x' }), '0.6');
+  assert.equal(getPostPriority({ slug: 'x', series: 'random-series' }), '0.6');
+});
+
+test('sitemap: URL 절대 경로 형식 (loc은 https://...로 시작)', () => {
+  const posts = [makePost({ slug: 'a' })];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+  assert.ok(locs.length >= 4);
+  for (const loc of locs) {
+    assert.ok(loc.startsWith(SITE), `loc must be absolute: ${loc}`);
+  }
+});
+
+test('sitemap: XML 헤더와 urlset namespace 포함', () => {
+  const xml = buildSitemapXml([], TODAY, SITE);
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'));
+  assert.ok(
+    xml.includes('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'),
+  );
+  assert.ok(xml.trimEnd().endsWith('</urlset>'));
+});

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -3,6 +3,9 @@ import { test } from 'node:test';
 import { buildSitemapXml, getPostPriority } from './generate-sitemap';
 import type { SitemapPost } from './generate-sitemap';
 
+// arbitrary fixture date — not today's date. 단위 테스트는 실제 날짜에 의존하지
+// 않고 이 값이 sitemap 본문에 그대로 흘러가는지만 검증합니다. (실제 날짜 동작은
+// contract.test.ts의 TODAY = new Date().toISOString() 가 검증합니다.)
 const TODAY = '2026-05-16';
 const SITE = 'https://example.dev';
 

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { buildSitemapXml, getPostPriority } from './generate-sitemap';
+import {
+  buildSitemapXml,
+  getPostPriority,
+  HIGH_PRIORITY_SERIES,
+  HIGH_PRIORITY_SLUGS,
+} from './generate-sitemap';
 import type { SitemapPost } from './generate-sitemap';
 
 // arbitrary fixture date — not today's date. 단위 테스트는 실제 날짜에 의존하지
@@ -81,17 +86,21 @@ test('sitemap: date도 updatedAt도 없으면 lastmod = today', () => {
   assert.equal(block[1], TODAY);
 });
 
-test('getPostPriority: 고우선 slug는 0.8', () => {
-  assert.equal(getPostPriority({ slug: 'nodejs-contribution' }), '0.8');
-  assert.equal(
-    getPostPriority({ slug: 'first-open-source-contribution' }),
-    '0.8',
-  );
+test('getPostPriority: 고우선 slug는 0.8 (HIGH_PRIORITY_SLUGS 전부 0.8)', () => {
+  // 상수에서 직접 참조 — slug 목록이 변경되어도 테스트가 자동으로 맞춰짐.
+  for (const slug of HIGH_PRIORITY_SLUGS) {
+    assert.equal(getPostPriority({ slug }), '0.8', `${slug} priority`);
+  }
 });
 
-test('getPostPriority: 고우선 시리즈는 0.75', () => {
-  assert.equal(getPostPriority({ slug: 'x', series: 'bundler' }), '0.75');
-  assert.equal(getPostPriority({ slug: 'x', series: 'open-source' }), '0.75');
+test('getPostPriority: 고우선 시리즈는 0.75 (HIGH_PRIORITY_SERIES 전부 0.75)', () => {
+  for (const series of HIGH_PRIORITY_SERIES) {
+    assert.equal(
+      getPostPriority({ slug: 'arbitrary', series }),
+      '0.75',
+      `${series} series priority`,
+    );
+  }
 });
 
 test('getPostPriority: 그 외는 0.6', () => {

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -27,6 +27,10 @@ test('sitemap: 정적 URL 3개(루트/posts/about)가 포함됨', () => {
 });
 
 test('sitemap: 포스트 entry 개수만큼 <url> 블록 추가', () => {
+  // 정적 URL 개수는 빈 posts 결과로부터 동적으로 산출 — 새 정적 페이지가
+  // 추가될 때 이 테스트가 그 사실만으로 깨지지 않도록.
+  const staticCount = (buildSitemapXml([], TODAY, SITE).match(/<url>/g) || [])
+    .length;
   const posts = [
     makePost({ slug: 'a' }),
     makePost({ slug: 'b' }),
@@ -34,8 +38,7 @@ test('sitemap: 포스트 entry 개수만큼 <url> 블록 추가', () => {
   ];
   const xml = buildSitemapXml(posts, TODAY, SITE);
   const count = (xml.match(/<url>/g) || []).length;
-  // 정적 3 + 포스트 3
-  assert.equal(count, 6);
+  assert.equal(count, staticCount + posts.length);
 });
 
 test('sitemap: slug의 특수문자가 URL 인코딩됨 (디렉토리 구분자는 보존)', () => {

--- a/apps/blog/web/generate-sitemap.ts
+++ b/apps/blog/web/generate-sitemap.ts
@@ -73,15 +73,15 @@ export function buildSitemapXml(
 </urlset>`;
 }
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PUBLIC_DIR = path.join(__dirname, 'public');
-
 // 스크립트로 직접 실행될 때만 파일 쓰기. (테스트에서 import 시에는 실행 안 됨)
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const publicDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'public',
+  );
   const posts = getAllPosts();
   const today = new Date().toISOString().split('T')[0];
   const sitemap = buildSitemapXml(posts, today);
-  fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap.xml'), sitemap);
+  fs.writeFileSync(path.join(publicDir, 'sitemap.xml'), sitemap);
   console.log('Sitemap generated successfully!');
 }

--- a/apps/blog/web/generate-sitemap.ts
+++ b/apps/blog/web/generate-sitemap.ts
@@ -6,9 +6,14 @@ import { getAllPosts } from './domain/post/service';
 import { encodePostSlug } from './domain/post/utils';
 import type { PostSummary } from './domain/post/types';
 
-// 시리즈별 고가치 포스트는 우선순위 높게 설정
-const HIGH_PRIORITY_SERIES = new Set(['bundler', 'typescript', 'open-source']);
-const HIGH_PRIORITY_SLUGS = new Set([
+// 시리즈별 고가치 포스트는 우선순위 높게 설정.
+// 테스트에서 self-describing 패턴으로 참조하기 위해 export.
+export const HIGH_PRIORITY_SERIES = new Set([
+  'bundler',
+  'typescript',
+  'open-source',
+]);
+export const HIGH_PRIORITY_SLUGS = new Set([
   'ai-opensource-contribution',
   'nodejs-contribution',
   'nextjs-contributor',

--- a/apps/blog/web/generate-sitemap.ts
+++ b/apps/blog/web/generate-sitemap.ts
@@ -4,13 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { SITE_URL } from './lib/constants';
 import { getAllPosts } from './domain/post/service';
 import { encodePostSlug } from './domain/post/utils';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PUBLIC_DIR = path.join(__dirname, 'public');
-
-const posts = getAllPosts();
-const today = new Date().toISOString().split('T')[0];
+import type { PostSummary } from './domain/post/types';
 
 // 시리즈별 고가치 포스트는 우선순위 높게 설정
 const HIGH_PRIORITY_SERIES = new Set(['bundler', 'typescript', 'open-source']);
@@ -21,26 +15,43 @@ const HIGH_PRIORITY_SLUGS = new Set([
   'first-open-source-contribution',
 ]);
 
-function getPostPriority(post: { slug: string; series?: string }): string {
+export function getPostPriority(post: {
+  slug: string;
+  series?: string;
+}): string {
   if (HIGH_PRIORITY_SLUGS.has(post.slug)) return '0.8';
   if (post.series && HIGH_PRIORITY_SERIES.has(post.series)) return '0.75';
   return '0.6';
 }
 
-const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+export type SitemapPost = Pick<
+  PostSummary,
+  'slug' | 'series' | 'date' | 'updatedAt'
+>;
+
+/**
+ * sitemap.xml 본문을 생성합니다. (정적 페이지 + 포스트 목록)
+ * `today`/`siteUrl`을 주입받아 결정성을 확보합니다 (테스트에서 재현 가능하도록).
+ */
+export function buildSitemapXml(
+  posts: SitemapPost[],
+  today: string,
+  siteUrl: string = SITE_URL,
+): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>${SITE_URL}/</loc>
+    <loc>${siteUrl}/</loc>
     <lastmod>${today}</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>${SITE_URL}/posts/</loc>
+    <loc>${siteUrl}/posts/</loc>
     <lastmod>${today}</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>${SITE_URL}/about/</loc>
+    <loc>${siteUrl}/about/</loc>
     <lastmod>${today}</lastmod>
     <priority>0.7</priority>
   </url>
@@ -53,13 +64,24 @@ const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
           : today;
       return `
   <url>
-    <loc>${SITE_URL}/posts/${encodePostSlug(post.slug)}/</loc>
+    <loc>${siteUrl}/posts/${encodePostSlug(post.slug)}/</loc>
     <lastmod>${lastmod}</lastmod>
     <priority>${getPostPriority(post)}</priority>
   </url>`;
     })
     .join('')}
 </urlset>`;
+}
 
-fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap.xml'), sitemap);
-console.log('Sitemap generated successfully!');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+// 스크립트로 직접 실행될 때만 파일 쓰기. (테스트에서 import 시에는 실행 안 됨)
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const posts = getAllPosts();
+  const today = new Date().toISOString().split('T')[0];
+  const sitemap = buildSitemapXml(posts, today);
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap.xml'), sitemap);
+  console.log('Sitemap generated successfully!');
+}

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:posts": "npx tsx scripts/validate-posts.ts",
     "check-types": "tsc --noEmit",
-    "test": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts'",
+    "test": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts'",
     "new-post": "npx tsx scripts/new-post.ts",
     "supabase-stop": "supabase stop --all --no-backup --debug",
     "supabase-start": "pnpm supabase-stop && pnpm supabase start"

--- a/apps/blog/web/scripts/generate-llms-full.test.ts
+++ b/apps/blog/web/scripts/generate-llms-full.test.ts
@@ -90,15 +90,15 @@ test('llms-full: excerpt가 200자 초과면 잘림', () => {
   assert.ok(!text.includes('A'.repeat(201)));
 });
 
-test('llms-full: excerpt 없으면 content에서 추출', () => {
+test('llms-full: excerpt 없으면 content에서 추출 (마크다운 # 만 제거, 개행 유지)', () => {
   const text = buildLlmsFullText([
     makePost({ slug: 'a', excerpt: undefined, content: '# h1\n본문입니다' }),
   ]);
-  // 마크다운 기호 제거된 형태가 들어가야 함
+  // generate-llms-full의 content 추출은 `[#`*\[\]]` 만 제거하고 개행은 보존.
+  // `# h1\n본문입니다` → `h1\n본문입니다` (trim 후 slice(0, 200))
   assert.ok(
-    text.includes('h1\n본문입니다...') ||
-      text.includes('h1 본문입니다...') ||
-      text.includes('h1'),
+    text.includes('h1\n본문입니다...'),
+    `expected 'h1\\n본문입니다...' in output, got: ${text.slice(0, 500)}`,
   );
 });
 

--- a/apps/blog/web/scripts/generate-llms-full.test.ts
+++ b/apps/blog/web/scripts/generate-llms-full.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildLlmsFullText } from './generate-llms-full';
+import type { PostData } from '../domain/post';
+
+function makePost(over: Partial<PostData> = {}): PostData {
+  return {
+    slug: 'hello',
+    originalSlug: 'hello',
+    relativeDir: '',
+    title: 'Hello',
+    date: '2026-05-09',
+    updatedAt: null,
+    content: 'content body',
+    readMin: 1,
+    excerpt: '요약',
+    tags: ['x'],
+    series: undefined,
+    status: 'published',
+    ...over,
+  };
+}
+
+test('llms-full: 헤더/푸터 포함', () => {
+  const text = buildLlmsFullText([]);
+  assert.ok(text.startsWith('# Frontend Lab'));
+  assert.ok(text.includes('## Key Facts'));
+  assert.ok(text.includes('## Contact'));
+  assert.ok(text.includes('https://blog.sangwook.dev'));
+  assert.ok(text.includes('https://github.com/Han5991'));
+  assert.ok(text.includes('https://blog.sangwook.dev/rss.xml'));
+});
+
+test('llms-full: Total posts 수 반영', () => {
+  const text = buildLlmsFullText([makePost(), makePost({ slug: 'b' })]);
+  assert.ok(text.includes('Total posts: 2+ articles'));
+});
+
+test('llms-full: 시리즈 헤더와 단독 헤더', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'a', series: 'bundler' }),
+    makePost({ slug: 'b', series: undefined }),
+  ]);
+  assert.ok(text.includes('## 시리즈: bundler'));
+  assert.ok(text.includes('## 단독 포스트'));
+});
+
+test('llms-full: 단독 포스트만 있으면 시리즈 헤더 없음', () => {
+  const text = buildLlmsFullText([makePost({ slug: 'a', series: undefined })]);
+  assert.ok(!text.includes('## 시리즈:'));
+  assert.ok(text.includes('## 단독 포스트'));
+});
+
+test('llms-full: 시리즈 포스트만 있으면 단독 헤더 없음', () => {
+  const text = buildLlmsFullText([makePost({ slug: 'a', series: 'bundler' })]);
+  assert.ok(text.includes('## 시리즈: bundler'));
+  assert.ok(!text.includes('## 단독 포스트'));
+});
+
+test('llms-full: 포스트 entry 형식 = ### [title](url) (date)', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'my-post', title: 'My Post', date: '2026-05-09' }),
+  ]);
+  assert.ok(
+    text.includes(
+      '### [My Post](https://blog.sangwook.dev/posts/my-post/) (2026-05-09)',
+    ),
+  );
+});
+
+test('llms-full: tags가 있으면 entry에 포함', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'a', tags: ['react', 'ts'] }),
+  ]);
+  assert.ok(text.includes('Tags: react, ts.'));
+});
+
+test('llms-full: tags가 비면 Tags 표기 없음', () => {
+  const text = buildLlmsFullText([makePost({ slug: 'a', tags: undefined })]);
+  assert.ok(!text.includes('Tags:'));
+});
+
+test('llms-full: excerpt가 200자 초과면 잘림', () => {
+  const longExcerpt = 'A'.repeat(300);
+  const text = buildLlmsFullText([
+    makePost({ slug: 'a', excerpt: longExcerpt }),
+  ]);
+  // 200자 + "..." 확인
+  assert.ok(text.includes('A'.repeat(200) + '...'));
+  assert.ok(!text.includes('A'.repeat(201)));
+});
+
+test('llms-full: excerpt 없으면 content에서 추출', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'a', excerpt: undefined, content: '# h1\n본문입니다' }),
+  ]);
+  // 마크다운 기호 제거된 형태가 들어가야 함
+  assert.ok(
+    text.includes('h1\n본문입니다...') ||
+      text.includes('h1 본문입니다...') ||
+      text.includes('h1'),
+  );
+});
+
+test('llms-full: 같은 시리즈 내 포스트는 date 오름차순', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'a', title: 'A', date: '2026-03-01', series: 's' }),
+    makePost({ slug: 'b', title: 'B', date: '2026-01-01', series: 's' }),
+    makePost({ slug: 'c', title: 'C', date: '2026-02-01', series: 's' }),
+  ]);
+  const idxB = text.indexOf('### [B]');
+  const idxC = text.indexOf('### [C]');
+  const idxA = text.indexOf('### [A]');
+  // B(1월) < C(2월) < A(3월) 순서
+  assert.ok(idxB > 0 && idxC > idxB && idxA > idxC);
+});
+
+test('llms-full: 단독 포스트는 date 내림차순', () => {
+  const text = buildLlmsFullText([
+    makePost({ slug: 'old', title: 'Old', date: '2025-01-01' }),
+    makePost({ slug: 'new', title: 'New', date: '2026-05-01' }),
+  ]);
+  const idxNew = text.indexOf('### [New]');
+  const idxOld = text.indexOf('### [Old]');
+  assert.ok(idxNew > 0 && idxNew < idxOld);
+});

--- a/apps/blog/web/scripts/generate-llms-full.ts
+++ b/apps/blog/web/scripts/generate-llms-full.ts
@@ -1,117 +1,129 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getAllPosts } from '../domain/post';
+import type { PostData } from '../domain/post';
 
 const SITE_URL = 'https://blog.sangwook.dev';
-const outputPath = join(process.cwd(), 'public', 'llms-full.txt');
 
-const posts = getAllPosts();
+/**
+ * llms-full.txt 본문을 생성합니다.
+ * 시리즈는 입력 순서(= getAllPosts 정렬 결과)에 따른 등장 순서대로 출력됩니다.
+ */
+export function buildLlmsFullText(posts: PostData[]): string {
+  const lines: string[] = [
+    `# Frontend Lab`,
+    ``,
+    `> Frontend engineering blog by Sangwook Han (한상욱). Deep-dive technical experiments in bundler architecture, TypeScript domain modeling, React patterns, and open source contributions. All posts include working code and first-hand implementation experience. Content primarily in Korean.`,
+    ``,
+    `## Key Facts`,
+    ``,
+    `- Author: Sangwook Han (한상욱), Frontend Engineer`,
+    `- Blog: ${SITE_URL}`,
+    `- GitHub: https://github.com/Han5991`,
+    `- LinkedIn: https://www.linkedin.com/in/sangwook-han/`,
+    `- Language: Primarily Korean, some English`,
+    `- Total posts: ${posts.length}+ articles`,
+    `- Open source: 27 Mantine PRs merged, Node.js core contributor, Next.js contributor`,
+    `- Notable contribution: gemini-cli 74% performance improvement (408ms → 107ms)`,
+    `- Speaking: FEConf 2025 (Korea's largest frontend conference), TeoConf`,
+    `- Main topics: Bundler internals, TypeScript domain modeling, React patterns, design systems, open source`,
+    ``,
+    `---`,
+    ``,
+  ];
 
-const lines: string[] = [
-  `# Frontend Lab`,
-  ``,
-  `> Frontend engineering blog by Sangwook Han (한상욱). Deep-dive technical experiments in bundler architecture, TypeScript domain modeling, React patterns, and open source contributions. All posts include working code and first-hand implementation experience. Content primarily in Korean.`,
-  ``,
-  `## Key Facts`,
-  ``,
-  `- Author: Sangwook Han (한상욱), Frontend Engineer`,
-  `- Blog: ${SITE_URL}`,
-  `- GitHub: https://github.com/Han5991`,
-  `- LinkedIn: https://www.linkedin.com/in/sangwook-han/`,
-  `- Language: Primarily Korean, some English`,
-  `- Total posts: ${posts.length}+ articles`,
-  `- Open source: 27 Mantine PRs merged, Node.js core contributor, Next.js contributor`,
-  `- Notable contribution: gemini-cli 74% performance improvement (408ms → 107ms)`,
-  `- Speaking: FEConf 2025 (Korea's largest frontend conference), TeoConf`,
-  `- Main topics: Bundler internals, TypeScript domain modeling, React patterns, design systems, open source`,
-  ``,
-  `---`,
-  ``,
-];
+  const seriesMap = new Map<string, PostData[]>();
+  const standalone: PostData[] = [];
 
-// 시리즈별로 포스트 분류
-const seriesMap = new Map<string, typeof posts>();
-const standalone: typeof posts = [];
-
-for (const post of posts) {
-  if (post.series) {
-    if (!seriesMap.has(post.series)) seriesMap.set(post.series, []);
-    seriesMap.get(post.series)!.push(post);
-  } else {
-    standalone.push(post);
+  for (const post of posts) {
+    if (post.series) {
+      if (!seriesMap.has(post.series)) seriesMap.set(post.series, []);
+      seriesMap.get(post.series)!.push(post);
+    } else {
+      standalone.push(post);
+    }
   }
-}
 
-// 시리즈 포스트 출력
-for (const [seriesName, seriesPosts] of seriesMap) {
-  lines.push(`## 시리즈: ${seriesName}`);
-  lines.push(``);
+  for (const [seriesName, seriesPosts] of seriesMap) {
+    lines.push(`## 시리즈: ${seriesName}`);
+    lines.push(``);
 
-  const sorted = [...seriesPosts].sort((a, b) => {
+    const sorted = [...seriesPosts].sort((a, b) => {
+      if (!a.date || !b.date) return 0;
+      return a.date.localeCompare(b.date);
+    });
+
+    for (const post of sorted) {
+      const url = `${SITE_URL}/posts/${post.slug}/`;
+      const excerpt = post.excerpt
+        ? post.excerpt.slice(0, 200)
+        : post.content
+            .replace(/[#`*\[\]]/g, '')
+            .trim()
+            .slice(0, 200);
+      const tags = post.tags?.length ? ` Tags: ${post.tags.join(', ')}.` : '';
+      const date = post.date ? ` (${post.date})` : '';
+
+      lines.push(`### [${post.title}](${url})${date}`);
+      lines.push(``);
+      lines.push(`${excerpt.trim()}...${tags}`);
+      lines.push(``);
+    }
+  }
+
+  const sortedStandalone = [...standalone].sort((a, b) => {
     if (!a.date || !b.date) return 0;
-    return a.date.localeCompare(b.date);
+    return b.date.localeCompare(a.date);
   });
 
-  for (const post of sorted) {
-    const url = `${SITE_URL}/posts/${post.slug}/`;
-    const excerpt = post.excerpt
-      ? post.excerpt.slice(0, 200)
-      : post.content
-          .replace(/[#`*\[\]]/g, '')
-          .trim()
-          .slice(0, 200);
-    const tags = post.tags?.length ? ` Tags: ${post.tags.join(', ')}.` : '';
-    const date = post.date ? ` (${post.date})` : '';
+  if (sortedStandalone.length > 0) {
+    lines.push(`## 단독 포스트`);
+    lines.push(``);
 
-    lines.push(`### [${post.title}](${url})${date}`);
-    lines.push(``);
-    lines.push(`${excerpt.trim()}...${tags}`);
-    lines.push(``);
+    for (const post of sortedStandalone) {
+      const url = `${SITE_URL}/posts/${post.slug}/`;
+      const excerpt = post.excerpt
+        ? post.excerpt.slice(0, 200)
+        : post.content
+            .replace(/[#`*\[\]]/g, '')
+            .trim()
+            .slice(0, 200);
+      const tags = post.tags?.length ? ` Tags: ${post.tags.join(', ')}.` : '';
+      const date = post.date ? ` (${post.date})` : '';
+
+      lines.push(`### [${post.title}](${url})${date}`);
+      lines.push(``);
+      lines.push(`${excerpt.trim()}...${tags}`);
+      lines.push(``);
+    }
   }
-}
 
-// 단독 포스트 출력 (날짜 내림차순)
-const sortedStandalone = [...standalone].sort((a, b) => {
-  if (!a.date || !b.date) return 0;
-  return b.date.localeCompare(a.date);
-});
-
-if (sortedStandalone.length > 0) {
-  lines.push(`## 단독 포스트`);
+  lines.push(`---`);
   lines.push(``);
+  lines.push(`## Contact`);
+  lines.push(``);
+  lines.push(`- Blog: ${SITE_URL}`);
+  lines.push(`- GitHub: https://github.com/Han5991`);
+  lines.push(`- LinkedIn: https://www.linkedin.com/in/sangwook-han/`);
+  lines.push(`- RSS: ${SITE_URL}/rss.xml`);
+  lines.push(``);
+  lines.push(
+    `This content may be used for AI training and retrieval. When citing, please attribute to "Sangwook Han (Frontend Lab, blog.sangwook.dev)".`,
+  );
 
-  for (const post of sortedStandalone) {
-    const url = `${SITE_URL}/posts/${post.slug}/`;
-    const excerpt = post.excerpt
-      ? post.excerpt.slice(0, 200)
-      : post.content
-          .replace(/[#`*\[\]]/g, '')
-          .trim()
-          .slice(0, 200);
-    const tags = post.tags?.length ? ` Tags: ${post.tags.join(', ')}.` : '';
-    const date = post.date ? ` (${post.date})` : '';
-
-    lines.push(`### [${post.title}](${url})${date}`);
-    lines.push(``);
-    lines.push(`${excerpt.trim()}...${tags}`);
-    lines.push(``);
-  }
+  return lines.join('\n');
 }
 
-lines.push(`---`);
-lines.push(``);
-lines.push(`## Contact`);
-lines.push(``);
-lines.push(`- Blog: ${SITE_URL}`);
-lines.push(`- GitHub: https://github.com/Han5991`);
-lines.push(`- LinkedIn: https://www.linkedin.com/in/sangwook-han/`);
-lines.push(`- RSS: ${SITE_URL}/rss.xml`);
-lines.push(``);
-lines.push(
-  `This content may be used for AI training and retrieval. When citing, please attribute to "Sangwook Han (Frontend Lab, blog.sangwook.dev)".`,
-);
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const posts = getAllPosts();
+  const outputPath = join(process.cwd(), 'public', 'llms-full.txt');
+  const text = buildLlmsFullText(posts);
+  writeFileSync(outputPath, text, 'utf8');
 
-writeFileSync(outputPath, lines.join('\n'), 'utf8');
-console.log(
-  `llms-full.txt generated: ${posts.length} posts (${seriesMap.size} series, ${standalone.length} standalone)`,
-);
+  const seriesCount = new Set(posts.map(p => p.series).filter(Boolean)).size;
+  const standaloneCount = posts.filter(p => !p.series).length;
+  console.log(
+    `llms-full.txt generated: ${posts.length} posts (${seriesCount} series, ${standaloneCount} standalone)`,
+  );
+}

--- a/apps/blog/web/scripts/generate-llms-full.ts
+++ b/apps/blog/web/scripts/generate-llms-full.ts
@@ -3,14 +3,22 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getAllPosts } from '../domain/post';
 import type { PostData } from '../domain/post';
+import { SITE_URL as DEFAULT_SITE_URL } from '../lib/constants';
 
-const SITE_URL = 'https://blog.sangwook.dev';
+export interface LlmsFullBuildOptions {
+  siteUrl?: string;
+}
 
 /**
  * llms-full.txt 본문을 생성합니다.
  * 시리즈는 입력 순서(= getAllPosts 정렬 결과)에 따른 등장 순서대로 출력됩니다.
+ * sitemap/rss와 동일한 패턴으로 siteUrl을 주입받아 결정성을 확보합니다.
  */
-export function buildLlmsFullText(posts: PostData[]): string {
+export function buildLlmsFullText(
+  posts: PostData[],
+  options: LlmsFullBuildOptions = {},
+): string {
+  const SITE_URL = options.siteUrl ?? DEFAULT_SITE_URL;
   const lines: string[] = [
     `# Frontend Lab`,
     ``,

--- a/apps/blog/web/scripts/generate-llms-full.ts
+++ b/apps/blog/web/scripts/generate-llms-full.ts
@@ -46,8 +46,9 @@ export function buildLlmsFullText(
 
   for (const post of posts) {
     if (post.series) {
-      if (!seriesMap.has(post.series)) seriesMap.set(post.series, []);
-      seriesMap.get(post.series)!.push(post);
+      const arr = seriesMap.get(post.series) ?? [];
+      arr.push(post);
+      seriesMap.set(post.series, arr);
     } else {
       standalone.push(post);
     }

--- a/apps/blog/web/scripts/generate-llms-full.ts
+++ b/apps/blog/web/scripts/generate-llms-full.ts
@@ -65,6 +65,8 @@ export function buildLlmsFullText(
 
     for (const post of sorted) {
       const url = `${SITE_URL}/posts/${post.slug}/`;
+      // `truthy 체크` 의도적: 빈 문자열 excerpt('')도 content fallback으로 처리해
+      // 빈 entry를 방지. excerpt 필드를 frontmatter에서 명시적으로 생략하면 동일 효과.
       const excerpt = post.excerpt
         ? post.excerpt.slice(0, 200)
         : post.content

--- a/apps/blog/web/scripts/generate-search-index.test.ts
+++ b/apps/blog/web/scripts/generate-search-index.test.ts
@@ -49,16 +49,13 @@ test('toPlainText: 마크다운 기호 제거', () => {
   );
 });
 
-test('toPlainText: HTML 태그가 마크다운 기호(>) 단계에서 절단됨', () => {
-  // 현재 구현: `>`가 먼저 [#*`_>~] 제거 단계에서 사라져 `<[^>]+>` 정규식이
-  // 매치되지 않음. 의도된 정밀 동작은 아니지만 출력 텍스트의 모양을 잠금하여
-  // 인덱스 크기/검색 매칭 결과가 무의식적으로 바뀌지 않도록 가드합니다.
-  assert.equal(toPlainText('<div>hi</div><br/>there'), '<divhi</div<br/there');
+test('toPlainText: HTML 태그가 정상적으로 제거됨', () => {
+  // HTML 태그 제거 → 그 다음 마크다운 기호 제거 → 공백 정리 순서.
+  assert.equal(toPlainText('<div>hi</div><br/>there'), 'hi there');
 });
 
-test('toPlainText: 정상 HTML 태그도 안전하게 처리 (공백 정리)', () => {
-  // 단일 토큰만 남으면 trim 결과는 그 토큰 그대로
-  assert.equal(toPlainText('<span>x</span>'), '<spanx</span');
+test('toPlainText: 닫는 태그도 정상 처리', () => {
+  assert.equal(toPlainText('<span>x</span>'), 'x');
 });
 
 test('toPlainText: 연속 공백 압축', () => {

--- a/apps/blog/web/scripts/generate-search-index.test.ts
+++ b/apps/blog/web/scripts/generate-search-index.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  buildAdminPostsIndex,
+  buildPublicSearchIndex,
+  CONTENT_PREVIEW_CHARS,
+  toPlainText,
+} from './generate-search-index';
+import type { PostData } from '../domain/post';
+
+function makePost(over: Partial<PostData> = {}): PostData {
+  return {
+    slug: 'hello',
+    originalSlug: 'hello',
+    relativeDir: '',
+    title: 'Hello',
+    date: '2026-05-09',
+    updatedAt: null,
+    content: '',
+    readMin: 1,
+    excerpt: 'short',
+    tags: ['t'],
+    series: undefined,
+    status: 'published',
+    ...over,
+  };
+}
+
+test('toPlainText: 코드 블록 제거', () => {
+  const raw = `before\n\`\`\`ts\nconst x = 1;\n\`\`\`\nafter`;
+  assert.equal(toPlainText(raw), 'before after');
+});
+
+test('toPlainText: 이미지 마크업 제거', () => {
+  assert.equal(toPlainText('text ![alt](url) more'), 'text more');
+});
+
+test('toPlainText: 링크는 텍스트만 남김', () => {
+  assert.equal(
+    toPlainText('see [Next.js](https://nextjs.org)!'),
+    'see Next.js!',
+  );
+});
+
+test('toPlainText: 마크다운 기호 제거', () => {
+  assert.equal(
+    toPlainText('## hello *world* `code` _emph_ ~strike~'),
+    'hello world code emph strike',
+  );
+});
+
+test('toPlainText: HTML 태그가 마크다운 기호(>) 단계에서 절단됨', () => {
+  // 현재 구현: `>`가 먼저 [#*`_>~] 제거 단계에서 사라져 `<[^>]+>` 정규식이
+  // 매치되지 않음. 의도된 정밀 동작은 아니지만 출력 텍스트의 모양을 잠금하여
+  // 인덱스 크기/검색 매칭 결과가 무의식적으로 바뀌지 않도록 가드합니다.
+  assert.equal(toPlainText('<div>hi</div><br/>there'), '<divhi</div<br/there');
+});
+
+test('toPlainText: 정상 HTML 태그도 안전하게 처리 (공백 정리)', () => {
+  // 단일 토큰만 남으면 trim 결과는 그 토큰 그대로
+  assert.equal(toPlainText('<span>x</span>'), '<spanx</span');
+});
+
+test('toPlainText: 연속 공백 압축', () => {
+  assert.equal(toPlainText('a  \n\n  b'), 'a b');
+});
+
+test('buildPublicSearchIndex: 필수 필드 모두 포함', () => {
+  const idx = buildPublicSearchIndex([
+    makePost({
+      slug: 'a',
+      title: 'A',
+      date: '2026-01-01',
+      excerpt: 'ex',
+      tags: ['x', 'y'],
+      series: 's',
+      content: 'hello world',
+    }),
+  ]);
+  assert.equal(idx.length, 1);
+  assert.deepEqual(idx[0], {
+    slug: 'a',
+    title: 'A',
+    date: '2026-01-01',
+    excerpt: 'ex',
+    tags: ['x', 'y'],
+    series: 's',
+    contentPreview: 'hello world',
+  });
+});
+
+test('buildPublicSearchIndex: 결측 필드는 기본값', () => {
+  const idx = buildPublicSearchIndex([
+    makePost({
+      excerpt: undefined,
+      tags: undefined,
+      series: undefined,
+    }),
+  ]);
+  assert.equal(idx[0].excerpt, '');
+  assert.deepEqual(idx[0].tags, []);
+  assert.equal(idx[0].series, null);
+});
+
+test('buildPublicSearchIndex: contentPreview는 CONTENT_PREVIEW_CHARS로 제한', () => {
+  const long = 'x'.repeat(CONTENT_PREVIEW_CHARS + 1000);
+  const idx = buildPublicSearchIndex([makePost({ content: long })]);
+  assert.equal(idx[0].contentPreview.length, CONTENT_PREVIEW_CHARS);
+});
+
+test('buildAdminPostsIndex: status/scheduledDate 보존', () => {
+  const idx = buildAdminPostsIndex([
+    makePost({ status: 'draft' }),
+    makePost({
+      slug: 'b',
+      status: 'scheduled',
+      scheduledDate: '2026-06-01T00:00:00Z',
+    }),
+  ]);
+  assert.equal(idx[0].status, 'draft');
+  assert.equal(idx[0].scheduledDate, null);
+  assert.equal(idx[1].status, 'scheduled');
+  assert.equal(idx[1].scheduledDate, '2026-06-01T00:00:00Z');
+});
+
+test('buildAdminPostsIndex: status 누락 시 published 기본값', () => {
+  const idx = buildAdminPostsIndex([makePost({ status: undefined })]);
+  assert.equal(idx[0].status, 'published');
+});
+
+test('buildAdminPostsIndex: contentPreview 필드 없음 (보안/용량 분리)', () => {
+  const idx = buildAdminPostsIndex([makePost({ content: 'should not leak' })]);
+  assert.ok(!('contentPreview' in idx[0]));
+});
+
+test('CONTENT_PREVIEW_CHARS 상수가 1500자', () => {
+  // 검색 인덱스 크기를 통제하는 핵심 상수. 회귀 잠금.
+  assert.equal(CONTENT_PREVIEW_CHARS, 1500);
+});

--- a/apps/blog/web/scripts/generate-search-index.ts
+++ b/apps/blog/web/scripts/generate-search-index.ts
@@ -1,12 +1,12 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getAllPosts, getAllPostsIncludingHidden } from '../domain/post';
+import type { PostData } from '../domain/post';
 
-const outputPath = join(process.cwd(), 'public', 'search-index.json');
+export const CONTENT_PREVIEW_CHARS = 1500;
 
-const CONTENT_PREVIEW_CHARS = 1500;
-
-function toPlainText(content: string): string {
+export function toPlainText(content: string): string {
   return content
     .replace(/```[\s\S]*?```/g, '')
     .replace(/!\[.*?\]\(.*?\)/g, '')
@@ -17,34 +17,73 @@ function toPlainText(content: string): string {
     .trim();
 }
 
-// 공개 포스트용 검색 인덱스 (프론트엔드 검색용)
-const publicPosts = getAllPosts().map(p => ({
-  slug: p.slug,
-  title: p.title,
-  date: p.date,
-  excerpt: p.excerpt || '',
-  tags: p.tags || [],
-  series: p.series || null,
-  contentPreview: toPlainText(p.content).slice(0, CONTENT_PREVIEW_CHARS),
-}));
+export interface PublicSearchIndexEntry {
+  slug: string;
+  title: string;
+  date: string | null;
+  excerpt: string;
+  tags: string[];
+  series: string | null;
+  contentPreview: string;
+}
 
-writeFileSync(outputPath, JSON.stringify(publicPosts, null, 2), 'utf8');
-console.log(`Search index generated: ${publicPosts.length} posts`);
+export interface AdminPostsIndexEntry {
+  slug: string;
+  title: string;
+  date: string | null;
+  excerpt: string;
+  tags: string[];
+  series: string | null;
+  status: string;
+  scheduledDate: string | null;
+}
 
-// Admin 대시보드용 전체 포스트 인덱스 (draft, scheduled 포함)
-const adminOutputPath = join(process.cwd(), 'public', 'admin-posts-index.json');
-const allPosts = getAllPostsIncludingHidden().map(p => ({
-  slug: p.slug,
-  title: p.title,
-  date: p.date,
-  excerpt: p.excerpt || '',
-  tags: p.tags || [],
-  series: p.series || null,
-  status: p.status || 'published',
-  scheduledDate: p.scheduledDate || null,
-}));
+/** 공개 포스트용 검색 인덱스 (프론트엔드 검색용) */
+export function buildPublicSearchIndex(
+  posts: PostData[],
+): PublicSearchIndexEntry[] {
+  return posts.map(p => ({
+    slug: p.slug,
+    title: p.title,
+    date: p.date,
+    excerpt: p.excerpt || '',
+    tags: p.tags || [],
+    series: p.series || null,
+    contentPreview: toPlainText(p.content).slice(0, CONTENT_PREVIEW_CHARS),
+  }));
+}
 
-writeFileSync(adminOutputPath, JSON.stringify(allPosts, null, 2), 'utf8');
-console.log(
-  `Admin posts index generated: ${allPosts.length} posts (including hidden)`,
-);
+/** Admin 대시보드용 전체 포스트 인덱스 (draft, scheduled 포함) */
+export function buildAdminPostsIndex(
+  posts: PostData[],
+): AdminPostsIndexEntry[] {
+  return posts.map(p => ({
+    slug: p.slug,
+    title: p.title,
+    date: p.date,
+    excerpt: p.excerpt || '',
+    tags: p.tags || [],
+    series: p.series || null,
+    status: p.status || 'published',
+    scheduledDate: p.scheduledDate || null,
+  }));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const outputPath = join(process.cwd(), 'public', 'search-index.json');
+  const adminOutputPath = join(
+    process.cwd(),
+    'public',
+    'admin-posts-index.json',
+  );
+
+  const publicPosts = buildPublicSearchIndex(getAllPosts());
+  writeFileSync(outputPath, JSON.stringify(publicPosts, null, 2), 'utf8');
+  console.log(`Search index generated: ${publicPosts.length} posts`);
+
+  const allPosts = buildAdminPostsIndex(getAllPostsIncludingHidden());
+  writeFileSync(adminOutputPath, JSON.stringify(allPosts, null, 2), 'utf8');
+  console.log(
+    `Admin posts index generated: ${allPosts.length} posts (including hidden)`,
+  );
+}

--- a/apps/blog/web/scripts/generate-search-index.ts
+++ b/apps/blog/web/scripts/generate-search-index.ts
@@ -7,14 +7,18 @@ import type { PostData } from '../domain/post';
 export const CONTENT_PREVIEW_CHARS = 1500;
 
 export function toPlainText(content: string): string {
-  return content
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/!\[.*?\]\(.*?\)/g, '')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[#*`_>~]/g, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  return (
+    content
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/!\[.*?\]\(.*?\)/g, '')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // HTML 태그를 마크다운 기호 제거(`>` 포함)보다 먼저 처리해야 `<div>...</div>` 같은
+      // 태그가 정상적으로 공백으로 치환됩니다.
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/[#*`_>~]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
 }
 
 export interface PublicSearchIndexEntry {

--- a/apps/blog/web/scripts/generate-search-index.ts
+++ b/apps/blog/web/scripts/generate-search-index.ts
@@ -42,7 +42,13 @@ export interface AdminPostsIndexEntry {
   scheduledDate: string | null;
 }
 
-/** 공개 포스트용 검색 인덱스 (프론트엔드 검색용) */
+/**
+ * 공개 포스트용 검색 인덱스 (프론트엔드 검색용).
+ *
+ * `||`는 의도적: 빈 문자열/undefined 모두 falsy fallback으로 정규화.
+ * 검색 UI에서 빈 entry vs 누락 entry의 차이가 없으므로 일관된 빈 값을 사용.
+ * (llms-full.ts의 excerpt 처리도 같은 의도이며 거기엔 본문 fallback이 한 단계 더 있음.)
+ */
 export function buildPublicSearchIndex(
   posts: PostData[],
 ): PublicSearchIndexEntry[] {

--- a/apps/blog/web/turbo.json
+++ b/apps/blog/web/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "test": {
-      "dependsOn": ["^build", "^test"],
+      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/apps/blog/posts/**"]
     }
   }

--- a/apps/blog/web/turbo.json
+++ b/apps/blog/web/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["^build", "^test"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/apps/blog/posts/**"]
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+# Lefthook 설정 — Git hook 관리
+# 참고: https://lefthook.dev/configuration/
+#
+# pre-commit: staged 파일에만 빠른 검증 (prettier 자동 포매팅)
+# pre-push: 전체 워크스페이스에 무거운 검증 (lint + type-check + test, turbo 캐시 활용)
+#
+# 우회: 긴급 시 `LEFTHOOK=0 git commit` 또는 `git commit --no-verify`
+
+pre-commit:
+  parallel: true
+  commands:
+    prettier:
+      glob: '*.{ts,tsx,js,jsx,json,md,mjs,cjs,yml,yaml}'
+      run: pnpm exec prettier --write {staged_files} --ignore-unknown
+      stage_fixed: true
+
+pre-push:
+  parallel: true
+  commands:
+    lint:
+      run: pnpm lint
+    types:
+      run: pnpm check-types
+    test:
+      run: pnpm test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,8 @@ pre-commit:
   parallel: true
   commands:
     prettier:
-      glob: '*.{ts,tsx,js,jsx,json,md,mjs,cjs,yml,yaml}'
+      # 모노레포 하위 파일까지 명시적으로 매치 — 루트만 잡는 오해 방지
+      glob: '**/*.{ts,tsx,js,jsx,json,md,mjs,cjs,yml,yaml}'
       run: pnpm exec prettier --write {staged_files} --ignore-unknown
       stage_fixed: true
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "blog-web": "turbo run dev --filter=@blog/web",
     "blog-build": "turbo run build --filter=@blog/web",
     "socket-server": "turbo run dev --filter=socket-server",
-    "socket": "concurrently \"pnpm socket-server\" \"pnpm react\""
+    "socket": "concurrently \"pnpm socket-server\" \"pnpm react\"",
+    "prepare": "lefthook install"
   },
   "devDependencies": {
+    "lefthook": "^2.1.6",
     "prettier": "^3.5.0",
     "turbo": "^2.5.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,12 +61,15 @@ importers:
         specifier: ^9.2.0
         version: 9.2.1
     devDependencies:
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
       prettier:
         specifier: ^3.5.0
-        version: 3.8.3
+        version: 3.8.1
       turbo:
         specifier: ^2.5.3
-        version: 2.9.14
+        version: 2.9.5
 
   apps/blog/web:
     dependencies:
@@ -96,7 +99,7 @@ importers:
         version: 5.2.0
       '@supabase/supabase-js':
         specifier: ^2.89.0
-        version: 2.105.4
+        version: 2.103.0
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.3.0-canary-a757cb76-20251002)
@@ -184,13 +187,13 @@ importers:
         version: 9.39.4(jiti@2.4.2)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+        version: 16.2.6(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
-        version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
+        version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       supabase:
         specifier: ^2.70.5
-        version: 2.98.2
+        version: 2.88.1
       tsx:
         specifier: ^4.22.0
         version: 4.22.0
@@ -345,13 +348,13 @@ importers:
         version: 29.1.1
       msw:
         specifier: ^2.7.6
-        version: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
+        version: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
       typescript:
         specifier: catalog:typescript5
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.32.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+        version: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)
@@ -360,7 +363,7 @@ importers:
         version: 6.1.1(typescript@5.8.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
       vitest:
         specifier: ^4.0.0-beta.15
-        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
+        version: 4.1.4(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
 
   apps/socket-server:
     devDependencies:
@@ -378,7 +381,7 @@ importers:
         version: 7.29.0
       '@babel/preset-env':
         specifier: ^7.26.9
-        version: 7.29.5(@babel/core@7.29.0)
+        version: 7.29.2(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: ^7.26.0
         version: 7.28.5(@babel/core@7.29.0)
@@ -402,7 +405,7 @@ importers:
         version: 30.4.2(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.8.3))
       msw:
         specifier: ^2.7.6
-        version: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
+        version: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
       ts-jest:
         specifier: ^29.2.6
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.8.3)))(typescript@5.8.3)
@@ -445,7 +448,7 @@ importers:
     dependencies:
       react:
         specifier: '*'
-        version: 19.2.6
+        version: 19.2.5
 
   packages/@package/bundler:
     dependencies:
@@ -458,7 +461,7 @@ importers:
     devDependencies:
       '@types/estree':
         specifier: ^1.0.8
-        version: 1.0.9
+        version: 1.0.8
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -479,10 +482,10 @@ importers:
         version: link:../sample-lib
       react:
         specifier: ^19.0.0
-        version: 19.2.6
+        version: 19.2.5
       react-dom:
         specifier: ^19.0.0
-        version: 19.2.6(react@19.2.6)
+        version: 19.2.5(react@19.2.5)
 
   packages/@package/config: {}
 
@@ -502,10 +505,10 @@ importers:
         version: link:../bundler
       react:
         specifier: ^19.2.4
-        version: 19.2.6
+        version: 19.2.5
       react-dom:
         specifier: ^19.2.4
-        version: 19.2.6(react@19.2.6)
+        version: 19.2.5(react@19.2.5)
       tsx:
         specifier: ^4.22.0
         version: 4.22.0
@@ -551,8 +554,8 @@ packages:
     resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.0':
@@ -703,12 +706,6 @@ packages:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
-    resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1170,8 +1167,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.5':
-    resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
+  '@babel/preset-env@7.29.2':
+    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1856,35 +1853,31 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/ansi@2.0.5':
-    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-
-  '@inquirer/confirm@6.0.13':
-    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/confirm@5.1.9':
+    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@11.1.10':
-    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/core@10.1.10':
+    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@2.0.5':
-    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/figures@1.0.11':
+    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+    engines: {node: '>=18'}
 
-  '@inquirer/type@4.0.5':
-    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/type@3.0.6':
+    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2188,9 +2181,6 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
-
-  '@open-draft/deferred-promise@3.0.0':
-    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
 
   '@open-draft/logger@0.3.0':
     resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
@@ -2536,31 +2526,31 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@supabase/auth-js@2.105.4':
-    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+  '@supabase/auth-js@2.103.0':
+    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.105.4':
-    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+  '@supabase/functions-js@2.103.0':
+    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/phoenix@0.4.2':
-    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
 
-  '@supabase/postgrest-js@2.105.4':
-    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+  '@supabase/postgrest-js@2.103.0':
+    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.105.4':
-    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+  '@supabase/realtime-js@2.103.0':
+    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/storage-js@2.105.4':
-    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+  '@supabase/storage-js@2.103.0':
+    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.105.4':
-    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+  '@supabase/supabase-js@2.103.0':
+    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
     engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
@@ -2618,33 +2608,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.9.14':
-    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
+  '@turbo/darwin-64@2.9.5':
+    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.14':
-    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
+  '@turbo/darwin-arm64@2.9.5':
+    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.14':
-    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
+  '@turbo/linux-64@2.9.5':
+    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.14':
-    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
+  '@turbo/linux-arm64@2.9.5':
+    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.14':
-    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
+  '@turbo/windows-64@2.9.5':
+    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.14':
-    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
+  '@turbo/windows-arm64@2.9.5':
+    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
     cpu: [arm64]
     os: [win32]
 
@@ -2771,11 +2761,11 @@ packages:
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -2839,9 +2829,6 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@types/set-cookie-parser@2.4.10':
-    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
-
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -2863,6 +2850,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -2877,23 +2867,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/eslint-plugin@8.59.3':
-    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.59.3
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/parser@8.58.1':
     resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/parser@8.59.3':
-    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2905,28 +2880,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.59.3':
-    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/scope-manager@8.58.1':
     resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.59.3':
-    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/tsconfig-utils@8.58.1':
     resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/tsconfig-utils@8.59.3':
-    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2938,29 +2897,12 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.59.3':
-    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/types@8.58.1':
     resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.3':
-    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/typescript-estree@8.58.1':
     resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/typescript-estree@8.59.3':
-    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2972,19 +2914,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.3':
-    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/visitor-keys@8.58.1':
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.59.3':
-    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -3095,11 +3026,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3109,20 +3040,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@vue/compiler-core@3.5.25':
     resolution: {integrity: sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==}
@@ -3366,10 +3297,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.9.17:
-    resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
-    hasBin: true
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3387,8 +3314,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4136,11 +4063,11 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-hooks@7.1.1:
-    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+  eslint-plugin-react-hooks@7.0.1:
+    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react-refresh@0.4.26:
     resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
@@ -4308,17 +4235,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-string-truncated-width@3.0.3:
-    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
-
-  fast-string-width@3.0.2:
-    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
-  fast-wrap-ansi@0.2.0:
-    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
@@ -4509,8 +4427,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql@16.14.0:
-    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+  graphql@16.12.0:
+    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gray-matter@4.0.3:
@@ -4582,8 +4500,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  headers-polyfill@5.0.1:
-    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -5189,6 +5107,60 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5689,8 +5661,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.14.6:
-    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+  msw@2.13.2:
+    resolution: {integrity: sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -5699,9 +5671,9 @@ packages:
       typescript:
         optional: true
 
-  mute-stream@3.0.0:
-    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -6078,8 +6050,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6135,10 +6107,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.5
 
   react-dom@19.3.0-canary-a757cb76-20251002:
     resolution: {integrity: sha512-UvMoAElWcrEe1keKAMZqJ2Rw4wQZah8GFQHvqCLsBd+50LR22sme5hkjiyUO1dnoSVfAvEncARgDfJVEJ1miKA==}
@@ -6201,8 +6173,8 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   react@19.3.0-canary-a757cb76-20251002:
@@ -6349,8 +6321,8 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
-  rettime@0.11.11:
-    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -6426,11 +6398,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6441,9 +6408,6 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
-
-  set-cookie-parser@3.1.0:
-    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6660,8 +6624,8 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  supabase@2.98.2:
-    resolution: {integrity: sha512-COSz57JyuUGbj75GSGM5mmyz/behBiYSiJ4A9qJVVC/vNp9bYS+9RCTXBtEt8kgqDDYWZsOmzk+mPbIBdr9bPg==}
+  supabase@2.88.1:
+    resolution: {integrity: sha512-kGtKVV4Hze5ehJKHIb30+Hw6jq7gX7rm3aQ1olVCk6u4rXftKPbK6nW8LttPmvYYkLSLBDDni5rowOpee7aMyA==}
     engines: {npm: '>=8'}
     hasBin: true
 
@@ -6742,15 +6706,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.0.30:
-    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.0.30:
-    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
     hasBin: true
 
   tmpl@1.0.5:
@@ -6766,6 +6730,10 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
   tough-cookie@6.0.1:
@@ -6903,8 +6871,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.14:
-    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
+  turbo@2.9.5:
+    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -6923,8 +6891,8 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-fest@5.6.0:
-    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+  type-fest@5.4.1:
+    resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
     engines: {node: '>=20'}
 
   type-is@2.1.0:
@@ -6949,13 +6917,6 @@ packages:
 
   typescript-eslint@8.58.1:
     resolution: {integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  typescript-eslint@8.59.3:
-    resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -7146,20 +7107,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -7280,6 +7241,10 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -7353,6 +7318,10 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -7421,7 +7390,7 @@ snapshots:
 
   '@babel/compat-data@7.28.6': {}
 
-  '@babel/compat-data@7.29.3': {}
+  '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -7628,14 +7597,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -8121,9 +8082,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.3
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
@@ -8131,7 +8092,6 @@ snapshots:
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
@@ -8680,30 +8640,29 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/ansi@2.0.5': {}
-
-  '@inquirer/confirm@6.0.13(@types/node@25.8.0)':
+  '@inquirer/confirm@5.1.9(@types/node@25.8.0)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@25.8.0)
-      '@inquirer/type': 4.0.5(@types/node@25.8.0)
+      '@inquirer/core': 10.1.10(@types/node@25.8.0)
+      '@inquirer/type': 3.0.6(@types/node@25.8.0)
     optionalDependencies:
       '@types/node': 25.8.0
 
-  '@inquirer/core@11.1.10(@types/node@25.8.0)':
+  '@inquirer/core@10.1.10(@types/node@25.8.0)':
     dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@25.8.0)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@25.8.0)
+      ansi-escapes: 4.3.2
       cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.0
-      mute-stream: 3.0.0
+      mute-stream: 2.0.0
       signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 25.8.0
 
-  '@inquirer/figures@2.0.5': {}
+  '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/type@4.0.5(@types/node@25.8.0)':
+  '@inquirer/type@3.0.6(@types/node@25.8.0)':
     optionalDependencies:
       '@types/node': 25.8.0
 
@@ -9028,7 +8987,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
@@ -9169,8 +9128,6 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@open-draft/deferred-promise@2.2.0': {}
-
-  '@open-draft/deferred-promise@3.0.0': {}
 
   '@open-draft/logger@0.3.0':
     dependencies:
@@ -9669,37 +9626,45 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@supabase/auth-js@2.105.4':
+  '@supabase/auth-js@2.103.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.105.4':
+  '@supabase/functions-js@2.103.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.2': {}
+  '@supabase/phoenix@0.4.0': {}
 
-  '@supabase/postgrest-js@2.105.4':
+  '@supabase/postgrest-js@2.103.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.105.4':
+  '@supabase/realtime-js@2.103.0':
     dependencies:
-      '@supabase/phoenix': 0.4.2
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
       tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
-  '@supabase/storage-js@2.105.4':
+  '@supabase/storage-js@2.103.0':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.105.4':
+  '@supabase/supabase-js@2.103.0':
     dependencies:
-      '@supabase/auth-js': 2.105.4
-      '@supabase/functions-js': 2.105.4
-      '@supabase/postgrest-js': 2.105.4
-      '@supabase/realtime-js': 2.105.4
-      '@supabase/storage-js': 2.105.4
+      '@supabase/auth-js': 2.103.0
+      '@supabase/functions-js': 2.103.0
+      '@supabase/postgrest-js': 2.103.0
+      '@supabase/realtime-js': 2.103.0
+      '@supabase/storage-js': 2.103.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9760,22 +9725,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/darwin-64@2.9.14':
+  '@turbo/darwin-64@2.9.5':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.14':
+  '@turbo/darwin-arm64@2.9.5':
     optional: true
 
-  '@turbo/linux-64@2.9.14':
+  '@turbo/linux-64@2.9.5':
     optional: true
 
-  '@turbo/linux-arm64@2.9.14':
+  '@turbo/linux-arm64@2.9.5':
     optional: true
 
-  '@turbo/windows-64@2.9.14':
+  '@turbo/windows-64@2.9.5':
     optional: true
 
-  '@turbo/windows-arm64@2.9.14':
+  '@turbo/windows-arm64@2.9.5':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -9936,11 +9901,11 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
+
+  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -10007,10 +9972,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/set-cookie-parser@2.4.10':
-    dependencies:
-      '@types/node': 25.8.0
-
   '@types/stack-utils@2.0.3': {}
 
   '@types/statuses@2.0.6': {}
@@ -10024,6 +9985,10 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.8.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10047,40 +10012,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 9.39.4(jiti@2.4.2)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.4.2)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.4.2)
       typescript: 5.8.3
@@ -10096,30 +10033,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.3(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/types': 8.59.3
-      debug: 4.4.3
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.58.1':
     dependencies:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
 
-  '@typescript-eslint/scope-manager@8.59.3':
-    dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
-
   '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.8.3)':
-    dependencies:
-      typescript: 5.8.3
-
-  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
@@ -10135,21 +10054,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.4.2)
-      ts-api-utils: 2.5.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/types@8.58.1': {}
-
-  '@typescript-eslint/types@8.59.3': {}
 
   '@typescript-eslint/typescript-estree@8.58.1(typescript@5.8.3)':
     dependencies:
@@ -10160,21 +10065,6 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -10192,25 +10082,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.4.2))
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
-      eslint: 9.39.4(jiti@2.4.2)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/visitor-keys@8.58.1':
     dependencies:
       '@typescript-eslint/types': 8.58.1
-      eslint-visitor-keys: 5.0.1
-
-  '@typescript-eslint/visitor-keys@8.59.3':
-    dependencies:
-      '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -10291,45 +10165,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))':
+  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))':
     dependencies:
-      '@vitest/spy': 4.1.6
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
+      msw: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
       vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.6':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.6': {}
+  '@vitest/spy@4.1.4': {}
 
-  '@vitest/utils@4.1.6':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -10576,7 +10450,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.3
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -10650,8 +10524,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.18: {}
 
-  baseline-browser-mapping@2.9.17: {}
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -10687,7 +10559,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10697,7 +10569,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.17
+      baseline-browser-mapping: 2.10.18
       caniuse-lite: 1.0.30001765
       electron-to-chromium: 1.5.277
       node-releases: 2.0.27
@@ -11472,26 +11344,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.6(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.6
-      eslint: 9.39.4(jiti@2.4.2)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.4.2))
-      globals: 16.4.0
-      typescript-eslint: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-config-next@16.2.6(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
@@ -11501,7 +11353,7 @@ snapshots:
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.4.2))
       globals: 16.4.0
       typescript-eslint: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
     optionalDependencies:
@@ -11531,48 +11383,18 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.39.4(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.4.2))
     transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.4.2)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
@@ -11586,7 +11408,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11625,7 +11447,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
 
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -11688,7 +11510,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.7
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -11742,7 +11564,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -11755,7 +11577,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -11773,7 +11595,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -11888,17 +11710,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-string-truncated-width@3.0.3: {}
-
-  fast-string-width@3.0.2:
-    dependencies:
-      fast-string-truncated-width: 3.0.3
-
   fast-uri@3.1.2: {}
-
-  fast-wrap-ansi@0.2.0:
-    dependencies:
-      fast-string-width: 3.0.2
 
   fastq@1.19.0:
     dependencies:
@@ -12094,7 +11906,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.14.0: {}
+  graphql@16.12.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -12173,7 +11985,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -12194,7 +12006,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -12238,10 +12050,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  headers-polyfill@5.0.1:
-    dependencies:
-      '@types/set-cookie-parser': 2.4.10
-      set-cookie-parser: 3.1.0
+  headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
 
@@ -12519,7 +12328,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12903,7 +12712,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.8.0
+      semver: 7.7.4
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
@@ -13104,6 +12913,49 @@ snapshots:
 
   layout-base@2.0.1: {}
 
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -13284,7 +13136,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -13578,7 +13430,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -13589,7 +13441,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -13606,7 +13458,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -13642,7 +13494,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -13706,7 +13558,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -13780,7 +13632,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
@@ -13821,24 +13673,24 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3):
+  msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3):
     dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@25.8.0)
+      '@inquirer/confirm': 5.1.9(@types/node@25.8.0)
       '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 3.0.0
+      '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.11.11
+      rettime: 0.10.1
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
+      tough-cookie: 6.0.0
+      type-fest: 5.4.1
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
@@ -13846,7 +13698,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  mute-stream@3.0.0: {}
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -14176,7 +14028,7 @@ snapshots:
 
   prettier@3.2.5: {}
 
-  prettier@3.8.3: {}
+  prettier@3.8.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -14233,9 +14085,9 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@19.2.6(react@19.2.6):
+  react-dom@19.2.5(react@19.2.5):
     dependencies:
-      react: 19.2.6
+      react: 19.2.5
       scheduler: 0.27.0
 
   react-dom@19.3.0-canary-a757cb76-20251002(react@19.3.0-canary-a757cb76-20251002):
@@ -14303,7 +14155,7 @@ snapshots:
       react: 19.3.0-canary-a757cb76-20251002
       refractor: 5.0.0
 
-  react@19.2.6: {}
+  react@19.2.5: {}
 
   react@19.3.0-canary-a757cb76-20251002: {}
 
@@ -14333,7 +14185,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -14349,14 +14201,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -14445,7 +14297,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -14528,7 +14380,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rettime@0.11.11: {}
+  rettime@0.10.1: {}
 
   reusify@1.0.4: {}
 
@@ -14653,8 +14505,6 @@ snapshots:
 
   semver@7.7.4: {}
 
-  semver@7.8.0: {}
-
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -14681,8 +14531,6 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.1: {}
-
-  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -14951,7 +14799,7 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  supabase@2.98.2:
+  supabase@2.88.1:
     dependencies:
       bin-links: 6.0.0
       https-proxy-agent: 9.0.0
@@ -15034,15 +14882,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.0.30: {}
+  tldts-core@7.0.16: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.0.30:
+  tldts@7.0.16:
     dependencies:
-      tldts-core: 7.0.30
+      tldts-core: 7.0.16
 
   tmpl@1.0.5: {}
 
@@ -15056,9 +14904,13 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.30
+      tldts: 7.0.16
 
   tr46@1.0.1:
     dependencies:
@@ -15222,14 +15074,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.14:
+  turbo@2.9.5:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.14
-      '@turbo/darwin-arm64': 2.9.14
-      '@turbo/linux-64': 2.9.14
-      '@turbo/linux-arm64': 2.9.14
-      '@turbo/windows-64': 2.9.14
-      '@turbo/windows-arm64': 2.9.14
+      '@turbo/darwin-64': 2.9.5
+      '@turbo/darwin-arm64': 2.9.5
+      '@turbo/linux-64': 2.9.5
+      '@turbo/linux-arm64': 2.9.5
+      '@turbo/windows-64': 2.9.5
+      '@turbo/windows-arm64': 2.9.5
 
   type-check@0.4.0:
     dependencies:
@@ -15241,7 +15093,7 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-fest@5.6.0:
+  type-fest@5.4.1:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -15290,17 +15142,6 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.39.4(jiti@2.4.2)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.39.4(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -15499,15 +15340,15 @@ snapshots:
       jiti: 2.4.2
       tsx: 4.22.0
 
-  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)):
+  vitest@4.1.4(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -15639,6 +15480,12 @@ snapshots:
 
   wordwrapjs@5.1.1: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -15697,6 +15544,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoctocolors-cjs@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.2.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,10 +66,10 @@ importers:
         version: 2.1.6
       prettier:
         specifier: ^3.5.0
-        version: 3.8.1
+        version: 3.8.3
       turbo:
         specifier: ^2.5.3
-        version: 2.9.5
+        version: 2.9.14
 
   apps/blog/web:
     dependencies:
@@ -99,7 +99,7 @@ importers:
         version: 5.2.0
       '@supabase/supabase-js':
         specifier: ^2.89.0
-        version: 2.103.0
+        version: 2.105.4
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.3.0-canary-a757cb76-20251002)
@@ -187,13 +187,13 @@ importers:
         version: 9.39.4(jiti@2.4.2)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+        version: 16.2.6(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
-        version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
+        version: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       supabase:
         specifier: ^2.70.5
-        version: 2.88.1
+        version: 2.98.2
       tsx:
         specifier: ^4.22.0
         version: 4.22.0
@@ -348,13 +348,13 @@ importers:
         version: 29.1.1
       msw:
         specifier: ^2.7.6
-        version: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
+        version: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
       typescript:
         specifier: catalog:typescript5
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.32.0
-        version: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+        version: 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)
@@ -363,7 +363,7 @@ importers:
         version: 6.1.1(typescript@5.8.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
       vitest:
         specifier: ^4.0.0-beta.15
-        version: 4.1.4(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
+        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
 
   apps/socket-server:
     devDependencies:
@@ -381,7 +381,7 @@ importers:
         version: 7.29.0
       '@babel/preset-env':
         specifier: ^7.26.9
-        version: 7.29.2(@babel/core@7.29.0)
+        version: 7.29.5(@babel/core@7.29.0)
       '@babel/preset-typescript':
         specifier: ^7.26.0
         version: 7.28.5(@babel/core@7.29.0)
@@ -405,7 +405,7 @@ importers:
         version: 30.4.2(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.8.3))
       msw:
         specifier: ^2.7.6
-        version: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
+        version: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
       ts-jest:
         specifier: ^29.2.6
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.8.3)))(typescript@5.8.3)
@@ -448,7 +448,7 @@ importers:
     dependencies:
       react:
         specifier: '*'
-        version: 19.2.5
+        version: 19.2.6
 
   packages/@package/bundler:
     dependencies:
@@ -461,7 +461,7 @@ importers:
     devDependencies:
       '@types/estree':
         specifier: ^1.0.8
-        version: 1.0.8
+        version: 1.0.9
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -482,10 +482,10 @@ importers:
         version: link:../sample-lib
       react:
         specifier: ^19.0.0
-        version: 19.2.5
+        version: 19.2.6
       react-dom:
         specifier: ^19.0.0
-        version: 19.2.5(react@19.2.5)
+        version: 19.2.6(react@19.2.6)
 
   packages/@package/config: {}
 
@@ -505,10 +505,10 @@ importers:
         version: link:../bundler
       react:
         specifier: ^19.2.4
-        version: 19.2.5
+        version: 19.2.6
       react-dom:
         specifier: ^19.2.4
-        version: 19.2.5(react@19.2.5)
+        version: 19.2.6(react@19.2.6)
       tsx:
         specifier: ^4.22.0
         version: 4.22.0
@@ -554,8 +554,8 @@ packages:
     resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.0':
@@ -706,6 +706,12 @@ packages:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
+    resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1167,8 +1173,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
+  '@babel/preset-env@7.29.5':
+    resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1853,31 +1859,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/confirm@5.1.9':
-    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
-    engines: {node: '>=18'}
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.13':
+    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.10':
-    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
-    engines: {node: '>=18'}
+  '@inquirer/core@11.1.10':
+    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.11':
-    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
-    engines: {node: '>=18'}
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
-  '@inquirer/type@3.0.6':
-    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
-    engines: {node: '>=18'}
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2181,6 +2191,9 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
 
   '@open-draft/logger@0.3.0':
     resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
@@ -2526,31 +2539,31 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@supabase/auth-js@2.103.0':
-    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.103.0':
-    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/phoenix@0.4.0':
-    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
 
-  '@supabase/postgrest-js@2.103.0':
-    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.103.0':
-    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/storage-js@2.103.0':
-    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.103.0':
-    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
     engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
@@ -2608,33 +2621,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.9.5':
-    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.5':
-    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.5':
-    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.5':
-    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.5':
-    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.5':
-    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
     cpu: [arm64]
     os: [win32]
 
@@ -2761,11 +2774,11 @@ packages:
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -2829,6 +2842,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -2850,9 +2866,6 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -2867,8 +2880,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.59.3':
+    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.3
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.58.1':
     resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.3':
+    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2880,12 +2908,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.59.3':
+    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.58.1':
     resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.59.3':
+    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.58.1':
     resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.59.3':
+    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2897,12 +2941,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.59.3':
+    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.58.1':
     resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.59.3':
+    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.58.1':
     resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.59.3':
+    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2914,8 +2975,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.59.3':
+    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.58.1':
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -3026,11 +3098,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3040,20 +3112,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@vue/compiler-core@3.5.25':
     resolution: {integrity: sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==}
@@ -3297,6 +3369,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.9.17:
+    resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
+    hasBin: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3314,8 +3390,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4063,11 +4139,11 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.4.26:
     resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
@@ -4235,8 +4311,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
@@ -4427,8 +4512,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql@16.12.0:
-    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gray-matter@4.0.3:
@@ -4500,8 +4585,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  headers-polyfill@4.0.3:
-    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -5661,8 +5746,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.13.2:
-    resolution: {integrity: sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==}
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -5671,9 +5756,9 @@ packages:
       typescript:
         optional: true
 
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -6050,8 +6135,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6107,10 +6192,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.6
 
   react-dom@19.3.0-canary-a757cb76-20251002:
     resolution: {integrity: sha512-UvMoAElWcrEe1keKAMZqJ2Rw4wQZah8GFQHvqCLsBd+50LR22sme5hkjiyUO1dnoSVfAvEncARgDfJVEJ1miKA==}
@@ -6173,8 +6258,8 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
   react@19.3.0-canary-a757cb76-20251002:
@@ -6321,8 +6406,8 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
-  rettime@0.10.1:
-    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -6398,6 +6483,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6408,6 +6498,9 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6624,8 +6717,8 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  supabase@2.88.1:
-    resolution: {integrity: sha512-kGtKVV4Hze5ehJKHIb30+Hw6jq7gX7rm3aQ1olVCk6u4rXftKPbK6nW8LttPmvYYkLSLBDDni5rowOpee7aMyA==}
+  supabase@2.98.2:
+    resolution: {integrity: sha512-COSz57JyuUGbj75GSGM5mmyz/behBiYSiJ4A9qJVVC/vNp9bYS+9RCTXBtEt8kgqDDYWZsOmzk+mPbIBdr9bPg==}
     engines: {npm: '>=8'}
     hasBin: true
 
@@ -6706,15 +6799,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.0.16:
-    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.0.16:
-    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
   tmpl@1.0.5:
@@ -6730,10 +6823,6 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
-    engines: {node: '>=16'}
-
-  tough-cookie@6.0.0:
-    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
   tough-cookie@6.0.1:
@@ -6871,8 +6960,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.5:
-    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -6891,8 +6980,8 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-fest@5.4.1:
-    resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
   type-is@2.1.0:
@@ -6917,6 +7006,13 @@ packages:
 
   typescript-eslint@8.58.1:
     resolution: {integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript-eslint@8.59.3:
+    resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -7107,20 +7203,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -7241,10 +7337,6 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -7318,10 +7410,6 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  yoctocolors-cjs@2.1.2:
-    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
-    engines: {node: '>=18'}
-
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -7390,7 +7478,7 @@ snapshots:
 
   '@babel/compat-data@7.28.6': {}
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -7597,6 +7685,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -8082,9 +8178,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
@@ -8092,6 +8188,7 @@ snapshots:
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
@@ -8640,29 +8737,30 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/confirm@5.1.9(@types/node@25.8.0)':
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.13(@types/node@25.8.0)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@25.8.0)
-      '@inquirer/type': 3.0.6(@types/node@25.8.0)
+      '@inquirer/core': 11.1.10(@types/node@25.8.0)
+      '@inquirer/type': 4.0.5(@types/node@25.8.0)
     optionalDependencies:
       '@types/node': 25.8.0
 
-  '@inquirer/core@10.1.10(@types/node@25.8.0)':
+  '@inquirer/core@11.1.10(@types/node@25.8.0)':
     dependencies:
-      '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@25.8.0)
-      ansi-escapes: 4.3.2
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.8.0)
       cli-width: 4.1.0
-      mute-stream: 2.0.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 25.8.0
 
-  '@inquirer/figures@1.0.11': {}
+  '@inquirer/figures@2.0.5': {}
 
-  '@inquirer/type@3.0.6(@types/node@25.8.0)':
+  '@inquirer/type@4.0.5(@types/node@25.8.0)':
     optionalDependencies:
       '@types/node': 25.8.0
 
@@ -8987,7 +9085,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
@@ -9128,6 +9226,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
 
   '@open-draft/logger@0.3.0':
     dependencies:
@@ -9626,45 +9726,37 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@supabase/auth-js@2.103.0':
+  '@supabase/auth-js@2.105.4':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.103.0':
+  '@supabase/functions-js@2.105.4':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.0': {}
+  '@supabase/phoenix@0.4.2': {}
 
-  '@supabase/postgrest-js@2.103.0':
+  '@supabase/postgrest-js@2.105.4':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.103.0':
+  '@supabase/realtime-js@2.105.4':
     dependencies:
-      '@supabase/phoenix': 0.4.0
-      '@types/ws': 8.18.1
+      '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@supabase/storage-js@2.103.0':
+  '@supabase/storage-js@2.105.4':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.103.0':
+  '@supabase/supabase-js@2.105.4':
     dependencies:
-      '@supabase/auth-js': 2.103.0
-      '@supabase/functions-js': 2.103.0
-      '@supabase/postgrest-js': 2.103.0
-      '@supabase/realtime-js': 2.103.0
-      '@supabase/storage-js': 2.103.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9725,22 +9817,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/darwin-64@2.9.5':
+  '@turbo/darwin-64@2.9.14':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.5':
+  '@turbo/darwin-arm64@2.9.14':
     optional: true
 
-  '@turbo/linux-64@2.9.5':
+  '@turbo/linux-64@2.9.14':
     optional: true
 
-  '@turbo/linux-arm64@2.9.5':
+  '@turbo/linux-arm64@2.9.14':
     optional: true
 
-  '@turbo/windows-64@2.9.5':
+  '@turbo/windows-64@2.9.14':
     optional: true
 
-  '@turbo/windows-arm64@2.9.5':
+  '@turbo/windows-arm64@2.9.14':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -9901,11 +9993,11 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
-
-  '@types/estree@1.0.7': {}
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -9972,6 +10064,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.8.0
+
   '@types/stack-utils@2.0.3': {}
 
   '@types/statuses@2.0.6': {}
@@ -9985,10 +10081,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 25.8.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10012,12 +10104,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
+      eslint: 9.39.4(jiti@2.4.2)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.58.1
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.4.2)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.4.2)
       typescript: 5.8.3
@@ -10033,12 +10153,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.59.3(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/types': 8.59.3
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.58.1':
     dependencies:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
 
+  '@typescript-eslint/scope-manager@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+
   '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
@@ -10054,7 +10192,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.4.2)
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.58.1': {}
+
+  '@typescript-eslint/types@8.59.3': {}
 
   '@typescript-eslint/typescript-estree@8.58.1(typescript@5.8.3)':
     dependencies:
@@ -10065,6 +10217,21 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -10082,9 +10249,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.4.2))
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
+      eslint: 9.39.4(jiti@2.4.2)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.58.1':
     dependencies:
       '@typescript-eslint/types': 8.58.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -10165,45 +10348,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.4':
+  '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))':
+  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))':
     dependencies:
-      '@vitest/spy': 4.1.4
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.2(@types/node@25.8.0)(typescript@5.8.3)
+      msw: 2.14.6(@types/node@25.8.0)(typescript@5.8.3)
       vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)
 
-  '@vitest/pretty-format@4.1.4':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.4':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 4.1.4
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.4': {}
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/utils@4.1.4':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -10450,7 +10633,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -10524,6 +10707,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.18: {}
 
+  baseline-browser-mapping@2.9.17: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -10559,7 +10744,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10569,7 +10754,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.18
+      baseline-browser-mapping: 2.9.17
       caniuse-lite: 1.0.30001765
       electron-to-chromium: 1.5.277
       node-releases: 2.0.27
@@ -11344,6 +11529,26 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.6
+      eslint: 9.39.4(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.4.2))
+      globals: 16.4.0
+      typescript-eslint: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-config-next@16.2.6(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
@@ -11353,7 +11558,7 @@ snapshots:
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.4.2))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.4.2))
       globals: 16.4.0
       typescript-eslint: 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
     optionalDependencies:
@@ -11383,18 +11588,48 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.39.4(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.4.2))
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2)):
@@ -11408,7 +11643,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.39.4(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11447,7 +11682,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.4.2)
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.4.2)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -11510,7 +11745,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.9
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -11564,7 +11799,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -11577,7 +11812,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -11595,7 +11830,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -11710,7 +11945,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.19.0:
     dependencies:
@@ -11906,7 +12151,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.12.0: {}
+  graphql@16.14.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -11985,7 +12230,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -12006,7 +12251,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -12050,7 +12295,10 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   hermes-estree@0.25.1: {}
 
@@ -12328,7 +12576,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12712,7 +12960,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.7.4
+      semver: 7.8.0
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
@@ -13136,7 +13384,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   make-error@1.3.6: {}
 
@@ -13430,7 +13678,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -13441,7 +13689,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -13458,7 +13706,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -13494,7 +13742,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -13558,7 +13806,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -13632,7 +13880,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -13673,24 +13921,24 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3):
+  msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3):
     dependencies:
-      '@inquirer/confirm': 5.1.9(@types/node@25.8.0)
+      '@inquirer/confirm': 6.0.13(@types/node@25.8.0)
       '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
-      graphql: 16.12.0
-      headers-polyfill: 4.0.3
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.10.1
+      rettime: 0.11.11
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 5.4.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
@@ -13698,7 +13946,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  mute-stream@2.0.0: {}
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -14028,7 +14276,7 @@ snapshots:
 
   prettier@3.2.5: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -14085,9 +14333,9 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@19.2.5(react@19.2.5):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
-      react: 19.2.5
+      react: 19.2.6
       scheduler: 0.27.0
 
   react-dom@19.3.0-canary-a757cb76-20251002(react@19.3.0-canary-a757cb76-20251002):
@@ -14155,7 +14403,7 @@ snapshots:
       react: 19.3.0-canary-a757cb76-20251002
       refractor: 5.0.0
 
-  react@19.2.5: {}
+  react@19.2.6: {}
 
   react@19.3.0-canary-a757cb76-20251002: {}
 
@@ -14185,7 +14433,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -14201,14 +14449,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -14297,7 +14545,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -14380,7 +14628,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rettime@0.10.1: {}
+  rettime@0.11.11: {}
 
   reusify@1.0.4: {}
 
@@ -14505,6 +14753,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.0: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -14531,6 +14781,8 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.1: {}
+
+  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -14799,7 +15051,7 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  supabase@2.88.1:
+  supabase@2.98.2:
     dependencies:
       bin-links: 6.0.0
       https-proxy-agent: 9.0.0
@@ -14882,15 +15134,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.0.16: {}
+  tldts-core@7.0.30: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.0.16:
+  tldts@7.0.30:
     dependencies:
-      tldts-core: 7.0.16
+      tldts-core: 7.0.30
 
   tmpl@1.0.5: {}
 
@@ -14904,13 +15156,9 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
-  tough-cookie@6.0.0:
-    dependencies:
-      tldts: 7.0.16
-
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.16
+      tldts: 7.0.30
 
   tr46@1.0.1:
     dependencies:
@@ -15074,14 +15322,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.5:
+  turbo@2.9.14:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.5
-      '@turbo/darwin-arm64': 2.9.5
-      '@turbo/linux-64': 2.9.5
-      '@turbo/linux-arm64': 2.9.5
-      '@turbo/windows-64': 2.9.5
-      '@turbo/windows-arm64': 2.9.5
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   type-check@0.4.0:
     dependencies:
@@ -15093,7 +15341,7 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-fest@5.4.1:
+  type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -15142,6 +15390,17 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.39.4(jiti@2.4.2)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.39.4(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -15340,15 +15599,15 @@ snapshots:
       jiti: 2.4.2
       tsx: 4.22.0
 
-  vitest@4.1.4(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)):
+  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0)):
     dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@25.8.0)(typescript@5.8.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -15480,12 +15739,6 @@ snapshots:
 
   wordwrapjs@5.1.1: {}
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -15544,8 +15797,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
-
-  yoctocolors-cjs@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.2.1):
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["^build", "^test"]
+      "dependsOn": ["^build"]
     },
     "format": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -24,8 +24,7 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["^build", "^test"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/apps/blog/posts/**"]
+      "dependsOn": ["^build", "^test"]
     },
     "format": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,8 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["^build", "^test"]
+      "dependsOn": ["^build", "^test"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/apps/blog/posts/**"]
     },
     "format": {
       "cache": false


### PR DESCRIPTION
## Summary

두 가지 변경을 묶은 PR입니다.

### 1. 블로그 콘텐츠 파이프라인 회귀 테스트 (`test(blog)` 커밋)

리팩토링/리디자인 시 데이터 형태와 빌드 산출물이 깨지지 않도록 회귀 가드를 추가합니다.

- `generate-sitemap.ts`, `generate-rss.ts`, `scripts/generate-search-index.ts`, `scripts/generate-llms-full.ts` — top-level 실행 로직을 순수 함수(`buildSitemapXml`, `buildRssXml`, `buildPublicSearchIndex`/`buildAdminPostsIndex`, `buildLlmsFullText`)로 분리. `if (process.argv[1] === fileURLToPath(import.meta.url))` 가드로 직접 실행 모드는 유지 — 빌드 동작 100% 동일.
- 각 generate 함수에 대한 단위 테스트 + 실제 `apps/blog/posts/` 디렉토리를 읽는 contract 테스트 추가 (총 68개 신규 케이스, blog 워크스페이스 129개 전부 통과).
- `apps/blog/web/package.json` test glob에 `scripts/**/*.test.ts`와 `generate-*.test.ts` 추가.
- `turbo.json`의 `test` task `inputs`에 `apps/blog/posts/**` 추가 — 포스트 변경 시 회귀 테스트 캐시 무효화.
- CI: `push` 트리거를 모든 브랜치로 확장(lefthook이 로컬에서 잡지 못한 경우 안전망), `lint:posts`(frontmatter 무결성) step 추가.

### 2. lefthook 도입 (`chore` 커밋)

기존에 git hook 도구가 없어 커밋 전 검증이 부재했습니다. lefthook으로 로컬 검증을 명시화하고 CI는 안전망으로 정렬합니다.

- `lefthook.yml`
  - **pre-commit**: staged 파일에 `prettier --write` 자동 적용(`stage_fixed: true`)
  - **pre-push**: `pnpm lint` / `check-types` / `test` 병렬 실행 (turbo 캐시 활용)
- `package.json`에 `prepare: lefthook install` 추가 — `pnpm install` 시 자동 hook 등록.
- 우회는 `LEFTHOOK=0` 또는 `--no-verify` (lefthook.yml 주석 명시).

## 회귀 테스트가 잡는 시나리오

- 컴포넌트 리팩토링 중 `getAllPosts` 정렬/필터/visibility 동작이 깨지면 `contract.test.ts`가 검출.
- generate 스크립트 형식이 변경되면(XML 태그 누락, encoding 변경 등) 해당 generate 테스트가 검출.
- UI 리디자인 작업 중 안전망 — 콘텐츠 파이프라인 회귀를 보호.

## Test plan

- [x] `pnpm --filter @blog/web test` — 129 passed
- [x] `pnpm check-types` — 통과
- [x] `pnpm lint` — 통과 (사전 0 errors / 15 warnings 그대로)
- [x] `pnpm format:check` — 통과
- [x] `pnpm exec lefthook install` — pre-commit / pre-push 정상 등록
- [x] pre-commit hook 실제 커밋에서 prettier 정상 동작 확인
- [x] pre-push hook 실제 push에서 lint/types/test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
