### PR TITLE
docs(readme): 전체 아키텍처/성격 반영하여 루트 README 재작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,133 @@
-# 🧪 FE Lab
+# 🧪 fe-lab
 
-> **프론트엔드 기술 탐구와 실무 적용을 위한 실험실**
+> **공부하고 실험하며 기록하는 프론트엔드 실험실**
 
-다양한 프론트엔드 기술을 탐구하고, 실무에서 바로 적용할 수 있는 설계 패턴과 아키텍처를 연구하는 Turborepo 기반 모노레포입니다.
-
-## 📋 **프로젝트 개요**
-
-이 프로젝트는 **실무 중심의 프론트엔드 기술 연구**를 목적으로 합니다:
-
-- **TypeScript 설계 패턴** 탐구 및 적용
-- **다양한 프론트엔드 프레임워크** 비교 실험
-- **디자인 시스템** 구축 및 최적화
-- **실무 경험 기반 기술 블로그** 작성
+프론트엔드 기술을 직접 부딪혀 보고, 실험 결과를 글로 정리해 두는 개인 작업장입니다. Turborepo 기반 모노레포로 운영 중인 기술 블로그(`blog.sangwook.dev`)와, 새 기술/패턴을 시도해 보는 실험용 앱·패키지가 한 저장소 안에 함께 있습니다.
 
 ---
 
-## 🏗️ **아키텍처**
+## 🎯 이 저장소의 두 가지 목적
 
-### **Monorepo 구조**
+| 목적                         | 어디                                                            | 자세히                                                                                                                            |
+| ---------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **🚀 운영 중인 기술 블로그** | `apps/blog/web` + `apps/blog/posts`                             | Next.js SSG → GitHub Pages 배포, Supabase로 조회수/Admin/Analytics 처리. 콘텐츠 파이프라인이 깨지지 않도록 회귀 테스트로 잠가 둠. |
+| **🧪 새 기술/패턴 실험실**   | `apps/{react,next.js,typescript,socket-server}` + `packages/**` | 한 가지 주제에 한 앱을 붙여 두고, 디자인 시스템·번들러·실시간 통신·타입 설계 등을 자유롭게 시도.                                  |
 
-- **Turborepo**: 빌드 오케스트레이션 및 태스크 관리
-- **pnpm Workspaces**: 의존성 관리 및 패키지 공유
-- **TypeScript**: 모든 애플리케이션과 패키지에 타입 안전성 보장
-
-### **핵심 철학**
-
-- **점진적 개선**: 복잡한 아키텍처로 한번에 이주하지 않고 단계적 발전
-- **실무 중심**: 이론보다는 실제 프로젝트에서 적용 가능한 패턴 우선
-- **타입 안전성**: TypeScript를 활용한 컴파일 타임 오류 방지
+블로그는 실제로 쓰는 자산이라 신중하게, 그 외 워크스페이스는 부담 없이 실험합니다.
 
 ---
 
-## 📁 **프로젝트 구조**
+## 📁 워크스페이스
 
-### **애플리케이션** (`apps/`)
+### apps/
 
-#### **🎯 실험용 애플리케이션**
+| 이름            | 종류             | 핵심 스택                                         | 비고                                                                         |
+| --------------- | ---------------- | ------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `blog/web`      | 🚀 블로그 (운영) | Next.js 16, MDX, Panda CSS, Supabase, React Query | SSG + 동적 기능 하이브리드. 도메인 `blog.sangwook.dev`.                      |
+| `blog/posts`    | 📝 콘텐츠        | Markdown / MDX                                    | 시리즈별 폴더 구조, frontmatter 기반 메타. `_series.yml`로 시리즈 메타 정의. |
+| `next.js`       | 🧪 실험          | Next.js 16 (App Router, Turbopack), Jest          | 서버 컴포넌트·에러 바운더리·테스팅 전략.                                     |
+| `react`         | 🧪 실험          | React 19 SPA + Vite + Vitest + MSW                | React Router·커스텀 훅·API 모킹.                                             |
+| `typescript`    | 🧪 실험          | Pure TypeScript + Jest                            | 도메인 모델링·타입 설계 패턴.                                                |
+| `socket-server` | 🧪 실험          | Node.js + 순수 TypeScript WebSocket               | `react` 앱과 짝지어 실시간 통신 실험.                                        |
 
-- **`next.js/`**: Next.js App Router + Jest + Turbopack
-  - 서버 컴포넌트, 에러 바운더리, 테스팅 전략 실험
-- **`react/`**: React SPA + Vite + Vitest
-  - React Router, MSW, 커스텀 훅 패턴 실험
-- **`typescript/`**: Pure TypeScript 실험
-  - 도메인 모델링, 타입 설계 패턴 연구
+### packages/
 
-#### **📝 기술 블로그** (`blog/`)
-
-- **TypeScript 프로젝트 설계 시리즈**
-  - [도메인 모델로 복잡한 비즈니스 로직 정리하기](apps/blog/[Typescript로%20설계하는%20프로젝트]/domain/)
-  - [견고한 서버 API Type 설계하기](apps/blog/[Typescript로%20설계하는%20프로젝트]/http/)
-  - [Service Layer 설계 전략](apps/blog/[Typescript로%20설계하는%20프로젝트]/service/)
-
-- **실무 경험 기반 기술 아티클**
-  - [Panda CSS 1년 사용기](apps/blog/Panda%20CSS%201년%20사용기.md)
-  - [pnpm 10 업그레이드 이슈 해결](apps/blog/pnpm%2010%20업그레이드%20후/)
-  - [Next.js 배포 및 장애 대응](apps/blog/nextjs%20deploy/)
-
-### **공유 패키지** (`packages/`)
-
-#### **🎨 디자인 시스템**
-
-- **`@design-system/ui`**: 공통 컴포넌트 라이브러리
-- **`@design-system/ui-lib`**: Panda CSS 기반 스타일 유틸리티
-
-#### **🔧 핵심 유틸리티**
-
-- **`@package/core`**: HTTP 클라이언트, 상태 코드 정의
-- **`@package/config`**: 공유 TypeScript 설정
+| 이름                          | 종류               | 비고                                                                                        |
+| ----------------------------- | ------------------ | ------------------------------------------------------------------------------------------- |
+| `@design-system/ui`           | 🎨 컴포넌트        | React 19 + Panda CSS. `preset` / `blog-preset` export.                                      |
+| `@design-system/ui-lib`       | 🎨 토큰·유틸       | Panda CSS가 생성한 스타일 자산.                                                             |
+| `@package/core`               | 🔧 코어            | HTTP 클라이언트, 상태 코드 등.                                                              |
+| `@package/config`             | 🔧 설정            | 공유 `tsconfig` 베이스.                                                                     |
+| `@package/bundler`            | 🧪 번들러          | Acorn + magic-string 기반 미니 번들러 구현 — [번들러 시리즈](apps/blog/posts/bundler) 자료. |
+| `@package/bundler-playground` | 🧪 실험 앱         | bundler 결과 검증용.                                                                        |
+| `@package/sample-lib`         | 🧪 라이브러리 빌드 | minibundler로 패키지 배포 패턴 학습.                                                        |
 
 ---
 
-## 🚀 **시작하기**
+## 🛠️ 도구 체인
 
-### **환경 요구사항**
+| 도구                      | 용도                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Turborepo**             | 빌드/테스트 파이프라인 오케스트레이션 (`turbo.json`). `apps/blog/web/turbo.json`은 블로그 전용 task override. |
+| **pnpm (catalog)**        | 패키지 관리 + `catalog:react19` / `catalog:typescript5` 등으로 버전 통일.                                     |
+| **Lefthook**              | Git hook 관리 — pre-commit에 prettier, pre-push에 lint/types/test. 우회는 `LEFTHOOK=0` 또는 `--no-verify`.    |
+| **Prettier 3 / ESLint 9** | 포매팅 + 린트. ESLint는 플랫 설정.                                                                            |
+| **Panda CSS**             | 컴포넌트 레시피 기반 스타일링. 디자인 시스템과 블로그가 공유.                                                 |
+| **Renovate**              | 의존성 자동 업데이트 (`.github/renovate.json`).                                                               |
+| **GitHub Actions**        | CI(`ci.yml`)와 블로그 배포(`deploy-blog.yml`) 자동화.                                                         |
 
-- **Node.js**: >= 20
-- **pnpm**: 10.10.0 (패키지 매니저 고정)
+---
 
-### **설치 및 실행**
+## ✅ 테스트 / 검증 전략
+
+- **블로그 회귀 가드** — `apps/blog/web/domain/post/contract.test.ts` + `generate-*.test.ts`가 실제 `apps/blog/posts/` 디렉토리와 빌드 산출물(sitemap·RSS·search-index·llms-full) 불변식을 잠금. 리팩토링/리디자인 시 안전망.
+- **테스트 러너**: 블로그는 `node:test` (Node 22.5+ glob), React는 Vitest + RTL + MSW, Next.js는 Jest + next-router-mock, TypeScript는 Jest.
+- **CI**: `pnpm lint` / `check-types` / `test` 병렬 실행 + `pnpm --filter @blog/web lint:posts`로 frontmatter 무결성 확인.
+- **pre-push hook**: 푸시 전 워크스페이스 전체 lint·types·test (turbo 캐시로 보통 < 5초).
+
+---
+
+## 🚀 시작하기
 
 ```bash
-# 의존성 설치
+# 의존성 설치 (postinstall이 lefthook hook 자동 등록)
 pnpm install
 
-# 모든 애플리케이션 개발 서버 실행
-pnpm dev
+# 개발 서버
+pnpm dev              # 전체
+pnpm blog-web         # 블로그
+pnpm react            # React 실험 + 디자인 시스템
+pnpm next             # Next.js 실험 + 디자인 시스템
+pnpm typescript       # TypeScript 실험
 
-# 특정 애플리케이션 실행
-pnpm react    # React 앱 + 디자인 시스템
-pnpm next     # Next.js 앱 + 디자인 시스템
-pnpm typescript # TypeScript 실험 환경
+# 검증
+pnpm lint             # 전체 ESLint
+pnpm check-types      # 전체 tsc --noEmit
+pnpm test             # 전체 테스트
+pnpm format:check     # Prettier check
+
+# 빌드
+pnpm build            # 전체
+pnpm blog-build       # 블로그만
 ```
 
-### **테스트 및 빌드**
+### 블로그 글쓰기
 
 ```bash
-# 전체 테스트 실행
-pnpm test
-
-# 전체 빌드
-pnpm build
+# apps/blog/web 디렉토리에서
+pnpm new-post "글 제목" --series bundler --tags a,b   # 새 포스트 스캐폴딩
+pnpm new-post "예약글" --scheduled "2026-05-01T09:00+09:00"
+pnpm lint:posts                                     # frontmatter 검증
 ```
 
 ---
 
-## 🧪 **실험 중인 기술들**
+## 🌐 외부 서비스 & 배포
 
-### **프론트엔드 기술 스택**
-
-- **스타일링**: Panda CSS (CSS-in-JS 대안)
-- **테스팅**: Jest + Vitest + React Testing Library
-- **상태 관리**: 커스텀 훅 + Context API
-- **HTTP**: 타입 안전한 API 클라이언트
-
-### **아키텍처 패턴**
-
-- **도메인 주도 설계(DDD)** 개념을 프론트엔드에 적용
-- **클린 아키텍처** 원칙 기반 레이어 분리
-- **함수형 vs 객체지향** 하이브리드 접근
-
-### **개발 도구**
-
-- **Turborepo**: 모노레포 최적화
-- **Panda CSS**: 성능 중심 스타일링
-- **MSW**: API 모킹 및 테스트
+| 서비스                     | 역할                                                                                            |
+| -------------------------- | ----------------------------------------------------------------------------------------------- |
+| **GitHub Pages**           | 블로그 정적 호스팅 — `main` 브랜치 `apps/blog/**` 변경 시 자동 배포 + KST 09:00 cron(예약 발행) |
+| **Supabase Cloud**         | 블로그 조회수·Admin 인증(Google OAuth)·Analytics RPC                                            |
+| **Google Analytics (GA4)** | 블로그 트래픽 분석 (`@next/third-parties`)                                                      |
+| **Giscus**                 | 댓글 (GitHub Discussions 기반)                                                                  |
+| **Vercel Preview**         | PR 미리보기 빌드                                                                                |
 
 ---
 
-## 📖 **학습 자료**
+## ⚙️ 환경 요구사항
 
-### **추천 읽기 순서**
-
-1. [타입 설계의 시작](apps/blog/[Typescript로%20설계하는%20프로젝트]/http/) - HTTP API 타입 안전성
-2. [Service Layer 설계](apps/blog/[Typescript로%20설계하는%20프로젝트]/service/) - 비즈니스 로직 분리
-3. [도메인 모델링](apps/blog/[Typescript로%20설계하는%20프로젝트]/domain/) - 복잡한 로직 정리
+- **Node.js**: `>= 22` (`.tool-versions`는 24.6.0 권장 — `node:test`의 glob 지원이 22.5+부터)
+- **pnpm**: `10.10.0` (`package.json`의 `packageManager`로 고정)
+- **TypeScript**: `5.8.3` (pnpm catalog로 통일)
 
 ---
 
-> **"실무에서 바로 쓸 수 있는 프론트엔드 기술을 탐구합니다"** 🚀
+## 📖 이 저장소를 활용하는 법
+
+1. **글로 정리하기** — 새 기술을 실험해 본 결과는 `apps/blog/posts/` 안에 마크다운으로 정리. 시리즈 단위로 폴더를 분리하고 `_series.yml`로 표시명을 잡습니다.
+2. **실험 앱 추가하기** — 새 주제는 `apps/<name>` 하위에 워크스페이스를 만들고 디자인 시스템(`@design-system/ui`)을 의존성으로 가져와 시작합니다.
+3. **공유 가치가 생기면 패키지로** — 여러 앱이 공유할 만한 로직은 `packages/@package/<name>`으로 옮겨 catalog/workspace 프로토콜로 의존하게 합니다.
+
+---
+
+> "프로덕션과 실험을 한 저장소 안에서 함께 굴리는 작업장."


### PR DESCRIPTION
## Summary

루트 `README.md`를 리포지토리의 실제 모습에 맞게 다시 정리했습니다. 이전 README는 한참 전 상태(Node 20, ga-proxy, 블로그/lefthook 미언급)에 머물러 있어서 외부에서 보거나 미래의 본인이 다시 봤을 때 첫인상이 어긋났습니다.

### 핵심 변경

- **성격 재정의**: 한 줄로 "공부하고 실험하며 기록하는 프론트엔드 실험실".
- **이중 목적 명시**: 운영 블로그(`apps/blog/web`, `blog.sangwook.dev`)는 신중히, 실험 워크스페이스는 자유롭게 — 표로 분리.
- **워크스페이스 표 갱신**: `apps/{blog/{web,posts}, next.js, react, typescript, socket-server}` + `packages/` 7개 전부.
- **PR #108로 도입된 항목 반영**:
  - Lefthook 도구 체인 (pre-commit prettier / pre-push lint·types·test)
  - 블로그 회귀 가드 (`contract.test.ts`, `generate-*.test.ts`)
  - `apps/blog/web/turbo.json` 블로그 한정 task override
- **Node 요구사항**: `>= 20` → `>= 22` (실제 `engines.node` 및 `.tool-versions`와 정합).
- **글쓰기 도구**: `pnpm new-post`, `pnpm lint:posts` 사용법 추가.
- **외부 서비스**: GitHub Pages, Supabase, GA4, Giscus, Vercel Preview 정리.
- **활용 가이드 3단계**: 새 실험 추가 → 글로 정리 → 공유 가치는 패키지로.

### 사실관계 검증

- 모든 워크스페이스 경로가 실제 디렉토리와 일치하는지 확인 (`apps/`, `packages/@design-system/`, `packages/@package/`).
- 모든 pnpm 스크립트가 `package.json`에 실제 존재 확인 (`blog-web`, `blog-build`, `prepare`, `new-post`, `lint:posts`).
- `@design-system/ui`의 `preset` / `blog-preset` export 실재 확인.
- `apps/blog/web/turbo.json`이 main에 실제 존재 확인.
- 잘못 들어가 있던 `ga-proxy` 항목 제거 (실제 디렉토리 없음, 오래된 CLAUDE.md 언급만 존재).

## Test plan

- [x] `pnpm exec prettier --check README.md` 통과
- [x] pre-push hook (`pnpm lint` / `check-types` / `test`) 통과 (turbo 캐시로 0.87s)
- [x] 모든 링크/명령어/경로가 main 기준 실제 상태와 일치하는지 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
