### PR TITLE
chore(supabase): RPC/테이블 권한 lockdown (Phase 1 — 권한만)

### DIFF
--- a/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
+++ b/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Migration: RPC / 테이블 권한 lockdown + admin email 가드
+-- Migration: RPC / 테이블 권한 lockdown (Phase 1 — 권한만)
 -- =============================================================================
 --
 -- 배경:
@@ -7,32 +7,34 @@
 --   post_view_logs 테이블이 anon에 GRANT ALL 되어 있음.
 --   Supabase default privilege 때문에 기존 마이그레이션의
 --   REVOKE FROM PUBLIC 이 anon에는 효과가 없었음.
---   명시적 REVOKE + 함수 본문 가드로 이중 보호를 추가한다.
 --
--- 적용 전 수동 작업 (Supabase 대시보드):
---   1) Settings → Database → Configuration → "Database settings" 에서
---      커스텀 GUC 추가:
---        app.admin_email = 'rewq5991@gmail.com'
---      (또는 supabase CLI: ALTER DATABASE postgres SET "app.admin_email" = '...')
---      이 GUC 없이 마이그레이션을 적용하면 admin RPC 전체가 접근 불가.
+--   본 마이그레이션은 명시적 REVOKE / GRANT 만 적용한다 (Phase 1).
+--   함수 본문에 admin email 가드를 추가하는 작업은 Phase 2 별도 PR로:
+--     실제 production body가 daily_post_stats 테이블 / pre-computed 컬럼
+--     (view_hour, view_day_of_week) 기반인데 본 초안의 추정 body는
+--     post_view_logs + AT TIME ZONE 'Asia/Seoul' 으로 완전히 달라
+--     적용 시 silent regression이 일어날 수 있음 → 본 PR에서는 제외.
 --
--- 머지 후 적용 순서:
---   1) Supabase 대시보드에서 app.admin_email GUC 설정
---   2) supabase db push 로 production 반영
+-- ⚠️ 적용 시 즉시 발생하는 영향 (반드시 사전 처리 필수):
+--   클라이언트 admin 페이지(/admin/analytics 등)는 현재 anon key로 admin RPC
+--   (get_all_post_stats / get_all_posts_trends / get_post_hourly_distribution /
+--    get_post_dow_distribution / get_daily_view_trend / get_hourly_traffic_pattern /
+--    get_monthly_view_trend / get_popular_posts / get_weekly_traffic_pattern /
+--    aggregate_daily_stats / increment_post_views)을 직접 호출함.
+--   본 마이그레이션 적용 즉시 이 호출 경로는 모두 forbidden(42501)을 받게 됨.
+--
+--   → 다음 두 가지 follow-up PR 머지·배포 *후*에만 본 마이그레이션을 적용해야 함:
+--     (i) admin 클라이언트를 Supabase Edge Function 경유 호출로 변경 (Edge가
+--         사용자 JWT 검증 → service_role 키로 RPC 호출 → 결과 반환)
+--     (ii) Phase 2 마이그레이션: 실제 dump body + admin email 가드 추가
+--
+--   배포 순서:
+--     [Edge Function PR 머지·배포]
+--   → [Phase 2 마이그레이션 PR 머지·db push (admin email 가드 + 본문 보존)]
+--   → [본 PR 머지·db push (anon 권한 잠금)]
+--
+--   순서 위반 시 admin 페이지가 forbidden을 받아 즉시 사용 불가.
 -- =============================================================================
-
--- -----------------------------------------------------------------------------
--- 0. GUC 설정 안내 (실제 적용은 Supabase 대시보드에서 수행 필요)
--- -----------------------------------------------------------------------------
--- 아래 구문을 production에서 직접 실행하거나 Supabase Dashboard의
--- SQL Editor에서 실행하여 GUC를 영구 설정하세요.
--- (supabase db push는 이 ALTER DATABASE를 지원하지 않을 수 있음)
---
---   ALTER DATABASE postgres SET "app.admin_email" = 'rewq5991@gmail.com';
---
--- 참고: current_setting('app.admin_email', true) 는 GUC가 없으면 NULL을 반환.
---   GUC 미설정 시 auth.jwt()->>'email' IS DISTINCT FROM NULL → 항상 TRUE
---   → 모든 admin RPC가 forbidden 을 throw함.
 
 -- -----------------------------------------------------------------------------
 -- 1. Admin/Analytics RPC 권한 잠금
@@ -173,379 +175,22 @@ END;
 $$;
 
 -- -----------------------------------------------------------------------------
--- 2. Admin/Analytics RPC 본문에 admin email 가드 삽입
---    BEGIN 직후: auth.jwt()->>'email' = app.admin_email GUC 체크
---    sql language 함수를 plpgsql로 재정의.
--- -----------------------------------------------------------------------------
-
--- 2-1. get_all_post_stats()
-CREATE OR REPLACE FUNCTION public.get_all_post_stats()
-RETURNS TABLE (
-  slug text,
-  total_views bigint,
-  today_views bigint
-)
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-BEGIN
-  -- admin email 가드: GUC app.admin_email과 JWT의 email이 일치해야 함
-  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-  END IF;
-
-  RETURN QUERY
-  SELECT
-    pv.slug,
-    pv.view_count AS total_views,
-    COALESCE(today_logs.today_views, 0)::bigint AS today_views
-  FROM public.post_views pv
-  LEFT JOIN (
-    SELECT l.slug, COUNT(*) AS today_views
-    FROM public.post_view_logs l
-    WHERE l.viewed_at AT TIME ZONE 'Asia/Seoul'
-          >= date_trunc('day', NOW() AT TIME ZONE 'Asia/Seoul')
-    GROUP BY l.slug
-  ) today_logs ON today_logs.slug = pv.slug;
-END;
-$$;
-
--- 2-2. get_all_posts_trends()
-CREATE OR REPLACE FUNCTION public.get_all_posts_trends()
-RETURNS TABLE (
-  slug text,
-  view_date date,
-  view_count bigint
-)
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-BEGIN
-  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-  END IF;
-
-  RETURN QUERY
-  SELECT
-    pvl.slug,
-    (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_date,
-    COUNT(*)::bigint AS view_count
-  FROM public.post_view_logs pvl
-  WHERE (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date
-        >= (NOW() AT TIME ZONE 'Asia/Seoul' - INTERVAL '365 days')::date
-  GROUP BY pvl.slug, view_date
-  ORDER BY pvl.slug, view_date ASC;
-END;
-$$;
-
--- 2-3. get_post_hourly_distribution(text)
-CREATE OR REPLACE FUNCTION public.get_post_hourly_distribution(slug_input text)
-RETURNS TABLE (
-  hour int,
-  view_count bigint
-)
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-BEGIN
-  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-  END IF;
-
-  RETURN QUERY
-  SELECT
-    EXTRACT(HOUR FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS hour,
-    COUNT(*)::bigint AS view_count
-  FROM public.post_view_logs
-  WHERE slug = slug_input
-  GROUP BY hour
-  ORDER BY hour ASC;
-END;
-$$;
-
--- 2-4. get_post_dow_distribution(text)
-CREATE OR REPLACE FUNCTION public.get_post_dow_distribution(slug_input text)
-RETURNS TABLE (
-  dow int,
-  view_count bigint
-)
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-BEGIN
-  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-  END IF;
-
-  RETURN QUERY
-  SELECT
-    EXTRACT(DOW FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS dow,
-    COUNT(*)::bigint AS view_count
-  FROM public.post_view_logs
-  WHERE slug = slug_input
-  GROUP BY dow
-  ORDER BY dow ASC;
-END;
-$$;
-
--- 2-5. get_daily_view_trend(int, text)
---   production에 존재하나 마이그레이션 파일 없음 — 함수 본문 추정 재정의.
---   실제 body가 다를 경우 사용자가 직접 조정 필요.
---   반드시 pg_dump 원본과 비교 후 적용 권장.
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_daily_view_trend'
-  ) THEN
-    -- 기존 함수를 admin 가드가 포함된 plpgsql 버전으로 교체
-    EXECUTE $func$
-      CREATE OR REPLACE FUNCTION public.get_daily_view_trend(days_input int, slug_input text DEFAULT NULL)
-      RETURNS TABLE (
-        view_date date,
-        view_count bigint
-      )
-      LANGUAGE plpgsql
-      SECURITY DEFINER
-      SET search_path = public
-      AS $body$
-      BEGIN
-        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-        END IF;
-
-        RETURN QUERY
-        SELECT
-          (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_date,
-          COUNT(*)::bigint AS view_count
-        FROM public.post_view_logs pvl
-        WHERE (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date
-              >= (NOW() AT TIME ZONE 'Asia/Seoul' - (days_input || ' days')::interval)::date
-          AND (slug_input IS NULL OR pvl.slug = slug_input)
-        GROUP BY view_date
-        ORDER BY view_date ASC;
-      END;
-      $body$
-    $func$;
-  END IF;
-END;
-$$;
-
--- 2-6. get_hourly_traffic_pattern(int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_hourly_traffic_pattern'
-  ) THEN
-    EXECUTE $func$
-      CREATE OR REPLACE FUNCTION public.get_hourly_traffic_pattern(days_input int)
-      RETURNS TABLE (
-        hour int,
-        view_count bigint
-      )
-      LANGUAGE plpgsql
-      SECURITY DEFINER
-      SET search_path = public
-      AS $body$
-      BEGIN
-        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-        END IF;
-
-        RETURN QUERY
-        SELECT
-          EXTRACT(HOUR FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS hour,
-          COUNT(*)::bigint AS view_count
-        FROM public.post_view_logs
-        WHERE viewed_at >= NOW() - (days_input || ' days')::interval
-        GROUP BY hour
-        ORDER BY hour ASC;
-      END;
-      $body$
-    $func$;
-  END IF;
-END;
-$$;
-
--- 2-7. get_monthly_view_trend(int, text)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_monthly_view_trend'
-  ) THEN
-    EXECUTE $func$
-      CREATE OR REPLACE FUNCTION public.get_monthly_view_trend(months_input int, slug_input text DEFAULT NULL)
-      RETURNS TABLE (
-        view_month date,
-        view_count bigint
-      )
-      LANGUAGE plpgsql
-      SECURITY DEFINER
-      SET search_path = public
-      AS $body$
-      BEGIN
-        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-        END IF;
-
-        RETURN QUERY
-        SELECT
-          date_trunc('month', viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_month,
-          COUNT(*)::bigint AS view_count
-        FROM public.post_view_logs
-        WHERE viewed_at >= NOW() - (months_input || ' months')::interval
-          AND (slug_input IS NULL OR slug = slug_input)
-        GROUP BY view_month
-        ORDER BY view_month ASC;
-      END;
-      $body$
-    $func$;
-  END IF;
-END;
-$$;
-
--- 2-8. get_popular_posts(int, int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_popular_posts'
-  ) THEN
-    EXECUTE $func$
-      CREATE OR REPLACE FUNCTION public.get_popular_posts(days_input int, limit_input int DEFAULT 10)
-      RETURNS TABLE (
-        slug text,
-        view_count bigint
-      )
-      LANGUAGE plpgsql
-      SECURITY DEFINER
-      SET search_path = public
-      AS $body$
-      BEGIN
-        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-        END IF;
-
-        RETURN QUERY
-        SELECT
-          pvl.slug,
-          COUNT(*)::bigint AS view_count
-        FROM public.post_view_logs pvl
-        WHERE pvl.viewed_at >= NOW() - (days_input || ' days')::interval
-        GROUP BY pvl.slug
-        ORDER BY view_count DESC
-        LIMIT limit_input;
-      END;
-      $body$
-    $func$;
-  END IF;
-END;
-$$;
-
--- 2-9. get_weekly_traffic_pattern(int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_weekly_traffic_pattern'
-  ) THEN
-    EXECUTE $func$
-      CREATE OR REPLACE FUNCTION public.get_weekly_traffic_pattern(days_input int)
-      RETURNS TABLE (
-        dow int,
-        view_count bigint
-      )
-      LANGUAGE plpgsql
-      SECURITY DEFINER
-      SET search_path = public
-      AS $body$
-      BEGIN
-        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
-          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
-        END IF;
-
-        RETURN QUERY
-        SELECT
-          EXTRACT(DOW FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS dow,
-          COUNT(*)::bigint AS view_count
-        FROM public.post_view_logs
-        WHERE viewed_at >= NOW() - (days_input || ' days')::interval
-        GROUP BY dow
-        ORDER BY dow ASC;
-      END;
-      $body$
-    $func$;
-  END IF;
-END;
-$$;
-
--- 2-10. aggregate_daily_stats(date)
---   cron job이 호출하는 함수. admin email JWT 가드 없이 service_role/cron 전용.
---   (cron 호출 시 auth.jwt()가 없을 수 있으므로 email 가드 대신 권한 제어만 적용)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'aggregate_daily_stats'
-  ) THEN
-    -- aggregate_daily_stats는 cron/service_role 전용이므로 JWT email 가드는 넣지 않음.
-    -- REVOKE는 섹션 1에서 이미 처리됨.
-    NULL;
-  END IF;
-END;
-$$;
-
--- -----------------------------------------------------------------------------
--- 3. increment_view_count — slug 단위 1분 중복 호출 차단 (최소 rate limit)
+-- 3. increment_view_count — 본문은 그대로, 권한만 정리
 --
--- 주의: 이 가드는 같은 slug에 대한 전체 호출 빈도를 체크하며,
---   세션/IP 단위 구분은 하지 않음. 더 정밀한 rate limit은 별도 PR 필요.
--- TODO(#후속PR): IP/세션 기반 rate limit 또는 Supabase Edge Function rate limit 도입 검토
+-- 본 PR 초안에는 "slug 단위 1분 중복 차단" 블록이 있었으나 코드 리뷰에서
+-- "특정 slug의 첫 사용자 호출이 이후 1분간 B/C/D 사용자 호출까지 차단해
+-- 인기 포스트의 조회수가 분당 1회만 집계되는 데이터 유실 결함" 으로 지적됨.
+-- → slug 단위 가드는 클라이언트 쿠키와 무관하게 합법 트래픽을 잘라 먹기 때문에
+--   제거. 1차 중복 방지는 클라이언트 쿠키(6시간)에 유지하고, 서버측은 IP/세션
+--   단위 가드가 필요한데, 이는 SQL 함수에서 직접 식별이 어려움(pooler 환경에서
+--   inet_client_addr 부정확). 다음 follow-up에서 처리:
+-- TODO(#supabase-edge-rate-limit):
+--   1) Supabase Edge Function 경유 호출 → JWT/IP 단위 토큰 버킷
+--   2) 또는 클라이언트가 session_id를 RPC 인자로 보내 (slug, session_id) 단위 차단
+-- 본 PR은 권한 잠금/admin 가드/post_view_logs 접근 정리에 집중.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public.increment_view_count(slug_input text)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-BEGIN
-  -- slug 단위 1분 이내 중복 호출 차단 (최소 rate limit)
-  -- 동일 slug에 대해 1분 내에 이미 기록이 있으면 즉시 반환
-  IF EXISTS (
-    SELECT 1
-    FROM public.post_view_logs
-    WHERE slug = slug_input
-      AND viewed_at > NOW() - INTERVAL '1 minute'
-    LIMIT 1
-  ) THEN
-    RETURN;
-  END IF;
-
-  -- 1. Upsert into post_views (Stats aggregation)
-  INSERT INTO public.post_views (slug, view_count, updated_at)
-  VALUES (slug_input, 1, NOW())
-  ON CONFLICT (slug)
-  DO UPDATE SET
-    view_count = post_views.view_count + 1,
-    updated_at = NOW();
-
-  -- 2. Log the individual view event (History tracking)
-  INSERT INTO public.post_view_logs (slug, viewed_at)
-  VALUES (slug_input, NOW());
-END;
-$$;
+-- 함수 본문 자체는 production dump와 동일하므로 CREATE OR REPLACE 하지 않음.
+-- (재정의가 필요 없는 함수까지 다시 쓰면 비즈니스 로직 silent 변경 리스크 증가)
 
 -- increment_view_count는 anon 정상 호출 path이므로 권한 유지
 REVOKE ALL ON FUNCTION public.increment_view_count(text) FROM PUBLIC;
@@ -593,16 +238,23 @@ GRANT ALL ON TABLE public.post_views TO service_role;
 -- -----------------------------------------------------------------------------
 -- 후속 작업 필요 사항 (별도 PR)
 -- -----------------------------------------------------------------------------
--- 1. Admin 페이지 클라이언트 코드:
---    현재 domain/analytics/repository.ts 의 getAllPostStats(), getAllPostsTrends(),
---    getPostHourlyDistribution(), getPostDowDistribution() 함수들이
---    anon key(브라우저)로 Supabase RPC를 직접 호출함.
---    이 마이그레이션 적용 후 해당 RPC들은 service_role 에서만 실행 가능하므로
---    Admin 어드민 기능이 브라우저에서 동작하지 않음.
---    해결 방안:
---      a) Next.js API Route (서버사이드)에서 service_role key로 RPC 호출
---      b) 또는 Supabase Edge Function (server-side) 경유
---      c) 또는 auth.jwt()->>'email' 체크를 활용해 authenticated role에도
---         조건부 GRANT (보안 수준 낮아짐 — 권장하지 않음)
--- 2. increment_post_views 두 시그니처 정리 (위 섹션 5 참조)
--- 3. IP/세션 기반 rate limit 도입 (섹션 3 참조)
+-- 1. ⚠️ Admin 페이지 클라이언트 → Edge Function 경유 (반드시 본 PR 적용 전 처리):
+--    domain/analytics/repository.ts 의 admin 함수들이 anon key(브라우저)로
+--    Supabase RPC를 직접 호출 중. 본 마이그레이션 적용 즉시 forbidden(42501).
+--    apps/blog/web 은 SSG(output: 'export')라 Next.js API Route 사용 불가.
+--    → Supabase Edge Function 으로 admin RPC 호출 경로를 옮겨야 함.
+--      흐름: 브라우저(사용자 JWT) → Edge Function (JWT 검증 + admin email 확인)
+--           → service_role key로 RPC 호출 → 결과 반환.
+--
+-- 2. Phase 2 마이그레이션 — 함수 본문 admin email 가드:
+--    실제 dump body를 그대로 사용 + BEGIN 직후 IF auth.jwt()->>'email' IS DISTINCT
+--    FROM current_setting('app.admin_email', true) THEN RAISE forbidden END IF;
+--    추가. (현재 본 PR은 추정 본문 위험으로 제외)
+--    app.admin_email GUC 사전 설정 필요:
+--      ALTER DATABASE postgres SET "app.admin_email" = 'rewq5991@gmail.com';
+--
+-- 3. increment_post_views 두 시그니처 정리 (위 섹션 5 참조)
+--
+-- 4. IP/세션 기반 rate limit 도입 (위 섹션 3 참조)
+--    Supabase Edge Function에서 JWT 또는 IP 단위 토큰 버킷 권장.
+--    SQL 함수에서 inet_client_addr 사용은 pooler 환경에서 부정확.

--- a/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
+++ b/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
@@ -233,7 +233,37 @@ END;
 $$;
 
 -- -----------------------------------------------------------------------------
--- 4. increment_post_views 이중 정의 안내 (코멘트)
+-- 4. DEFAULT PRIVILEGES lockdown — 재발 방지
+-- -----------------------------------------------------------------------------
+-- 본 PR의 결함 원인이 바로 Supabase의 default privilege 였음:
+--   public 스키마에 새로 생성된 함수/테이블/시퀀스에 anon/authenticated/
+--   service_role 모두에 자동 GRANT ALL. 마이그레이션의 REVOKE FROM PUBLIC 은
+--   anon role 에 영향 없음 → 새 함수 생성 즉시 lockdown 무력화.
+--
+-- ALTER DEFAULT PRIVILEGES 를 적용하지 않으면 Phase 2 마이그레이션이나 향후
+-- 어떤 PR이든 public 함수/테이블을 새로 만드는 순간 동일 결함이 재발한다.
+--
+-- ⚠️ 영향:
+--   1) 적용 후에 만드는 모든 public 함수는 service_role 외에는 호출 불가.
+--      anon/authenticated가 호출해야 하는 public RPC(예: 새로운
+--      increment_view_count 류)는 명시적 GRANT 가 반드시 필요.
+--   2) 새 public 테이블도 anon/authenticated에 자동 SELECT 권한 없음.
+--      RLS 정책 + 명시적 GRANT SELECT 필수.
+--   3) ALTER DEFAULT PRIVILEGES 는 *적용한 role* (postgres) 이 만든 객체에만
+--      적용. 다른 role이 만든 객체에는 별도 ALTER 필요.
+--      → Supabase는 supabase_admin / postgres role로 마이그레이션 실행하므로
+--        실질적으로 모든 마이그레이션 객체에 적용됨.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE EXECUTE ON FUNCTIONS FROM anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE ALL ON TABLES FROM anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE ALL ON SEQUENCES FROM anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 5. increment_post_views 이중 정의 안내 (코멘트)
 -- -----------------------------------------------------------------------------
 -- production pg_dump 에서 increment_post_views 가 두 시그니처로 존재함.
 -- 현재 코드(domain/analytics/repository.ts)에서는 increment_view_count 만 호출.
@@ -259,7 +289,7 @@ $$;
 --    app.admin_email GUC 사전 설정 필요:
 --      ALTER DATABASE postgres SET "app.admin_email" = 'rewq5991@gmail.com';
 --
--- 3. increment_post_views 두 시그니처 정리 (위 섹션 4 참조)
+-- 3. increment_post_views 두 시그니처 정리 (위 섹션 5 참조)
 --
 -- 4. IP/세션 기반 rate limit 도입 (위 섹션 2 참조)
 --    Supabase Edge Function에서 JWT 또는 IP 단위 토큰 버킷 권장.

--- a/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
+++ b/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
@@ -42,21 +42,54 @@
 --    service_role → GRANT (Supabase client-side 호출 불가, 서버/cron만)
 -- -----------------------------------------------------------------------------
 
+-- 아래 10개 모두 동일 패턴(DO $$ IF EXISTS)으로 처리해 reset 안전성 + 일관성 확보.
+-- 4개는 기존 마이그레이션 파일에 정의되어 있고, 6개는 supabase 대시보드에서
+-- 직접 생성된 것으로 추정(production dump에는 있으나 마이그레이션 파일 없음).
+-- 어느 환경에 대해서도 동일 코드가 안전하게 동작하도록 모두 가드.
+
 -- get_all_post_stats()
-REVOKE ALL ON FUNCTION public.get_all_post_stats() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.get_all_post_stats() TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
+             WHERE n.nspname = 'public' AND p.proname = 'get_all_post_stats') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_all_post_stats() FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_all_post_stats() TO service_role';
+  END IF;
+END;
+$$;
 
 -- get_all_posts_trends()
-REVOKE ALL ON FUNCTION public.get_all_posts_trends() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.get_all_posts_trends() TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
+             WHERE n.nspname = 'public' AND p.proname = 'get_all_posts_trends') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_all_posts_trends() FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_all_posts_trends() TO service_role';
+  END IF;
+END;
+$$;
 
 -- get_post_hourly_distribution(text)
-REVOKE ALL ON FUNCTION public.get_post_hourly_distribution(text) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.get_post_hourly_distribution(text) TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
+             WHERE n.nspname = 'public' AND p.proname = 'get_post_hourly_distribution') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_post_hourly_distribution(text) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_post_hourly_distribution(text) TO service_role';
+  END IF;
+END;
+$$;
 
 -- get_post_dow_distribution(text)
-REVOKE ALL ON FUNCTION public.get_post_dow_distribution(text) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.get_post_dow_distribution(text) TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
+             WHERE n.nspname = 'public' AND p.proname = 'get_post_dow_distribution') THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_post_dow_distribution(text) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_post_dow_distribution(text) TO service_role';
+  END IF;
+END;
+$$;
 
 -- get_daily_view_trend(int, text) — production에 존재하나 마이그레이션 파일 없음
 -- (Supabase 대시보드에서 직접 생성된 것으로 추정)
@@ -175,7 +208,7 @@ END;
 $$;
 
 -- -----------------------------------------------------------------------------
--- 3. increment_view_count — 본문은 그대로, 권한만 정리
+-- 2. increment_view_count — 본문은 그대로, 권한만 정리
 --
 -- 본 PR 초안에는 "slug 단위 1분 중복 차단" 블록이 있었으나 코드 리뷰에서
 -- "특정 slug의 첫 사용자 호출이 이후 1분간 B/C/D 사용자 호출까지 차단해
@@ -197,16 +230,25 @@ REVOKE ALL ON FUNCTION public.increment_view_count(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.increment_view_count(text) TO anon, authenticated, service_role;
 
 -- -----------------------------------------------------------------------------
--- 4. 테이블 직접 권한 정리
+-- 3. 테이블 직접 권한 정리
 -- -----------------------------------------------------------------------------
 
--- 4-1. post_view_logs: anon GRANT ALL → REVOKE ALL
+-- 3-1. post_view_logs: anon GRANT ALL → REVOKE ALL
 --   SECURITY DEFINER RPC 경로만 허용. 직접 테이블 접근 불가.
 REVOKE ALL ON TABLE public.post_view_logs FROM anon, authenticated, PUBLIC;
--- service_role은 SECURITY DEFINER 함수 실행 컨텍스트에서 사용
-GRANT ALL ON TABLE public.post_view_logs TO service_role;
+-- service_role은 SECURITY DEFINER 함수 실행 컨텍스트에서 사용.
+--   service_role은 본래 RLS bypass + 기본적으로 모든 권한이 부여돼 GRANT 자체가
+--   엄밀히는 redundant지만, "이 테이블에 service_role이 SELECT/INSERT 한다"는
+--   의도를 명시적으로 남긴다. 실제 함수가 쓰는 동작:
+--     - SELECT: get_all_post_stats, get_post_hourly_distribution,
+--       get_post_dow_distribution, get_hourly_traffic_pattern,
+--       get_weekly_traffic_pattern, aggregate_daily_stats
+--     - INSERT: increment_view_count
+--   UPDATE/DELETE는 사용처 없음 → 좁혀서 명시.
+GRANT SELECT, INSERT ON TABLE public.post_view_logs TO service_role;
 
--- 4-2. post_view_logs_id_seq: 시퀀스도 동일하게 정리
+-- 3-2. post_view_logs_id_seq: 시퀀스 권한 좁혀서 명시
+--   INSERT 시 nextval 호출 → USAGE 필요. SELECT는 currval 호출 시.
 DO $$
 BEGIN
   IF EXISTS (
@@ -215,19 +257,21 @@ BEGIN
       AND sequence_name = 'post_view_logs_id_seq'
   ) THEN
     EXECUTE 'REVOKE ALL ON SEQUENCE public.post_view_logs_id_seq FROM anon, authenticated, PUBLIC';
-    EXECUTE 'GRANT ALL ON SEQUENCE public.post_view_logs_id_seq TO service_role';
+    EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE public.post_view_logs_id_seq TO service_role';
   END IF;
 END;
 $$;
 
--- 4-3. post_views: anon에 SELECT만 남기고 INSERT/UPDATE/DELETE REVOKE
+-- 3-3. post_views: anon에 SELECT만 남기고 INSERT/UPDATE/DELETE REVOKE
 --   "Allow public read access" RLS 정책과 일관성 유지
 REVOKE INSERT, UPDATE, DELETE ON TABLE public.post_views FROM anon, authenticated, PUBLIC;
 GRANT SELECT ON TABLE public.post_views TO anon, authenticated;
-GRANT ALL ON TABLE public.post_views TO service_role;
+-- service_role: increment_view_count(INSERT/UPDATE upsert), 기타 SELECT 함수들.
+--   DELETE 사용처 없음 → 좁혀서 명시.
+GRANT SELECT, INSERT, UPDATE ON TABLE public.post_views TO service_role;
 
 -- -----------------------------------------------------------------------------
--- 5. increment_post_views 이중 정의 안내 (코멘트)
+-- 4. increment_post_views 이중 정의 안내 (코멘트)
 -- -----------------------------------------------------------------------------
 -- production pg_dump 에서 increment_post_views 가 두 시그니처로 존재함.
 -- 현재 코드(domain/analytics/repository.ts)에서는 increment_view_count 만 호출.
@@ -253,8 +297,8 @@ GRANT ALL ON TABLE public.post_views TO service_role;
 --    app.admin_email GUC 사전 설정 필요:
 --      ALTER DATABASE postgres SET "app.admin_email" = 'rewq5991@gmail.com';
 --
--- 3. increment_post_views 두 시그니처 정리 (위 섹션 5 참조)
+-- 3. increment_post_views 두 시그니처 정리 (위 섹션 4 참조)
 --
--- 4. IP/세션 기반 rate limit 도입 (위 섹션 3 참조)
+-- 4. IP/세션 기반 rate limit 도입 (위 섹션 2 참조)
 --    Supabase Edge Function에서 JWT 또는 IP 단위 토큰 버킷 권장.
 --    SQL 함수에서 inet_client_addr 사용은 pooler 환경에서 부정확.

--- a/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
+++ b/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
@@ -1,0 +1,608 @@
+-- =============================================================================
+-- Migration: RPC / 테이블 권한 lockdown + admin email 가드
+-- =============================================================================
+--
+-- 배경:
+--   pg_dump --schema public 결과 production에서 모든 analytics RPC와
+--   post_view_logs 테이블이 anon에 GRANT ALL 되어 있음.
+--   Supabase default privilege 때문에 기존 마이그레이션의
+--   REVOKE FROM PUBLIC 이 anon에는 효과가 없었음.
+--   명시적 REVOKE + 함수 본문 가드로 이중 보호를 추가한다.
+--
+-- 적용 전 수동 작업 (Supabase 대시보드):
+--   1) Settings → Database → Configuration → "Database settings" 에서
+--      커스텀 GUC 추가:
+--        app.admin_email = 'rewq5991@gmail.com'
+--      (또는 supabase CLI: ALTER DATABASE postgres SET "app.admin_email" = '...')
+--      이 GUC 없이 마이그레이션을 적용하면 admin RPC 전체가 접근 불가.
+--
+-- 머지 후 적용 순서:
+--   1) Supabase 대시보드에서 app.admin_email GUC 설정
+--   2) supabase db push 로 production 반영
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 0. GUC 설정 안내 (실제 적용은 Supabase 대시보드에서 수행 필요)
+-- -----------------------------------------------------------------------------
+-- 아래 구문을 production에서 직접 실행하거나 Supabase Dashboard의
+-- SQL Editor에서 실행하여 GUC를 영구 설정하세요.
+-- (supabase db push는 이 ALTER DATABASE를 지원하지 않을 수 있음)
+--
+--   ALTER DATABASE postgres SET "app.admin_email" = 'rewq5991@gmail.com';
+--
+-- 참고: current_setting('app.admin_email', true) 는 GUC가 없으면 NULL을 반환.
+--   GUC 미설정 시 auth.jwt()->>'email' IS DISTINCT FROM NULL → 항상 TRUE
+--   → 모든 admin RPC가 forbidden 을 throw함.
+
+-- -----------------------------------------------------------------------------
+-- 1. Admin/Analytics RPC 권한 잠금
+--    anon, authenticated, PUBLIC → REVOKE
+--    service_role → GRANT (Supabase client-side 호출 불가, 서버/cron만)
+-- -----------------------------------------------------------------------------
+
+-- get_all_post_stats()
+REVOKE ALL ON FUNCTION public.get_all_post_stats() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_all_post_stats() TO service_role;
+
+-- get_all_posts_trends()
+REVOKE ALL ON FUNCTION public.get_all_posts_trends() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_all_posts_trends() TO service_role;
+
+-- get_post_hourly_distribution(text)
+REVOKE ALL ON FUNCTION public.get_post_hourly_distribution(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_post_hourly_distribution(text) TO service_role;
+
+-- get_post_dow_distribution(text)
+REVOKE ALL ON FUNCTION public.get_post_dow_distribution(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_post_dow_distribution(text) TO service_role;
+
+-- get_daily_view_trend(int, text) — production에 존재하나 마이그레이션 파일 없음
+-- (Supabase 대시보드에서 직접 생성된 것으로 추정)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_daily_view_trend'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_daily_view_trend(int, text) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_daily_view_trend(int, text) TO service_role';
+  END IF;
+END;
+$$;
+
+-- get_hourly_traffic_pattern(int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_hourly_traffic_pattern'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_hourly_traffic_pattern(int) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_hourly_traffic_pattern(int) TO service_role';
+  END IF;
+END;
+$$;
+
+-- get_monthly_view_trend(int, text)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_monthly_view_trend'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_monthly_view_trend(int, text) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_monthly_view_trend(int, text) TO service_role';
+  END IF;
+END;
+$$;
+
+-- get_popular_posts(int, int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_popular_posts'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_popular_posts(int, int) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_popular_posts(int, int) TO service_role';
+  END IF;
+END;
+$$;
+
+-- get_weekly_traffic_pattern(int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_weekly_traffic_pattern'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.get_weekly_traffic_pattern(int) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_weekly_traffic_pattern(int) TO service_role';
+  END IF;
+END;
+$$;
+
+-- aggregate_daily_stats(date)
+-- service_role + supabase_cron (pg_cron이 쓰는 role) 만 허용
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'aggregate_daily_stats'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.aggregate_daily_stats(date) FROM PUBLIC, anon, authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(date) TO service_role';
+    -- supabase_cron role이 있으면 추가 grant (없으면 무시)
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_cron') THEN
+      EXECUTE 'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(date) TO supabase_cron';
+    END IF;
+  END IF;
+END;
+$$;
+
+-- increment_post_views — 두 시그니처 존재 (production dump 기준)
+-- 현재 코드에서 사용되지 않는 것으로 보이나 권한만 잠금.
+-- 함수 자체 DROP은 사용 여부 확인 후 별도 PR에서 처리 권장.
+-- TODO(#후속PR): increment_post_views 두 시그니처 중 불필요한 것 DROP 검토
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT p.oid, pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'increment_post_views'
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL ON FUNCTION public.increment_post_views(%s) FROM PUBLIC, anon, authenticated',
+      r.args
+    );
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION public.increment_post_views(%s) TO service_role',
+      r.args
+    );
+  END LOOP;
+END;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. Admin/Analytics RPC 본문에 admin email 가드 삽입
+--    BEGIN 직후: auth.jwt()->>'email' = app.admin_email GUC 체크
+--    sql language 함수를 plpgsql로 재정의.
+-- -----------------------------------------------------------------------------
+
+-- 2-1. get_all_post_stats()
+CREATE OR REPLACE FUNCTION public.get_all_post_stats()
+RETURNS TABLE (
+  slug text,
+  total_views bigint,
+  today_views bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- admin email 가드: GUC app.admin_email과 JWT의 email이 일치해야 함
+  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pv.slug,
+    pv.view_count AS total_views,
+    COALESCE(today_logs.today_views, 0)::bigint AS today_views
+  FROM public.post_views pv
+  LEFT JOIN (
+    SELECT l.slug, COUNT(*) AS today_views
+    FROM public.post_view_logs l
+    WHERE l.viewed_at AT TIME ZONE 'Asia/Seoul'
+          >= date_trunc('day', NOW() AT TIME ZONE 'Asia/Seoul')
+    GROUP BY l.slug
+  ) today_logs ON today_logs.slug = pv.slug;
+END;
+$$;
+
+-- 2-2. get_all_posts_trends()
+CREATE OR REPLACE FUNCTION public.get_all_posts_trends()
+RETURNS TABLE (
+  slug text,
+  view_date date,
+  view_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pvl.slug,
+    (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_date,
+    COUNT(*)::bigint AS view_count
+  FROM public.post_view_logs pvl
+  WHERE (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date
+        >= (NOW() AT TIME ZONE 'Asia/Seoul' - INTERVAL '365 days')::date
+  GROUP BY pvl.slug, view_date
+  ORDER BY pvl.slug, view_date ASC;
+END;
+$$;
+
+-- 2-3. get_post_hourly_distribution(text)
+CREATE OR REPLACE FUNCTION public.get_post_hourly_distribution(slug_input text)
+RETURNS TABLE (
+  hour int,
+  view_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    EXTRACT(HOUR FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS hour,
+    COUNT(*)::bigint AS view_count
+  FROM public.post_view_logs
+  WHERE slug = slug_input
+  GROUP BY hour
+  ORDER BY hour ASC;
+END;
+$$;
+
+-- 2-4. get_post_dow_distribution(text)
+CREATE OR REPLACE FUNCTION public.get_post_dow_distribution(slug_input text)
+RETURNS TABLE (
+  dow int,
+  view_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    EXTRACT(DOW FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS dow,
+    COUNT(*)::bigint AS view_count
+  FROM public.post_view_logs
+  WHERE slug = slug_input
+  GROUP BY dow
+  ORDER BY dow ASC;
+END;
+$$;
+
+-- 2-5. get_daily_view_trend(int, text)
+--   production에 존재하나 마이그레이션 파일 없음 — 함수 본문 추정 재정의.
+--   실제 body가 다를 경우 사용자가 직접 조정 필요.
+--   반드시 pg_dump 원본과 비교 후 적용 권장.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_daily_view_trend'
+  ) THEN
+    -- 기존 함수를 admin 가드가 포함된 plpgsql 버전으로 교체
+    EXECUTE $func$
+      CREATE OR REPLACE FUNCTION public.get_daily_view_trend(days_input int, slug_input text DEFAULT NULL)
+      RETURNS TABLE (
+        view_date date,
+        view_count bigint
+      )
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS $body$
+      BEGIN
+        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+        END IF;
+
+        RETURN QUERY
+        SELECT
+          (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_date,
+          COUNT(*)::bigint AS view_count
+        FROM public.post_view_logs pvl
+        WHERE (pvl.viewed_at AT TIME ZONE 'Asia/Seoul')::date
+              >= (NOW() AT TIME ZONE 'Asia/Seoul' - (days_input || ' days')::interval)::date
+          AND (slug_input IS NULL OR pvl.slug = slug_input)
+        GROUP BY view_date
+        ORDER BY view_date ASC;
+      END;
+      $body$
+    $func$;
+  END IF;
+END;
+$$;
+
+-- 2-6. get_hourly_traffic_pattern(int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_hourly_traffic_pattern'
+  ) THEN
+    EXECUTE $func$
+      CREATE OR REPLACE FUNCTION public.get_hourly_traffic_pattern(days_input int)
+      RETURNS TABLE (
+        hour int,
+        view_count bigint
+      )
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS $body$
+      BEGIN
+        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+        END IF;
+
+        RETURN QUERY
+        SELECT
+          EXTRACT(HOUR FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS hour,
+          COUNT(*)::bigint AS view_count
+        FROM public.post_view_logs
+        WHERE viewed_at >= NOW() - (days_input || ' days')::interval
+        GROUP BY hour
+        ORDER BY hour ASC;
+      END;
+      $body$
+    $func$;
+  END IF;
+END;
+$$;
+
+-- 2-7. get_monthly_view_trend(int, text)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_monthly_view_trend'
+  ) THEN
+    EXECUTE $func$
+      CREATE OR REPLACE FUNCTION public.get_monthly_view_trend(months_input int, slug_input text DEFAULT NULL)
+      RETURNS TABLE (
+        view_month date,
+        view_count bigint
+      )
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS $body$
+      BEGIN
+        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+        END IF;
+
+        RETURN QUERY
+        SELECT
+          date_trunc('month', viewed_at AT TIME ZONE 'Asia/Seoul')::date AS view_month,
+          COUNT(*)::bigint AS view_count
+        FROM public.post_view_logs
+        WHERE viewed_at >= NOW() - (months_input || ' months')::interval
+          AND (slug_input IS NULL OR slug = slug_input)
+        GROUP BY view_month
+        ORDER BY view_month ASC;
+      END;
+      $body$
+    $func$;
+  END IF;
+END;
+$$;
+
+-- 2-8. get_popular_posts(int, int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_popular_posts'
+  ) THEN
+    EXECUTE $func$
+      CREATE OR REPLACE FUNCTION public.get_popular_posts(days_input int, limit_input int DEFAULT 10)
+      RETURNS TABLE (
+        slug text,
+        view_count bigint
+      )
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS $body$
+      BEGIN
+        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+        END IF;
+
+        RETURN QUERY
+        SELECT
+          pvl.slug,
+          COUNT(*)::bigint AS view_count
+        FROM public.post_view_logs pvl
+        WHERE pvl.viewed_at >= NOW() - (days_input || ' days')::interval
+        GROUP BY pvl.slug
+        ORDER BY view_count DESC
+        LIMIT limit_input;
+      END;
+      $body$
+    $func$;
+  END IF;
+END;
+$$;
+
+-- 2-9. get_weekly_traffic_pattern(int)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'get_weekly_traffic_pattern'
+  ) THEN
+    EXECUTE $func$
+      CREATE OR REPLACE FUNCTION public.get_weekly_traffic_pattern(days_input int)
+      RETURNS TABLE (
+        dow int,
+        view_count bigint
+      )
+      LANGUAGE plpgsql
+      SECURITY DEFINER
+      SET search_path = public
+      AS $body$
+      BEGIN
+        IF auth.jwt() ->> 'email' IS DISTINCT FROM current_setting('app.admin_email', true) THEN
+          RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+        END IF;
+
+        RETURN QUERY
+        SELECT
+          EXTRACT(DOW FROM viewed_at AT TIME ZONE 'Asia/Seoul')::int AS dow,
+          COUNT(*)::bigint AS view_count
+        FROM public.post_view_logs
+        WHERE viewed_at >= NOW() - (days_input || ' days')::interval
+        GROUP BY dow
+        ORDER BY dow ASC;
+      END;
+      $body$
+    $func$;
+  END IF;
+END;
+$$;
+
+-- 2-10. aggregate_daily_stats(date)
+--   cron job이 호출하는 함수. admin email JWT 가드 없이 service_role/cron 전용.
+--   (cron 호출 시 auth.jwt()가 없을 수 있으므로 email 가드 대신 권한 제어만 적용)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'aggregate_daily_stats'
+  ) THEN
+    -- aggregate_daily_stats는 cron/service_role 전용이므로 JWT email 가드는 넣지 않음.
+    -- REVOKE는 섹션 1에서 이미 처리됨.
+    NULL;
+  END IF;
+END;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 3. increment_view_count — slug 단위 1분 중복 호출 차단 (최소 rate limit)
+--
+-- 주의: 이 가드는 같은 slug에 대한 전체 호출 빈도를 체크하며,
+--   세션/IP 단위 구분은 하지 않음. 더 정밀한 rate limit은 별도 PR 필요.
+-- TODO(#후속PR): IP/세션 기반 rate limit 또는 Supabase Edge Function rate limit 도입 검토
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.increment_view_count(slug_input text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- slug 단위 1분 이내 중복 호출 차단 (최소 rate limit)
+  -- 동일 slug에 대해 1분 내에 이미 기록이 있으면 즉시 반환
+  IF EXISTS (
+    SELECT 1
+    FROM public.post_view_logs
+    WHERE slug = slug_input
+      AND viewed_at > NOW() - INTERVAL '1 minute'
+    LIMIT 1
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- 1. Upsert into post_views (Stats aggregation)
+  INSERT INTO public.post_views (slug, view_count, updated_at)
+  VALUES (slug_input, 1, NOW())
+  ON CONFLICT (slug)
+  DO UPDATE SET
+    view_count = post_views.view_count + 1,
+    updated_at = NOW();
+
+  -- 2. Log the individual view event (History tracking)
+  INSERT INTO public.post_view_logs (slug, viewed_at)
+  VALUES (slug_input, NOW());
+END;
+$$;
+
+-- increment_view_count는 anon 정상 호출 path이므로 권한 유지
+REVOKE ALL ON FUNCTION public.increment_view_count(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_view_count(text) TO anon, authenticated, service_role;
+
+-- -----------------------------------------------------------------------------
+-- 4. 테이블 직접 권한 정리
+-- -----------------------------------------------------------------------------
+
+-- 4-1. post_view_logs: anon GRANT ALL → REVOKE ALL
+--   SECURITY DEFINER RPC 경로만 허용. 직접 테이블 접근 불가.
+REVOKE ALL ON TABLE public.post_view_logs FROM anon, authenticated, PUBLIC;
+-- service_role은 SECURITY DEFINER 함수 실행 컨텍스트에서 사용
+GRANT ALL ON TABLE public.post_view_logs TO service_role;
+
+-- 4-2. post_view_logs_id_seq: 시퀀스도 동일하게 정리
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.sequences
+    WHERE sequence_schema = 'public'
+      AND sequence_name = 'post_view_logs_id_seq'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON SEQUENCE public.post_view_logs_id_seq FROM anon, authenticated, PUBLIC';
+    EXECUTE 'GRANT ALL ON SEQUENCE public.post_view_logs_id_seq TO service_role';
+  END IF;
+END;
+$$;
+
+-- 4-3. post_views: anon에 SELECT만 남기고 INSERT/UPDATE/DELETE REVOKE
+--   "Allow public read access" RLS 정책과 일관성 유지
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.post_views FROM anon, authenticated, PUBLIC;
+GRANT SELECT ON TABLE public.post_views TO anon, authenticated;
+GRANT ALL ON TABLE public.post_views TO service_role;
+
+-- -----------------------------------------------------------------------------
+-- 5. increment_post_views 이중 정의 안내 (코멘트)
+-- -----------------------------------------------------------------------------
+-- production pg_dump 에서 increment_post_views 가 두 시그니처로 존재함.
+-- 현재 코드(domain/analytics/repository.ts)에서는 increment_view_count 만 호출.
+-- increment_post_views 는 사용되지 않는 것으로 보이나 DROP은 영향도 확인 후 수행 권장.
+-- 본 PR에서는 권한만 service_role로 잠금 (섹션 1의 DO $$ 블록에서 처리).
+-- TODO(#후속PR): increment_post_views 두 시그니처 사용 여부 확인 후 DROP 또는 통합
+
+-- -----------------------------------------------------------------------------
+-- 후속 작업 필요 사항 (별도 PR)
+-- -----------------------------------------------------------------------------
+-- 1. Admin 페이지 클라이언트 코드:
+--    현재 domain/analytics/repository.ts 의 getAllPostStats(), getAllPostsTrends(),
+--    getPostHourlyDistribution(), getPostDowDistribution() 함수들이
+--    anon key(브라우저)로 Supabase RPC를 직접 호출함.
+--    이 마이그레이션 적용 후 해당 RPC들은 service_role 에서만 실행 가능하므로
+--    Admin 어드민 기능이 브라우저에서 동작하지 않음.
+--    해결 방안:
+--      a) Next.js API Route (서버사이드)에서 service_role key로 RPC 호출
+--      b) 또는 Supabase Edge Function (server-side) 경유
+--      c) 또는 auth.jwt()->>'email' 체크를 활용해 authenticated role에도
+--         조건부 GRANT (보안 수준 낮아짐 — 권장하지 않음)
+-- 2. increment_post_views 두 시그니처 정리 (위 섹션 5 참조)
+-- 3. IP/세션 기반 rate limit 도입 (섹션 3 참조)

--- a/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
+++ b/apps/blog/web/supabase/migrations/20260524120000_lockdown_admin_rpcs.sql
@@ -42,167 +42,94 @@
 --    service_role → GRANT (Supabase client-side 호출 불가, 서버/cron만)
 -- -----------------------------------------------------------------------------
 
--- 아래 10개 모두 동일 패턴(DO $$ IF EXISTS)으로 처리해 reset 안전성 + 일관성 확보.
--- 4개는 기존 마이그레이션 파일에 정의되어 있고, 6개는 supabase 대시보드에서
--- 직접 생성된 것으로 추정(production dump에는 있으나 마이그레이션 파일 없음).
--- 어느 환경에 대해서도 동일 코드가 안전하게 동작하도록 모두 가드.
-
--- get_all_post_stats()
+-- 모든 함수에 대해 pg_get_function_identity_arguments() 로 실제 시그니처를
+-- 동적으로 가져와 REVOKE/GRANT 한다. 이유:
+--   1) 마이그레이션 파일이 없는 함수가 다수(production 대시보드에서 직접 생성).
+--      실제 시그니처가 추정과 다르면 EXECUTE에서 시그니처 불일치 에러 발생.
+--   2) 같은 이름의 함수가 여러 오버로드를 가질 수 있음(예: increment_post_views).
+--      모두 일관되게 처리되어야 함.
+--   3) 함수가 없는 환경(supabase reset 직후 등)에서는 자동 skip 되어 reset 안전.
+--
+-- 일반 RPC: 9개 — 모두 service_role만 GRANT
 DO $$
+DECLARE
+  fname text;
+  args  text;
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-             WHERE n.nspname = 'public' AND p.proname = 'get_all_post_stats') THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_all_post_stats() FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_all_post_stats() TO service_role';
-  END IF;
+  FOR fname IN VALUES
+    ('get_all_post_stats'),
+    ('get_all_posts_trends'),
+    ('get_post_hourly_distribution'),
+    ('get_post_dow_distribution'),
+    ('get_daily_view_trend'),
+    ('get_hourly_traffic_pattern'),
+    ('get_monthly_view_trend'),
+    ('get_popular_posts'),
+    ('get_weekly_traffic_pattern')
+  LOOP
+    FOR args IN
+      SELECT pg_get_function_identity_arguments(p.oid)
+      FROM pg_proc p
+      JOIN pg_namespace n ON p.pronamespace = n.oid
+      WHERE n.nspname = 'public' AND p.proname = fname
+    LOOP
+      EXECUTE format(
+        'REVOKE ALL ON FUNCTION public.%I(%s) FROM PUBLIC, anon, authenticated',
+        fname, args);
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.%I(%s) TO service_role',
+        fname, args);
+    END LOOP;
+  END LOOP;
 END;
 $$;
 
--- get_all_posts_trends()
+-- aggregate_daily_stats: service_role + (있다면) supabase_cron 만 허용
 DO $$
+DECLARE
+  args text;
+  has_cron boolean := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_cron');
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-             WHERE n.nspname = 'public' AND p.proname = 'get_all_posts_trends') THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_all_posts_trends() FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_all_posts_trends() TO service_role';
-  END IF;
-END;
-$$;
-
--- get_post_hourly_distribution(text)
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-             WHERE n.nspname = 'public' AND p.proname = 'get_post_hourly_distribution') THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_post_hourly_distribution(text) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_post_hourly_distribution(text) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_post_dow_distribution(text)
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid
-             WHERE n.nspname = 'public' AND p.proname = 'get_post_dow_distribution') THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_post_dow_distribution(text) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_post_dow_distribution(text) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_daily_view_trend(int, text) — production에 존재하나 마이그레이션 파일 없음
--- (Supabase 대시보드에서 직접 생성된 것으로 추정)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_daily_view_trend'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_daily_view_trend(int, text) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_daily_view_trend(int, text) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_hourly_traffic_pattern(int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_hourly_traffic_pattern'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_hourly_traffic_pattern(int) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_hourly_traffic_pattern(int) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_monthly_view_trend(int, text)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_monthly_view_trend'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_monthly_view_trend(int, text) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_monthly_view_trend(int, text) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_popular_posts(int, int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_popular_posts'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_popular_posts(int, int) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_popular_posts(int, int) TO service_role';
-  END IF;
-END;
-$$;
-
--- get_weekly_traffic_pattern(int)
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'public' AND p.proname = 'get_weekly_traffic_pattern'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.get_weekly_traffic_pattern(int) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_weekly_traffic_pattern(int) TO service_role';
-  END IF;
-END;
-$$;
-
--- aggregate_daily_stats(date)
--- service_role + supabase_cron (pg_cron이 쓰는 role) 만 허용
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
+  FOR args IN
+    SELECT pg_get_function_identity_arguments(p.oid)
+    FROM pg_proc p
     JOIN pg_namespace n ON p.pronamespace = n.oid
     WHERE n.nspname = 'public' AND p.proname = 'aggregate_daily_stats'
-  ) THEN
-    EXECUTE 'REVOKE ALL ON FUNCTION public.aggregate_daily_stats(date) FROM PUBLIC, anon, authenticated';
-    EXECUTE 'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(date) TO service_role';
-    -- supabase_cron role이 있으면 추가 grant (없으면 무시)
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_cron') THEN
-      EXECUTE 'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(date) TO supabase_cron';
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL ON FUNCTION public.aggregate_daily_stats(%s) FROM PUBLIC, anon, authenticated',
+      args);
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(%s) TO service_role',
+      args);
+    IF has_cron THEN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.aggregate_daily_stats(%s) TO supabase_cron',
+        args);
     END IF;
-  END IF;
+  END LOOP;
 END;
 $$;
 
--- increment_post_views — 두 시그니처 존재 (production dump 기준)
--- 현재 코드에서 사용되지 않는 것으로 보이나 권한만 잠금.
--- 함수 자체 DROP은 사용 여부 확인 후 별도 PR에서 처리 권장.
+-- increment_post_views: production dump에 두 시그니처(오버로드) 존재.
+-- 현재 코드 사용처 없음. 본 PR은 권한만 잠금.
 -- TODO(#후속PR): increment_post_views 두 시그니처 중 불필요한 것 DROP 검토
 DO $$
 DECLARE
-  r RECORD;
+  args text;
 BEGIN
-  FOR r IN
-    SELECT p.oid, pg_get_function_identity_arguments(p.oid) AS args
+  FOR args IN
+    SELECT pg_get_function_identity_arguments(p.oid)
     FROM pg_proc p
     JOIN pg_namespace n ON p.pronamespace = n.oid
     WHERE n.nspname = 'public' AND p.proname = 'increment_post_views'
   LOOP
     EXECUTE format(
       'REVOKE ALL ON FUNCTION public.increment_post_views(%s) FROM PUBLIC, anon, authenticated',
-      r.args
-    );
+      args);
     EXECUTE format(
       'GRANT EXECUTE ON FUNCTION public.increment_post_views(%s) TO service_role',
-      r.args
-    );
+      args);
   END LOOP;
 END;
 $$;
@@ -225,9 +152,27 @@ $$;
 -- 함수 본문 자체는 production dump와 동일하므로 CREATE OR REPLACE 하지 않음.
 -- (재정의가 필요 없는 함수까지 다시 쓰면 비즈니스 로직 silent 변경 리스크 증가)
 
--- increment_view_count는 anon 정상 호출 path이므로 권한 유지
-REVOKE ALL ON FUNCTION public.increment_view_count(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.increment_view_count(text) TO anon, authenticated, service_role;
+-- increment_view_count는 anon 정상 호출 path이므로 권한 유지.
+-- 함수 존재 여부 확인 후 동적 시그니처로 GRANT (다른 섹션과 일관성).
+DO $$
+DECLARE
+  args text;
+BEGIN
+  FOR args IN
+    SELECT pg_get_function_identity_arguments(p.oid)
+    FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'increment_view_count'
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL ON FUNCTION public.increment_view_count(%s) FROM PUBLIC',
+      args);
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION public.increment_view_count(%s) TO anon, authenticated, service_role',
+      args);
+  END LOOP;
+END;
+$$;
 
 -- -----------------------------------------------------------------------------
 -- 3. 테이블 직접 권한 정리
@@ -235,8 +180,6 @@ GRANT EXECUTE ON FUNCTION public.increment_view_count(text) TO anon, authenticat
 
 -- 3-1. post_view_logs: anon GRANT ALL → REVOKE ALL
 --   SECURITY DEFINER RPC 경로만 허용. 직접 테이블 접근 불가.
-REVOKE ALL ON TABLE public.post_view_logs FROM anon, authenticated, PUBLIC;
--- service_role은 SECURITY DEFINER 함수 실행 컨텍스트에서 사용.
 --   service_role은 본래 RLS bypass + 기본적으로 모든 권한이 부여돼 GRANT 자체가
 --   엄밀히는 redundant지만, "이 테이블에 service_role이 SELECT/INSERT 한다"는
 --   의도를 명시적으로 남긴다. 실제 함수가 쓰는 동작:
@@ -245,7 +188,17 @@ REVOKE ALL ON TABLE public.post_view_logs FROM anon, authenticated, PUBLIC;
 --       get_weekly_traffic_pattern, aggregate_daily_stats
 --     - INSERT: increment_view_count
 --   UPDATE/DELETE는 사용처 없음 → 좁혀서 명시.
-GRANT SELECT, INSERT ON TABLE public.post_view_logs TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'post_view_logs'
+  ) THEN
+    EXECUTE 'REVOKE ALL ON TABLE public.post_view_logs FROM anon, authenticated, PUBLIC';
+    EXECUTE 'GRANT SELECT, INSERT ON TABLE public.post_view_logs TO service_role';
+  END IF;
+END;
+$$;
 
 -- 3-2. post_view_logs_id_seq: 시퀀스 권한 좁혀서 명시
 --   INSERT 시 nextval 호출 → USAGE 필요. SELECT는 currval 호출 시.
@@ -264,11 +217,20 @@ $$;
 
 -- 3-3. post_views: anon에 SELECT만 남기고 INSERT/UPDATE/DELETE REVOKE
 --   "Allow public read access" RLS 정책과 일관성 유지
-REVOKE INSERT, UPDATE, DELETE ON TABLE public.post_views FROM anon, authenticated, PUBLIC;
-GRANT SELECT ON TABLE public.post_views TO anon, authenticated;
 -- service_role: increment_view_count(INSERT/UPDATE upsert), 기타 SELECT 함수들.
 --   DELETE 사용처 없음 → 좁혀서 명시.
-GRANT SELECT, INSERT, UPDATE ON TABLE public.post_views TO service_role;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'post_views'
+  ) THEN
+    EXECUTE 'REVOKE INSERT, UPDATE, DELETE ON TABLE public.post_views FROM anon, authenticated, PUBLIC';
+    EXECUTE 'GRANT SELECT ON TABLE public.post_views TO anon, authenticated';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON TABLE public.post_views TO service_role';
+  END IF;
+END;
+$$;
 
 -- -----------------------------------------------------------------------------
 -- 4. increment_post_views 이중 정의 안내 (코멘트)


### PR DESCRIPTION
## ⚠️ 머지 전 / 적용 전 사용자 검토 필수

이 PR은 SQL 마이그레이션 파일만 추가합니다. 머지 ≠ production DB 변경.
**그리고 적용 순서가 매우 중요합니다 (아래 "배포 순서" 절 참조).**

본 PR은 코드 리뷰 봇이 지적한 두 Critical을 반영해 초안에서 **Phase 1 — 권한만**으로 좁혔습니다.

## Summary

`pg_dump --schema public` 으로 확인한 production 상태:
- 11개 admin/analytics RPC (`get_all_post_stats`, `get_all_posts_trends`, `get_post_hourly_distribution`, `get_post_dow_distribution`, `get_daily_view_trend`, `get_hourly_traffic_pattern`, `get_monthly_view_trend`, `get_popular_posts`, `get_weekly_traffic_pattern`, `aggregate_daily_stats`, `increment_post_views`(2개)) 가 `anon` 에 GRANT ALL (Supabase default privilege 효과)
- 모든 함수가 SECURITY DEFINER + 내부 auth 가드 0건
- `post_view_logs` 테이블 + 시퀀스가 anon에 GRANT ALL
- `post_views` 가 anon에 INSERT/UPDATE/DELETE GRANT

→ anon key 한 줄만 있으면 전체 통계 조회/조작 가능. AdminGuard(클라이언트 이메일 비교)와 무관.

## 변경 내역 (Phase 1)

1. **권한 잠금** — 위 11개 admin/analytics RPC에 대해 `REVOKE EXECUTE FROM anon, authenticated, PUBLIC` + `GRANT EXECUTE TO service_role`. 마이그레이션 파일 없는 함수는 `DO $$ IF EXISTS THEN EXECUTE … END $$` 로 안전하게 처리.
2. **테이블 권한 정리** — `post_view_logs` + 시퀀스 anon REVOKE ALL (SECURITY DEFINER RPC 경유만), `post_views` 는 anon SELECT만 유지(INSERT/UPDATE/DELETE REVOKE).
3. **`increment_view_count`** — 본문 그대로 유지, 권한도 anon 유지(공개 RPC). slug-단위 1분 rate limit 블록은 제거(아래 리뷰 반영 1번).
4. **`aggregate_daily_stats`** — anon/authenticated REVOKE, service_role + (있다면) supabase_cron 만.

## 코드 리뷰 봇 Critical 반영

### ✅ 1. slug-단위 rate limit 제거
초안에는 `increment_view_count` 본문에 1분 슬러그 단위 차단이 있었으나, "A 사용자가 보면 이후 1분간 B/C/D 사용자 조회까지 차단해 인기 포스트가 분당 1회만 집계되는 데이터 유실"로 지적됨. → 블록 제거. 1차 중복 방지는 클라이언트 쿠키(6시간)에 유지, 서버측 IP/세션 단위 rate limit은 Edge Function 후속 PR로.

### ✅ 2. 함수 본문 추정 재정의 제거
초안에는 10개 함수를 admin email 가드 포함된 plpgsql로 재정의했으나, 실제 dump body는 `daily_post_stats` 테이블 + pre-computed 컬럼(`view_hour`, `view_day_of_week`) 기반인데 추정 body는 `post_view_logs` + `AT TIME ZONE 'Asia/Seoul'` 사용으로 완전히 다름. → 적용 시 silent regression. 본 PR에서 CREATE OR REPLACE 블록 **전부 제거**. Phase 2 별도 PR에서 실제 dump body + 가드 1줄만 추가하는 형태로 다시.

### ✅ 3. Admin breaking 배포 순서 명문화
적용 즉시 `/admin/analytics` 페이지의 anon key 호출 경로가 forbidden. SSG(`output: 'export'`)라 Next.js API Route 사용 불가 → Supabase Edge Function으로 admin RPC 경로 이동 필수.

## 배포 순서 (반드시 이 순서)

1. **[Edge Function PR 머지·배포]** — admin 클라이언트가 Edge Function 경유 호출로 전환 (Edge가 사용자 JWT 검증 + admin email 확인 + service_role key로 RPC 호출)
2. **[Phase 2 마이그레이션 PR 머지·`supabase db push`]** — `app.admin_email` GUC 사전 설정 + 함수 본문에 admin email 가드 추가 (실제 dump body 보존)
3. **[본 PR 머지·`supabase db push`]** — anon 권한 잠금

순서 위반 시 admin 페이지가 즉시 forbidden을 받아 사용 불가.

## 후속 PR 체크리스트

- [ ] supabase/functions/admin-analytics/ Edge Function 작성 + admin 클라이언트(`domain/analytics/repository.ts`) 호출 경로 전환
- [ ] Phase 2 마이그레이션 — 실제 dump body + admin email 가드. `ALTER DATABASE postgres SET "app.admin_email" = '...'` GUC 사전 설정 안내
- [ ] IP/세션 기반 rate limit (Edge Function)
- [ ] `increment_post_views` 두 시그니처 사용 여부 확인 후 DROP/통합

## Test plan
- [ ] 사용자 검토 (auto-merge 비활성)
- [ ] 로컬에서 `supabase start` → `supabase db reset` 으로 본 마이그레이션 적용 후, anon JWT로 admin RPC 호출 시 forbidden 반환 검증
- [ ] 머지 후: 위 배포 순서대로 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)
