### PR TITLE
chore(blog): 아키텍처 경계 하드닝 + analytics 배럴 + ESLint 강제 (PR2)

### DIFF
--- a/apps/blog/web/domain/analytics/index.ts
+++ b/apps/blog/web/domain/analytics/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Analytics domain 공개 API
+ *
+ * 외부(컴포넌트·훅)는 이 배럴을 통해서만 접근합니다. repository.ts(인프라)를
+ * 직접 import하지 않습니다 — eslint no-restricted-imports로 강제됩니다.
+ * post 도메인과 동일한 캡슐화 정책을 따릅니다.
+ */
+
+// 도메인 모델 타입
+export * from './types';
+
+// 순수 계산(use-case) + 공유 타입(AnalyticsRange, AnalyticsOverview 등)
+export * from './service';
+
+// 데이터 접근(Supabase / Edge Function / 정적 JSON). 의도적으로 공개하는 함수만 노출.
+export {
+  getTopPosts,
+  getAllViewCounts,
+  getAllPostStats,
+  getAllPostsTrends,
+  getAdminPostsIndex,
+  getPostHourlyDistribution,
+  getPostDowDistribution,
+  incrementViewCount,
+} from './repository';
+export type {
+  AdminPostIndex,
+  PostStatsRow,
+  PostTrendRow,
+  TopPostRow,
+} from './repository';

--- a/apps/blog/web/domain/analytics/repository.ts
+++ b/apps/blog/web/domain/analytics/repository.ts
@@ -57,6 +57,10 @@ export async function getTopPosts(limit: number): Promise<TopPostRow[]> {
 /**
  * 모든 글의 조회수를 반환합니다(정렬/limit 없음).
  * PostsArchive의 '인기순' 정렬처럼 전체 slug→view_count 맵이 필요할 때 사용합니다.
+ *
+ * post_views는 글당 1행이므로 PostgREST의 1000-row cap에 닿으려면 글이 1000편을
+ * 넘어야 합니다(getAllPostsTrends와 달리 post×day가 아님). 그 전까지는 페이지네이션
+ * 불필요. 1000편을 넘기면 range 페이지네이션을 추가해야 합니다.
  */
 export async function getAllViewCounts(): Promise<TopPostRow[]> {
   const { data } = await client.from('post_views').select('slug, view_count');

--- a/apps/blog/web/domain/analytics/repository.ts
+++ b/apps/blog/web/domain/analytics/repository.ts
@@ -54,6 +54,18 @@ export async function getTopPosts(limit: number): Promise<TopPostRow[]> {
   }));
 }
 
+/**
+ * 모든 글의 조회수를 반환합니다(정렬/limit 없음).
+ * PostsArchive의 '인기순' 정렬처럼 전체 slug→view_count 맵이 필요할 때 사용합니다.
+ */
+export async function getAllViewCounts(): Promise<TopPostRow[]> {
+  const { data } = await client.from('post_views').select('slug, view_count');
+  return (data ?? []).map(d => ({
+    slug: d.slug,
+    view_count: d.view_count ?? 0,
+  }));
+}
+
 export async function getAllPostStats(): Promise<PostStatsRow[]> {
   // admin RPC — service_role 한정. Edge Function 경유.
   const data = await adminApi.call<PostStatsRow[]>('all_post_stats');

--- a/apps/blog/web/domain/analytics/service.test.ts
+++ b/apps/blog/web/domain/analytics/service.test.ts
@@ -1,10 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import {
-  computeDerivedStats,
-  computeAnalyticsOverview,
-  UNIQUES_ESTIMATE_RATIO,
-} from './service';
+import { computeDerivedStats, computeAnalyticsOverview } from './service';
 import type { PostStatDetail } from './types';
 
 function makePost(
@@ -148,6 +144,28 @@ test('computeAnalyticsOverview: range=30d → rangeDays=30, totalSeries.length=3
   assert.equal(result.totalSeries.length, 30);
 });
 
+test('computeAnalyticsOverview: range=90d → rangeDays=90, totalSeries.length=90', () => {
+  const result = computeAnalyticsOverview([], '90d', '2026-05-24');
+  assert.equal(result.rangeDays, 90);
+  assert.equal(result.totalSeries.length, 90);
+});
+
+test('computeAnalyticsOverview: 90d는 현재/직전 90일 윈도우를 분리 집계', () => {
+  // todayISO=2026-05-24, range=90d → 현재 약 [2026-02-24 ~ 2026-05-24],
+  // 직전 약 [2025-11-26 ~ 2026-02-23]. 직전보다 더 과거는 제외되어야 한다.
+  const data = [
+    makePostDetail('a', [
+      { view_date: '2026-03-01', view_count: 50 }, // 현재 기간
+      { view_date: '2026-01-01', view_count: 20 }, // 직전 기간
+      { view_date: '2025-06-01', view_count: 999 }, // 직전보다 과거 → 제외
+    ]),
+  ];
+  const result = computeAnalyticsOverview(data, '90d', '2026-05-24');
+  assert.equal(result.total, 50);
+  // 직전 20 → (50-20)/20 = 1.5
+  assert.equal(result.totalDelta, 1.5);
+});
+
 test('computeAnalyticsOverview: 현재 기간 조회수만 total에 포함', () => {
   // todayISO = 2026-05-24, range=7d → 윈도우 2026-05-18 ~ 2026-05-24
   const data = [
@@ -191,12 +209,36 @@ test('computeAnalyticsOverview: totalDelta — 직전 기간 대비 증감율', 
   assert.equal(result.totalDelta, 2.0);
 });
 
-test('computeAnalyticsOverview: uniques는 UNIQUES_ESTIMATE_RATIO 비율', () => {
+test('computeAnalyticsOverview: uniques는 총 조회수의 추정 비율(0.55)', () => {
   const data = [
     makePostDetail('a', [{ view_date: '2026-05-20', view_count: 100 }]),
   ];
   const result = computeAnalyticsOverview(data, '7d', '2026-05-24');
-  assert.equal(result.uniques, Math.round(100 * UNIQUES_ESTIMATE_RATIO));
+  // 리터럴로 고정 — UNIQUES_ESTIMATE_RATIO(0.55)가 바뀌면 의도적으로 함께 갱신.
+  // round(100 * 0.55) = 55.
+  assert.equal(result.uniques, 55);
+});
+
+test('computeAnalyticsOverview: uniquesDelta — 직전 고유추정 대비 증감율, 직전 0이면 null', () => {
+  // todayISO=2026-05-14, range=7d → 현재 [05-08~05-14], 직전 [05-01~05-07]
+  // 현재 total=200 → uniques=round(200*0.55)=110
+  // 직전 total=100 → prevUniques=round(100*0.55)=55 → uniquesDelta=(110-55)/55=1.0
+  const data = [
+    makePostDetail('a', [
+      { view_date: '2026-05-10', view_count: 200 }, // 현재
+      { view_date: '2026-05-03', view_count: 100 }, // 직전
+    ]),
+  ];
+  const result = computeAnalyticsOverview(data, '7d', '2026-05-14');
+  assert.equal(result.uniques, 110);
+  assert.equal(result.uniquesDelta, 1.0);
+
+  // 직전 기간 조회수 0 → uniquesDelta는 null (0 나눗셈 가드)
+  const onlyCurrent = [
+    makePostDetail('b', [{ view_date: '2026-05-10', view_count: 200 }]),
+  ];
+  const r2 = computeAnalyticsOverview(onlyCurrent, '7d', '2026-05-14');
+  assert.equal(r2.uniquesDelta, null);
 });
 
 test('computeAnalyticsOverview: postsPublished는 published 상태 글만 카운트', () => {

--- a/apps/blog/web/domain/post/series.test.ts
+++ b/apps/blog/web/domain/post/series.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { sortPostsBySeriesOrder } from './series';
+
+interface Fixture {
+  slug: string;
+  originalSlug: string;
+  date?: string | null;
+}
+
+function makePost(over: Partial<Fixture> = {}): Fixture {
+  const slug = over.slug ?? 'slug';
+  return {
+    slug,
+    originalSlug: slug,
+    date: '2026-01-01',
+    ...over,
+  };
+}
+
+test('sortPostsBySeriesOrder: order=[b,a] → b가 a보다 앞', () => {
+  const posts = [
+    makePost({ slug: 'a', date: '2026-01-01' }),
+    makePost({ slug: 'b', date: '2026-01-02' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['b', 'a']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['b', 'a'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order는 date를 무시하고 순서를 우선시', () => {
+  // a의 날짜가 더 빠르지만 order가 b를 앞에 두므로 b가 먼저.
+  const posts = [
+    makePost({ slug: 'a', date: '2020-01-01' }),
+    makePost({ slug: 'b', date: '2099-12-31' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['b', 'a']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['b', 'a'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 3개 이상도 order 순서대로', () => {
+  const posts = [
+    makePost({ slug: 'x', date: '2026-01-01' }),
+    makePost({ slug: 'y', date: '2026-01-02' }),
+    makePost({ slug: 'z', date: '2026-01-03' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['z', 'x', 'y']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['z', 'x', 'y'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order에 slug 없으면 originalSlug로 rank 매칭', () => {
+  // order에는 originalSlug 값만 들어있고, 표시 slug는 다르다.
+  const posts = [
+    makePost({ slug: 'display-a', originalSlug: 'orig-a', date: '2026-01-01' }),
+    makePost({ slug: 'display-b', originalSlug: 'orig-b', date: '2026-01-02' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['orig-b', 'orig-a']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['display-b', 'display-a'],
+  );
+});
+
+test('sortPostsBySeriesOrder: slug 매칭이 originalSlug 매칭보다 우선', () => {
+  // slug로 먼저 조회되므로 slug 'a'(rank 0)가 originalSlug 매칭보다 우선.
+  const posts = [
+    makePost({ slug: 'a', originalSlug: 'zzz', date: '2026-01-01' }),
+    makePost({ slug: 'b', originalSlug: 'a', date: '2026-01-02' }),
+  ];
+  // order=['a','b']: 첫 글은 slug='a' → rank 0, 둘째는 slug='b' → rank 1.
+  const sorted = sortPostsBySeriesOrder(posts, ['a', 'b']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['a', 'b'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order에 둘 다 없는 글은 맨 뒤(POSITIVE_INFINITY)', () => {
+  const posts = [
+    makePost({ slug: 'unranked', date: '2026-01-01' }),
+    makePost({ slug: 'ranked', date: '2026-12-31' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['ranked']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['ranked', 'unranked'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order 미발견 글끼리는 date localeCompare 오름차순 폴백', () => {
+  // 셋 다 order에 없으므로 모두 POSITIVE_INFINITY → date 오름차순.
+  const posts = [
+    makePost({ slug: 'c', date: '2026-03-01' }),
+    makePost({ slug: 'a', date: '2026-01-01' }),
+    makePost({ slug: 'b', date: '2026-02-01' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['nonexistent']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['a', 'b', 'c'],
+  );
+});
+
+test('sortPostsBySeriesOrder: ranked 먼저, 그 뒤 unranked는 date 오름차순', () => {
+  const posts = [
+    makePost({ slug: 'u2', date: '2026-05-01' }),
+    makePost({ slug: 'r', date: '2026-12-31' }),
+    makePost({ slug: 'u1', date: '2026-01-01' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['r']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['r', 'u1', 'u2'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 같은 rank(둘 다 미발견) tie는 date 오름차순', () => {
+  const posts = [
+    makePost({ slug: 'later', date: '2026-06-01' }),
+    makePost({ slug: 'earlier', date: '2026-01-01' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['x', 'y']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['earlier', 'later'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order=undefined → 전체 date 오름차순', () => {
+  const posts = [
+    makePost({ slug: 'b', date: '2026-02-01' }),
+    makePost({ slug: 'a', date: '2026-01-01' }),
+    makePost({ slug: 'c', date: '2026-03-01' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, undefined);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['a', 'b', 'c'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order=[] (빈 배열) → 전체 date 오름차순', () => {
+  const posts = [
+    makePost({ slug: 'b', date: '2026-02-01' }),
+    makePost({ slug: 'a', date: '2026-01-01' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, []);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['a', 'b'],
+  );
+});
+
+test('sortPostsBySeriesOrder: date null/undefined는 (a.date ?? "")로 처리되어 맨 앞', () => {
+  // order 없는 경로: ''(빈 문자열)이 어떤 날짜 문자열보다 먼저 정렬됨.
+  const posts = [
+    makePost({ slug: 'has', date: '2026-01-01' }),
+    makePost({ slug: 'nullish', date: null }),
+    makePost({ slug: 'undef', date: undefined }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, undefined);
+  // null과 undefined는 둘 다 ''로 취급되어 tie → 안정 정렬로 입력 순서(nullish, undef) 유지.
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['nullish', 'undef', 'has'],
+  );
+});
+
+test('sortPostsBySeriesOrder: order 경로에서도 date 없는 unranked가 앞', () => {
+  // 둘 다 order에 없어 rank 동일(POSITIVE_INFINITY) → date 폴백, ''가 맨 앞.
+  const posts = [
+    makePost({ slug: 'dated', date: '2026-01-01' }),
+    makePost({ slug: 'no-date', date: null }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, ['ranked-only']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['no-date', 'dated'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 빈 입력 배열 → 빈 배열 반환', () => {
+  assert.deepEqual(sortPostsBySeriesOrder([], ['a', 'b']), []);
+  assert.deepEqual(sortPostsBySeriesOrder([], undefined), []);
+  assert.deepEqual(sortPostsBySeriesOrder([], []), []);
+});
+
+test('sortPostsBySeriesOrder: 단일 원소 배열은 그대로', () => {
+  const posts = [makePost({ slug: 'only', date: '2026-01-01' })];
+  assert.deepEqual(
+    sortPostsBySeriesOrder(posts, ['only']).map(p => p.slug),
+    ['only'],
+  );
+  assert.deepEqual(
+    sortPostsBySeriesOrder(posts, undefined).map(p => p.slug),
+    ['only'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 특수문자/한글 slug도 정상 정렬', () => {
+  const posts = [
+    makePost({ slug: '나중-글', date: '2026-02-01' }),
+    makePost({ slug: '첫-글', date: '2026-01-01' }),
+  ];
+  // order로 한글 slug 매칭.
+  const sorted = sortPostsBySeriesOrder(posts, ['나중-글', '첫-글']);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['나중-글', '첫-글'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 날짜 문자열은 사전식(localeCompare) 비교 — datetime도 일관', () => {
+  const posts = [
+    makePost({ slug: 'noon', date: '2026-01-01T12:00:00+09:00' }),
+    makePost({ slug: 'morning', date: '2026-01-01T09:00:00+09:00' }),
+  ];
+  const sorted = sortPostsBySeriesOrder(posts, undefined);
+  assert.deepEqual(
+    sorted.map(p => p.slug),
+    ['morning', 'noon'],
+  );
+});
+
+test('sortPostsBySeriesOrder: 입력 배열을 변형하지 않음(복사본 정렬)', () => {
+  const posts = [
+    makePost({ slug: 'a', date: '2026-03-01' }),
+    makePost({ slug: 'b', date: '2026-01-01' }),
+  ];
+  const before = posts.map(p => p.slug);
+  const result = sortPostsBySeriesOrder(posts, undefined);
+  assert.notEqual(result, posts, '새 배열이 반환되어야 함');
+  assert.deepEqual(
+    posts.map(p => p.slug),
+    before,
+    '원본 배열 순서가 보존되어야 함',
+  );
+});
+
+test('sortPostsBySeriesOrder: order 경로에서도 입력 불변', () => {
+  const posts = [
+    makePost({ slug: 'a', date: '2026-01-01' }),
+    makePost({ slug: 'b', date: '2026-01-02' }),
+  ];
+  const before = posts.map(p => p.slug);
+  const result = sortPostsBySeriesOrder(posts, ['b', 'a']);
+  assert.notEqual(result, posts);
+  assert.deepEqual(
+    posts.map(p => p.slug),
+    before,
+  );
+});

--- a/apps/blog/web/domain/post/thumbnail.test.ts
+++ b/apps/blog/web/domain/post/thumbnail.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { resolveThumbnailUrl, resolveAbsoluteThumbnailUrl } from './thumbnail';
+
+// 인코딩 결과 상수 (실제 encodeURIComponent / encodePostSlug 출력으로 확정)
+const ENC_BUNDLER = '%EB%B2%88%EB%93%A4%EB%9F%AC'; // '번들러'
+const ENC_3PYEON = '3%ED%8E%B8'; // '3편'
+
+test('resolveThumbnailUrl: thumbnail이 undefined면 기본 OG 이미지', () => {
+  assert.equal(resolveThumbnailUrl({ relativeDir: '' }), '/og-default.png');
+});
+
+test('resolveThumbnailUrl: thumbnail이 빈 문자열이면 기본 OG 이미지', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: '', relativeDir: '번들러/3편' }),
+    '/og-default.png',
+  );
+});
+
+test('resolveThumbnailUrl: https URL은 그대로 반환', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'https://cdn/x.png', relativeDir: '' }),
+    'https://cdn/x.png',
+  );
+});
+
+test('resolveThumbnailUrl: http URL은 그대로 반환', () => {
+  assert.equal(
+    resolveThumbnailUrl({
+      thumbnail: 'http://example.com/a/b.png',
+      relativeDir: '번들러/3편',
+    }),
+    'http://example.com/a/b.png',
+  );
+});
+
+test('resolveThumbnailUrl: 슬래시로 시작하는 절대 경로는 그대로 반환', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: '/abs/x.png', relativeDir: '번들러' }),
+    '/abs/x.png',
+  );
+});
+
+test('resolveThumbnailUrl: 루트 슬래시 하나도 절대 경로로 간주하여 그대로', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: '/', relativeDir: '번들러' }),
+    '/',
+  );
+});
+
+test('resolveThumbnailUrl: 상대 경로 + 한글 relativeDir (디렉터리 구분자 보존, 한글 인코딩)', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: '번들러/3편' }),
+    `/posts/${ENC_BUNDLER}/${ENC_3PYEON}/cover.png`,
+  );
+});
+
+test('resolveThumbnailUrl: 상대 경로 + relativeDir 빈 문자열', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: '' }),
+    '/posts/cover.png',
+  );
+});
+
+test('resolveThumbnailUrl: 상대 경로 + 단일 ASCII 디렉터리', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: 'bundler' }),
+    '/posts/bundler/cover.png',
+  );
+});
+
+test('resolveThumbnailUrl: 디렉터리 구분자는 세그먼트별 인코딩으로 보존', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: 'a/b/c' }),
+    '/posts/a/b/c/cover.png',
+  );
+});
+
+test('resolveThumbnailUrl: relativeDir의 공백은 %20으로 인코딩', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: 'my dir' }),
+    '/posts/my%20dir/cover.png',
+  );
+});
+
+test('resolveThumbnailUrl: thumbnail 파일명의 공백/특수문자 인코딩', () => {
+  assert.equal(
+    resolveThumbnailUrl({
+      thumbnail: '내 사진 (1).png',
+      relativeDir: '',
+    }),
+    '/posts/%EB%82%B4%20%EC%82%AC%EC%A7%84%20(1).png',
+  );
+});
+
+test('resolveThumbnailUrl: thumbnail 파일명의 슬래시는 %2F로 인코딩 (구분자 보존 아님)', () => {
+  // thumbnail은 encodeURIComponent 통째 적용 → 내부 '/'는 %2F
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'sub/cover.png', relativeDir: 'dir' }),
+    '/posts/dir/sub%2Fcover.png',
+  );
+});
+
+test('resolveThumbnailUrl: relativeDir 한글 단일 세그먼트', () => {
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'cover.png', relativeDir: '번들러' }),
+    `/posts/${ENC_BUNDLER}/cover.png`,
+  );
+});
+
+test('resolveThumbnailUrl: startsWith("http") quirk — http로 시작하는 비URL도 절대로 간주', () => {
+  // 절대 판정이 startsWith('http')라 'httpsfoo'·'http-guide.png' 같은 상대
+  // 파일명도 외부 URL로 오분류되어 미해결 반환된다. 현재 동작 회귀 고정이며,
+  // 'http://'·'https://' 프리픽스로 좁히는 게 옳은지는 별도 검토 대상이다.
+  assert.equal(
+    resolveThumbnailUrl({ thumbnail: 'httpsfoo', relativeDir: 'dir' }),
+    'httpsfoo',
+  );
+});
+
+test('resolveAbsoluteThumbnailUrl: 기본 OG 이미지에는 SITE_URL prefix', () => {
+  assert.equal(
+    resolveAbsoluteThumbnailUrl({ relativeDir: '' }),
+    'https://blog.sangwook.dev/og-default.png',
+  );
+});
+
+test('resolveAbsoluteThumbnailUrl: 슬래시 절대 경로에는 SITE_URL prefix', () => {
+  assert.equal(
+    resolveAbsoluteThumbnailUrl({ thumbnail: '/abs/x.png', relativeDir: '' }),
+    'https://blog.sangwook.dev/abs/x.png',
+  );
+});
+
+test('resolveAbsoluteThumbnailUrl: 상대 경로 결과에 SITE_URL prefix (한글 인코딩 포함)', () => {
+  assert.equal(
+    resolveAbsoluteThumbnailUrl({
+      thumbnail: 'cover.png',
+      relativeDir: '번들러/3편',
+    }),
+    `https://blog.sangwook.dev/posts/${ENC_BUNDLER}/${ENC_3PYEON}/cover.png`,
+  );
+});
+
+test('resolveAbsoluteThumbnailUrl: https URL은 prefix 없이 그대로', () => {
+  assert.equal(
+    resolveAbsoluteThumbnailUrl({
+      thumbnail: 'https://cdn/x.png',
+      relativeDir: '',
+    }),
+    'https://cdn/x.png',
+  );
+});
+
+test('resolveAbsoluteThumbnailUrl: http URL은 prefix 없이 그대로', () => {
+  assert.equal(
+    resolveAbsoluteThumbnailUrl({
+      thumbnail: 'http://example.com/x.png',
+      relativeDir: 'dir',
+    }),
+    'http://example.com/x.png',
+  );
+});

--- a/apps/blog/web/domain/post/utils.test.ts
+++ b/apps/blog/web/domain/post/utils.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { encodePostSlug } from './utils';
+
+test('encodePostSlug: 영숫자/슬래시는 그대로 보존된다', () => {
+  assert.equal(encodePostSlug('a/b/c'), 'a/b/c');
+});
+
+test('encodePostSlug: 대괄호·한글·공백 세그먼트는 인코딩되고 슬래시는 보존된다', () => {
+  assert.equal(
+    encodePostSlug('[Typescript로 설계하는 프로젝트]/글제목'),
+    '%5BTypescript%EB%A1%9C%20%EC%84%A4%EA%B3%84%ED%95%98%EB%8A%94%20%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%5D/%EA%B8%80%EC%A0%9C%EB%AA%A9',
+  );
+});
+
+test('encodePostSlug: 단일 한글 세그먼트는 퍼센트 인코딩된다', () => {
+  assert.equal(encodePostSlug('번들러'), '%EB%B2%88%EB%93%A4%EB%9F%AC');
+});
+
+test('encodePostSlug: 빈 문자열은 빈 문자열을 반환한다', () => {
+  assert.equal(encodePostSlug(''), '');
+});
+
+test('encodePostSlug: 이미 인코딩된 입력은 이중 인코딩된다(% → %25)', () => {
+  assert.equal(encodePostSlug('%20'), '%2520');
+  assert.equal(encodePostSlug('%5B'), '%255B');
+});
+
+test('encodePostSlug: 세그먼트 내부 공백은 %20으로 인코딩된다', () => {
+  assert.equal(encodePostSlug('hello world'), 'hello%20world');
+  assert.equal(encodePostSlug('a b/c d'), 'a%20b/c%20d');
+});
+
+test('encodePostSlug: 단일 슬래시는 빈 세그먼트 두 개로 join되어 그대로 유지된다', () => {
+  assert.equal(encodePostSlug('/'), '/');
+});
+
+test('encodePostSlug: 연속 슬래시(빈 세그먼트)도 보존된다', () => {
+  assert.equal(encodePostSlug('a//b'), 'a//b');
+});
+
+test('encodePostSlug: 앞뒤 슬래시는 빈 세그먼트로 보존된다', () => {
+  assert.equal(encodePostSlug('/a/b/'), '/a/b/');
+});
+
+test('encodePostSlug: URL 예약/특수문자(? & #)는 퍼센트 인코딩된다', () => {
+  assert.equal(encodePostSlug('foo?bar&baz'), 'foo%3Fbar%26baz');
+  assert.equal(encodePostSlug('#anchor'), '%23anchor');
+});
+
+test('encodePostSlug: 악센트 문자(café)는 UTF-8 퍼센트 인코딩된다', () => {
+  assert.equal(encodePostSlug('café'), 'caf%C3%A9');
+});
+
+test('encodePostSlug: 하이픈/언더스코어/숫자는 비예약 문자로 보존된다', () => {
+  assert.equal(
+    encodePostSlug('한글-제목_123'),
+    '%ED%95%9C%EA%B8%80-%EC%A0%9C%EB%AA%A9_123',
+  );
+});
+
+test('encodePostSlug: 이모지(서로게이트 페어)도 UTF-8 바이트로 인코딩된다', () => {
+  assert.equal(encodePostSlug('emoji😀'), 'emoji%F0%9F%98%80');
+});
+
+test('encodePostSlug: 다중 세그먼트가 각각 인코딩되고 슬래시는 보존된다 (리터럴 고정)', () => {
+  // expected를 구현으로 재계산하지 않고 리터럴로 고정해 독립 검증한다.
+  assert.equal(
+    encodePostSlug('[A 1]/번들러/c d'),
+    '%5BA%201%5D/%EB%B2%88%EB%93%A4%EB%9F%AC/c%20d',
+  );
+});

--- a/apps/blog/web/eslint.config.mjs
+++ b/apps/blog/web/eslint.config.mjs
@@ -37,18 +37,22 @@ const eslintConfig = [
     files: ['src/**/*.{ts,tsx}'],
     ignores: ['**/*.test.{ts,tsx}'],
     rules: {
+      // `**/` 접두로 alias(@/domain/...)와 상대경로(../../domain/...) 양쪽을 차단.
       'no-restricted-imports': [
         'error',
         {
           patterns: [
             {
-              group: ['@/domain/*/repository', '@/domain/*/repository.*'],
+              group: ['**/domain/*/repository', '**/domain/*/repository.*'],
               message:
                 'repository는 인프라 레이어입니다. domain/<x> 공개 API(배럴, 예: @/domain/analytics)를 통해 접근하세요.',
             },
           ],
         },
       ],
+      // 주의: 아래 selector는 식별자 이름(client/supabase)에 매칭하므로, Supabase
+      // 클라이언트를 임의 이름으로 alias하면(예: `client as db`) 우회될 수 있습니다.
+      // 클라이언트 import 자체를 lib/client로 한정하는 컨벤션과 함께 봐야 합니다.
       'no-restricted-syntax': [
         'error',
         {
@@ -76,7 +80,7 @@ const eslintConfig = [
         {
           patterns: [
             {
-              group: ['@/src/*', '@/src'],
+              group: ['**/src', '**/src/**'],
               message: 'domain은 상위 레이어(src)를 import할 수 없습니다.',
             },
           ],
@@ -94,7 +98,7 @@ const eslintConfig = [
         {
           patterns: [
             {
-              group: ['@/domain/*', '@/domain', '@/src/*', '@/src'],
+              group: ['**/domain', '**/domain/**', '**/src', '**/src/**'],
               message:
                 'lib은 최하위 레이어입니다. domain·src를 import할 수 없습니다.',
             },

--- a/apps/blog/web/eslint.config.mjs
+++ b/apps/blog/web/eslint.config.mjs
@@ -28,6 +28,91 @@ const eslintConfig = [
       '@next/next/no-img-element': 'off',
     },
   },
+
+  // ── 아키텍처 경계 강제 (헥사고날 레이어링: src → domain → lib) ──────────────
+  // 경계를 컨벤션이 아니라 lint로 강제해 회귀를 막습니다.
+  {
+    // src(상위)는 domain/<x>의 공개 API(배럴)만 쓰고, repository(인프라)를 직접
+    // 찌르거나 Supabase client를 직접 호출하지 않습니다.
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/domain/*/repository', '@/domain/*/repository.*'],
+              message:
+                'repository는 인프라 레이어입니다. domain/<x> 공개 API(배럴, 예: @/domain/analytics)를 통해 접근하세요.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.property.name='from'][callee.object.name=/^(client|supabase)$/]",
+          message:
+            'Supabase 데이터 접근은 src에서 직접 하지 말고 domain repository/service(배럴)를 통하세요.',
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='rpc'][callee.object.name=/^(client|supabase)$/]",
+          message:
+            'Supabase RPC는 src에서 직접 호출하지 말고 domain repository를 통하세요.',
+        },
+      ],
+    },
+  },
+  {
+    // domain(중간)은 상위 레이어(src)를 import할 수 없습니다(역방향 의존 금지).
+    files: ['domain/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/src/*', '@/src'],
+              message: 'domain은 상위 레이어(src)를 import할 수 없습니다.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // lib(최하위)은 domain·src를 import할 수 없습니다.
+    files: ['lib/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/domain/*', '@/domain', '@/src/*', '@/src'],
+              message:
+                'lib은 최하위 레이어입니다. domain·src를 import할 수 없습니다.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // 타입은 항상 `import type`으로 — isolatedModules 정확성 + 번들 누수 예방.
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { prefer: 'type-imports' },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/blog/web/lib/dates.test.ts
+++ b/apps/blog/web/lib/dates.test.ts
@@ -7,6 +7,7 @@ import {
   getKSTCutoffDate,
   getKSTDateISO,
   hasAmbiguousTimezone,
+  msUntilKSTMidnight,
   parseScheduledDateKST,
 } from './dates';
 
@@ -155,4 +156,24 @@ test('getKSTCutoffDate: todayKST 미제공 시 현재 KST 기준', () => {
   const cutoff = getKSTCutoffDate('7days');
   const today = getKSTDateISO();
   assert.equal(addDaysISO(cutoff, 7), today);
+});
+
+// --- msUntilKSTMidnight ---
+
+test('msUntilKSTMidnight: KST 23:00이면 1시간 + 60초', () => {
+  // KST 2026-05-08 23:00 = UTC 14:00 → 다음 자정까지 1시간
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T14:00:00Z'));
+  assert.equal(ms, 60 * 60 * 1000 + 60_000);
+});
+
+test('msUntilKSTMidnight: KST 00:01이면 거의 24시간(정확히 24h - 1min + 60s)', () => {
+  // KST 2026-05-09 00:01 = UTC 2026-05-08 15:01 → 다음 자정까지 23h59m
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T15:01:00Z'));
+  assert.equal(ms, 24 * 60 * 60 * 1000); // (86400000 - 60000) + 60000
+});
+
+test('msUntilKSTMidnight: KST 자정 정각이면 60초만(경계 비퇴행)', () => {
+  // KST 2026-05-09 00:00:00 = UTC 2026-05-08 15:00:00 → 이미 자정이라 여유 60초만
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T15:00:00Z'));
+  assert.equal(ms, 60_000);
 });

--- a/apps/blog/web/lib/dates.ts
+++ b/apps/blog/web/lib/dates.ts
@@ -133,3 +133,17 @@ export function getKSTCutoffDate(
   if (filterType === '7days') return addDaysISO(today, -7);
   return addDaysISO(today, -30);
 }
+
+/**
+ * 주어진 시점에서 다음 KST 자정까지 남은 밀리초(+60초 여유).
+ *
+ * 자정 정각에 OS 타이머가 약간 일찍 발화하는 경우를 대비해 60초를 더합니다.
+ * useAnalyticsOverview가 자정마다 차트 윈도우를 리셋하는 setTimeout 스케줄에 씁니다.
+ * now를 주입받아 결정적으로 테스트할 수 있습니다.
+ */
+export function msUntilKSTMidnight(now: Date = new Date()): number {
+  const kstOffset = 9 * 60 * 60 * 1000; // 9시간
+  const nowKST = now.getTime() + kstOffset;
+  const midnightKST = Math.ceil(nowKST / 86400000) * 86400000;
+  return midnightKST - nowKST + 60_000;
+}

--- a/apps/blog/web/lib/ga-proxy-generator.test.ts
+++ b/apps/blog/web/lib/ga-proxy-generator.test.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  generateMultipleTrackingImages,
+  generateTrackingImageFromUrl,
+  generateVelogMarkdown,
+  generateVelogTrackingImage,
+} from './ga-proxy-generator';
+
+// 주의: 이 함수들은 host/page를 encodeURIComponent한 뒤 다시 URLSearchParams로
+// 직렬화해 '%'가 한 번 더 인코딩되는 이중 인코딩(예: '/' → %252F)이 발생한다.
+// 아래 테스트는 이 인코딩이 "옳다"는 계약 검증이 아니라 **현재 동작을 회귀로
+// 고정**하는 것이다. 소비자인 ga-proxy 서버(apps/ga-proxy)가 page/host를 몇 번
+// 디코딩하는지와 대조해 단일/이중 디코딩 계약을 확정하는 것은 별도 과제다.
+// (서버가 1회만 디코딩하면 추적 파라미터가 깨지므로 그쪽과 함께 봐야 한다.)
+
+// ---------------------------------------------------------------------------
+// generateVelogTrackingImage
+// ---------------------------------------------------------------------------
+
+test('generateVelogTrackingImage: baseUrl 미지정 시 기본값 your-blog.com 사용', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+  });
+  assert.ok(url.startsWith('https://your-blog.com/api/ga-proxy?'));
+});
+
+test('generateVelogTrackingImage: baseUrl 지정 시 해당 도메인 사용', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+    baseUrl: 'https://blog.sangwook.dev',
+  });
+  assert.ok(url.startsWith('https://blog.sangwook.dev/api/ga-proxy?'));
+});
+
+test('generateVelogTrackingImage: 항상 tid=velog 쿼리 포함', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+  });
+  assert.ok(url.includes('tid=velog'));
+});
+
+test('generateVelogTrackingImage: 특수문자 없는 host/page는 그대로 직렬화', () => {
+  const url = generateVelogTrackingImage({ host: 'velog.io', page: 'p' });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=p',
+  );
+});
+
+test('generateVelogTrackingImage: 슬래시가 든 page는 이중 인코딩(/ → %252F)', () => {
+  // encodeURIComponent('/posts/abc') → %2Fposts%2Fabc,
+  // 그 결과를 URLSearchParams가 다시 인코딩 → %252Fposts%252Fabc
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fabc',
+  );
+});
+
+test('generateVelogTrackingImage: 한글·공백·&·?·= 가 든 page도 이중 인코딩', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/한글 제목?x=1&y=2',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252F%25ED%2595%259C%25EA%25B8%2580%2520%25EC%25A0%259C%25EB%25AA%25A9%253Fx%253D1%2526y%253D2',
+  );
+});
+
+test('generateVelogTrackingImage: + 문자도 이중 인코딩(+ → %252B)', () => {
+  const url = generateVelogTrackingImage({ host: 'h', page: 'a+b' });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=h&page=a%252Bb',
+  );
+});
+
+test('generateVelogTrackingImage: title 제공 시 title param 추가(공백 → %2520)', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+    title: 'My Post',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fabc&title=My%2520Post',
+  );
+});
+
+test('generateVelogTrackingImage: title 미제공 시 title param 없음', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+  });
+  assert.ok(!url.includes('title='));
+});
+
+test('generateVelogTrackingImage: title이 빈 문자열이면 falsy로 처리되어 param 없음', () => {
+  const url = generateVelogTrackingImage({ host: 'h', page: 'p', title: '' });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=h&page=p',
+  );
+  assert.ok(!url.includes('title='));
+});
+
+test('generateVelogTrackingImage: 특수문자가 든 title은 이중 인코딩(& → %2526, = → %253D)', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/p',
+    title: 'a b&c=d',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fp&title=a%2520b%2526c%253Dd',
+  );
+});
+
+test('generateVelogTrackingImage: referrer 제공 시 referrer param 추가(이중 인코딩)', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+    referrer: 'https://google.com',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fabc&referrer=https%253A%252F%252Fgoogle.com',
+  );
+});
+
+test('generateVelogTrackingImage: referrer 미제공 시 referrer param 없음', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/posts/abc',
+  });
+  assert.ok(!url.includes('referrer='));
+});
+
+test('generateVelogTrackingImage: referrer가 빈 문자열이면 param 없음', () => {
+  const url = generateVelogTrackingImage({
+    host: 'h',
+    page: 'p',
+    referrer: '',
+  });
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=h&page=p',
+  );
+  assert.ok(!url.includes('referrer='));
+});
+
+test('generateVelogTrackingImage: title·referrer 모두 제공 시 둘 다 포함', () => {
+  const url = generateVelogTrackingImage({
+    host: 'velog.io',
+    page: '/p',
+    title: 'T',
+    referrer: 'https://r.com',
+  });
+  assert.ok(url.includes('title=T'));
+  assert.ok(url.includes('referrer=https%253A%252F%252Fr.com'));
+});
+
+test('generateVelogTrackingImage: 빈 host/page도 빈 값으로 직렬화', () => {
+  const url = generateVelogTrackingImage({ host: '', page: '' });
+  assert.equal(url, 'https://your-blog.com/api/ga-proxy?tid=velog&host=&page=');
+});
+
+// ---------------------------------------------------------------------------
+// generateVelogMarkdown
+// ---------------------------------------------------------------------------
+
+test('generateVelogMarkdown: ![](url) 형식으로 감싼다', () => {
+  const md = generateVelogMarkdown({ host: 'velog.io', page: '/posts/abc' });
+  assert.equal(
+    md,
+    '![](https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fabc)',
+  );
+});
+
+test('generateVelogMarkdown: 내부 URL은 generateVelogTrackingImage 결과와 동일', () => {
+  const options = { host: 'velog.io', page: '/p', title: 'T' };
+  const md = generateVelogMarkdown(options);
+  const url = generateVelogTrackingImage(options);
+  assert.equal(md, `![](${url})`);
+});
+
+// ---------------------------------------------------------------------------
+// generateMultipleTrackingImages
+// ---------------------------------------------------------------------------
+
+test('generateMultipleTrackingImages: 빈 배열이면 빈 배열 반환', () => {
+  assert.deepEqual(generateMultipleTrackingImages([]), []);
+});
+
+test('generateMultipleTrackingImages: host 미지정 시 velog.io 폴백 + page=/posts/{slug}', () => {
+  const result = generateMultipleTrackingImages([{ slug: 'a', title: 'A' }]);
+  assert.equal(result.length, 1);
+  assert.deepEqual(result[0], {
+    slug: 'a',
+    markdown:
+      '![](https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fa&title=A)',
+    url: 'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252Fposts%252Fa&title=A',
+  });
+});
+
+test('generateMultipleTrackingImages: host 지정 시 해당 host 사용', () => {
+  const result = generateMultipleTrackingImages([
+    { slug: 'b', title: 'B', host: 'custom.io' },
+  ]);
+  assert.equal(result[0].url.includes('host=custom.io'), true);
+  assert.equal(result[0].slug, 'b');
+});
+
+test('generateMultipleTrackingImages: 여러 포스트를 입력 순서대로 매핑', () => {
+  const result = generateMultipleTrackingImages([
+    { slug: 'a', title: 'A' },
+    { slug: 'b', title: 'B', host: 'custom.io' },
+  ]);
+  assert.equal(result.length, 2);
+  assert.deepEqual(
+    result.map(r => r.slug),
+    ['a', 'b'],
+  );
+  assert.ok(result[0].url.includes('host=velog.io'));
+  assert.ok(result[1].url.includes('host=custom.io'));
+});
+
+test('generateMultipleTrackingImages: 각 항목은 slug/markdown/url 키를 가진다', () => {
+  const [item] = generateMultipleTrackingImages([{ slug: 'x', title: 'X' }]);
+  assert.deepEqual(Object.keys(item).sort(), ['markdown', 'slug', 'url']);
+  assert.equal(item.markdown, `![](${item.url})`);
+});
+
+test('generateMultipleTrackingImages: 슬래시가 든 slug도 이중 인코딩되어 page에 반영', () => {
+  const [item] = generateMultipleTrackingImages([{ slug: 'a/b', title: 'AB' }]);
+  // page = '/posts/a/b' → 이중 인코딩
+  assert.ok(item.url.includes('page=%252Fposts%252Fa%252Fb'));
+});
+
+// ---------------------------------------------------------------------------
+// generateTrackingImageFromUrl
+// ---------------------------------------------------------------------------
+
+test('generateTrackingImageFromUrl: 정상 URL이면 hostname/(pathname+search) 추출', () => {
+  const url = generateTrackingImageFromUrl(
+    'https://velog.io/@user/post-slug?foo=bar',
+  );
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=velog.io&page=%252F%2540user%252Fpost-slug%253Ffoo%253Dbar',
+  );
+});
+
+test('generateTrackingImageFromUrl: baseUrl 전달 시 해당 도메인 사용', () => {
+  const url = generateTrackingImageFromUrl(
+    'https://velog.io/@user/post',
+    'https://blog.sangwook.dev',
+  );
+  assert.equal(
+    url,
+    'https://blog.sangwook.dev/api/ga-proxy?tid=velog&host=velog.io&page=%252F%2540user%252Fpost',
+  );
+});
+
+test('generateTrackingImageFromUrl: search 없는 URL은 pathname만 page에 반영', () => {
+  const url = generateTrackingImageFromUrl('https://example.com/path');
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=example.com&page=%252Fpath',
+  );
+});
+
+test('generateTrackingImageFromUrl: 루트 URL은 pathname이 / 로 정규화되어 page=%252F', () => {
+  const url = generateTrackingImageFromUrl('https://example.com');
+  assert.equal(
+    url,
+    'https://your-blog.com/api/ga-proxy?tid=velog&host=example.com&page=%252F',
+  );
+});
+
+test('generateTrackingImageFromUrl: 잘못된 URL이면 Invalid URL format 에러를 throw', () => {
+  const original = console.error;
+  console.error = () => {};
+  try {
+    assert.throws(
+      () => generateTrackingImageFromUrl('not-a-url'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, 'Invalid URL format');
+        return true;
+      },
+    );
+  } finally {
+    console.error = original;
+  }
+});
+
+test('generateTrackingImageFromUrl: 빈 문자열도 잘못된 URL로 간주되어 throw', () => {
+  const original = console.error;
+  console.error = () => {};
+  try {
+    assert.throws(() => generateTrackingImageFromUrl(''), {
+      message: 'Invalid URL format',
+    });
+  } finally {
+    console.error = original;
+  }
+});

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -11,7 +11,10 @@
     "lint": "eslint .",
     "lint:posts": "npx tsx scripts/validate-posts.ts",
     "check-types": "tsc --noEmit",
-    "test": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
+    "test": "pnpm test:node && pnpm test:vitest",
+    "test:node": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
+    "test:vitest": "vitest run",
+    "test:coverage": "c8 --reporter=text --reporter=text-summary --exclude='**/*.test.ts' --exclude='**/*.config.*' --exclude='**/database.types.ts' node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
     "new-post": "npx tsx scripts/new-post.ts",
     "supabase-stop": "supabase stop --all --no-backup --debug",
     "supabase-start": "pnpm supabase-stop && pnpm supabase start"
@@ -51,18 +54,26 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@pandacss/dev": "catalog:",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/mdx": "^2.0.13",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^25.8.0",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@vitejs/plugin-react": "^5.0.4",
+    "c8": "^11.0.0",
     "concurrently": "^9.2.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "eslint-plugin-react-hooks": "^7.0.0",
+    "jsdom": "^29.1.1",
     "supabase": "^2.70.5",
     "tsx": "^4.22.0",
-    "typescript": "catalog:typescript5"
+    "typescript": "catalog:typescript5",
+    "vitest": "^4.0.0-beta.15"
   }
 }

--- a/apps/blog/web/src/app/admin/analytics/AnalyticsContent.tsx
+++ b/apps/blog/web/src/app/admin/analytics/AnalyticsContent.tsx
@@ -9,10 +9,8 @@ import {
   useAnalyticsOverview,
   UNIQUES_ESTIMATE_RATIO,
 } from '@/src/hooks/useAnalyticsOverview';
-import {
-  AnalyticsRangeSelect,
-  type AnalyticsRange,
-} from '@/src/components/admin/AnalyticsRangeSelect';
+import { AnalyticsRangeSelect } from '@/src/components/admin/AnalyticsRangeSelect';
+import type { AnalyticsRange } from '@/domain/analytics';
 import { KpiCard } from '@/src/components/admin/KpiCard';
 import { TimeSeriesChart } from '@/src/components/admin/TimeSeriesChart';
 import { TopPostsTable } from '@/src/components/admin/TopPostsTable';

--- a/apps/blog/web/src/app/admin/components/PostAccordion.tsx
+++ b/apps/blog/web/src/app/admin/components/PostAccordion.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { PostStatDetail } from '@/src/hooks/useAdminViews';
+import type { PostStatDetail } from '@/src/hooks/useAdminViews';
 import { computeBriefStats } from '@/src/hooks/usePostDetailStats';
 import { css } from '@design-system/ui-lib/css';
 import {

--- a/apps/blog/web/src/components/admin/AnalyticsRangeSelect.tsx
+++ b/apps/blog/web/src/components/admin/AnalyticsRangeSelect.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { css } from '@design-system/ui-lib/css';
-
-export type AnalyticsRange = '7d' | '30d' | '90d';
+import type { AnalyticsRange } from '@/domain/analytics';
 
 interface AnalyticsRangeSelectProps {
   value: AnalyticsRange;

--- a/apps/blog/web/src/components/blog/PopularRail.tsx
+++ b/apps/blog/web/src/components/blog/PopularRail.tsx
@@ -38,7 +38,8 @@ export const PopularRail = ({ posts, limit = 5 }: PopularRailProps) => {
       .map(r => {
         const post = bySlug.get(r.slug);
         if (!post) return null;
-        return { ...post, viewCount: r.view_count ?? 0 } satisfies RankedPost;
+        // getTopPosts(TopPostRow)의 view_count는 이미 non-null number로 정규화됨.
+        return { ...post, viewCount: r.view_count } satisfies RankedPost;
       })
       .filter((p): p is RankedPost => p !== null);
   }, [rows, posts]);

--- a/apps/blog/web/src/components/blog/PopularRail.tsx
+++ b/apps/blog/web/src/components/blog/PopularRail.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import Link from 'next/link';
 import { css } from '@design-system/ui-lib/css';
 import { useQuery } from '@tanstack/react-query';
-import { client } from '@/lib/client';
+import { getTopPosts } from '@/domain/analytics';
 import type { PostSummary } from '@/domain/post';
 import { encodePostSlug } from '@/domain/post/utils';
 import { fmtNum } from '@/lib/format';
@@ -26,14 +26,7 @@ export const PopularRail = ({ posts, limit = 5 }: PopularRailProps) => {
   // 메모이제이션이 의미가 없으므로, raw rows만 캐시하고 매핑은 useMemo로 분리합니다.
   const { data: rows } = useQuery({
     queryKey: ['popular-rail', limit],
-    queryFn: async () => {
-      const res = await client
-        .from('post_views')
-        .select('slug, view_count')
-        .order('view_count', { ascending: false })
-        .limit(limit);
-      return res.data ?? [];
-    },
+    queryFn: () => getTopPosts(limit),
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });

--- a/apps/blog/web/src/components/blog/PostsArchive.tsx
+++ b/apps/blog/web/src/components/blog/PostsArchive.tsx
@@ -11,7 +11,7 @@ import {
   filterAndSortPostsByArchiveParams,
   parseTagParam,
 } from '@/domain/post/filtering';
-import { client } from '@/lib/client';
+import { getAllViewCounts } from '@/domain/analytics';
 
 import { Label } from './Label';
 import { type SortKey } from './SortRadio';
@@ -67,12 +67,10 @@ export const PostsArchiveView = ({
   const { data: viewCounts } = useQuery({
     queryKey: ['posts-view-counts'],
     queryFn: async () => {
-      const { data } = await client
-        .from('post_views')
-        .select('slug, view_count');
+      const rows = await getAllViewCounts();
       const map = new Map<string, number>();
-      for (const row of data ?? []) {
-        map.set(row.slug, row.view_count ?? 0);
+      for (const row of rows) {
+        map.set(row.slug, row.view_count);
       }
       return map;
     },

--- a/apps/blog/web/src/components/home/TopPosts.tsx
+++ b/apps/blog/web/src/components/home/TopPosts.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { css } from '@design-system/ui-lib/css';
-import { getTopPosts } from '@/domain/analytics/repository';
+import { getTopPosts } from '@/domain/analytics';
 import type { PostSummary } from '@/domain/post/types';
 import { PostCard } from './PostCard';
 import { useSuspenseQuery } from '@tanstack/react-query';

--- a/apps/blog/web/src/hooks/useAdminViews.ts
+++ b/apps/blog/web/src/hooks/useAdminViews.ts
@@ -3,8 +3,8 @@ import {
   getAdminPostsIndex,
   getAllPostStats,
   getAllPostsTrends,
-} from '@/domain/analytics/repository';
-import type { PostStatDetail } from '@/domain/analytics/types';
+} from '@/domain/analytics';
+import type { PostStatDetail } from '@/domain/analytics';
 
 export type { PostStatDetail };
 

--- a/apps/blog/web/src/hooks/useAnalyticsOverview.ts
+++ b/apps/blog/web/src/hooks/useAnalyticsOverview.ts
@@ -6,12 +6,12 @@ import { getKSTDateISO } from '@/lib/dates';
 import {
   computeAnalyticsOverview,
   UNIQUES_ESTIMATE_RATIO,
-} from '../../domain/analytics/service';
-import type { AnalyticsRange } from '@/src/components/admin/AnalyticsRangeSelect';
+} from '@/domain/analytics';
+import type { AnalyticsRange } from '@/domain/analytics';
 
 export type { AnalyticsRange };
 export { UNIQUES_ESTIMATE_RATIO };
-export type { AnalyticsOverview } from '../../domain/analytics/service';
+export type { AnalyticsOverview } from '@/domain/analytics';
 
 /**
  * KST 자정까지 남은 밀리초를 계산합니다.

--- a/apps/blog/web/src/hooks/useAnalyticsOverview.ts
+++ b/apps/blog/web/src/hooks/useAnalyticsOverview.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useEffect } from 'react';
 import { useAdminDashboardData } from './useAdminViews';
-import { getKSTDateISO } from '@/lib/dates';
+import { getKSTDateISO, msUntilKSTMidnight } from '@/lib/dates';
 import {
   computeAnalyticsOverview,
   UNIQUES_ESTIMATE_RATIO,
@@ -12,19 +12,6 @@ import type { AnalyticsRange } from '@/domain/analytics';
 export type { AnalyticsRange };
 export { UNIQUES_ESTIMATE_RATIO };
 export type { AnalyticsOverview } from '@/domain/analytics';
-
-/**
- * KST 자정까지 남은 밀리초를 계산합니다.
- * 자정 + 60s 여유를 두어 날짜 전환 직후 확실히 트리거됩니다.
- */
-function msUntilKSTMidnight(now: Date = new Date()): number {
-  // KST 기준 다음 자정 = UTC 기준 (오늘 15:00 또는 내일 15:00)
-  const kstOffset = 9 * 60 * 60 * 1000; // 9시간
-  const nowKST = now.getTime() + kstOffset;
-  const midnightKST = Math.ceil(nowKST / 86400000) * 86400000;
-  // 여유 60초 추가: 자정 정각에 OS 타이머가 약간 일찍 발화하는 경우 대비
-  return midnightKST - nowKST + 60_000;
-}
 
 /**
  * Supabase admin dashboard 데이터를 가공해 Analytics 페이지에서 쓰는 형태로 반환.

--- a/apps/blog/web/src/hooks/usePostDetailStats.ts
+++ b/apps/blog/web/src/hooks/usePostDetailStats.ts
@@ -2,22 +2,22 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   getPostDowDistribution,
   getPostHourlyDistribution,
-} from '@/domain/analytics/repository';
-import { computeDerivedStats } from '@/domain/analytics/service';
+  computeDerivedStats,
+} from '@/domain/analytics';
 import { useAdminDashboardData } from './useAdminViews';
 import type {
   PostDetailStats,
   HourlyDistribution,
   DowDistribution,
-} from '@/domain/analytics/types';
+} from '@/domain/analytics';
 
 export type {
   PostDetailStats,
   HourlyDistribution,
   DowDistribution,
-} from '@/domain/analytics/types';
+} from '@/domain/analytics';
 
-export { computeDerivedStats as computeBriefStats } from '@/domain/analytics/service';
+export { computeDerivedStats as computeBriefStats } from '@/domain/analytics';
 
 // SSR/prerender에서 useAdminDashboardData가 빈 배열일 때 쓰는 placeholder.
 // 클라이언트 hydration 후 진짜 post로 즉시 교체됩니다.

--- a/apps/blog/web/src/hooks/useRecentViews.test.ts
+++ b/apps/blog/web/src/hooks/useRecentViews.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  getRecentViews,
+  recordRecentView,
+  useRecordRecentView,
+} from './useRecentViews';
+
+const KEY = 'blog_recent_views';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('getRecentViews', () => {
+  test('키가 없으면 빈 배열', () => {
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('손상된 JSON은 빈 배열로 복구', () => {
+    window.localStorage.setItem(KEY, '{not json');
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('배열이 아니면 빈 배열', () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ slug: 'x' }));
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('유효하지 않은 항목(비문자열 slug/null/누락)은 필터링', () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify([
+        { slug: 'a', title: 'A', viewedAt: 1 },
+        { slug: 123, title: 'bad' },
+        null,
+        { title: 'no-slug' },
+      ]),
+    );
+    const result = getRecentViews();
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe('a');
+  });
+});
+
+describe('recordRecentView', () => {
+  test('새 항목을 맨 앞(최신)에 추가', () => {
+    recordRecentView('a', 'A');
+    recordRecentView('b', 'B');
+    expect(getRecentViews().map(r => r.slug)).toEqual(['b', 'a']);
+  });
+
+  test('같은 slug 재방문 시 중복 없이 맨 앞으로 이동(타이틀 갱신)', () => {
+    recordRecentView('a', 'A');
+    recordRecentView('b', 'B');
+    recordRecentView('a', 'A again');
+    const result = getRecentViews();
+    expect(result.map(r => r.slug)).toEqual(['a', 'b']);
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe('A again');
+  });
+
+  test('MAX=5개로 제한하고 가장 오래된 것을 제거', () => {
+    for (const s of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      recordRecentView(s, s.toUpperCase());
+    }
+    const result = getRecentViews();
+    expect(result).toHaveLength(5);
+    // 최신순 f,e,d,c,b — 가장 오래된 a가 밀려남
+    expect(result.map(r => r.slug)).toEqual(['f', 'e', 'd', 'c', 'b']);
+  });
+
+  test('viewedAt에 타임스탬프(number)를 기록하고 최신 항목이 더 크거나 같음', () => {
+    recordRecentView('a', 'A');
+    recordRecentView('b', 'B');
+    const result = getRecentViews();
+    expect(typeof result[0].viewedAt).toBe('number');
+    // b가 최신(index 0) → viewedAt이 a(index 1)보다 크거나 같아야 함
+    expect(result[0].viewedAt).toBeGreaterThanOrEqual(result[1].viewedAt);
+  });
+
+  test('setItem이 throw해도(한도 초과/사적 모드) 예외를 삼키고 조용히 반환', () => {
+    const spy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceeded');
+      });
+    expect(() => recordRecentView('a', 'A')).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+describe('useRecordRecentView', () => {
+  test('마운트 시 slug를 기록', () => {
+    renderHook(() => useRecordRecentView('hello', 'Hello'));
+    expect(getRecentViews().map(r => r.slug)).toEqual(['hello']);
+  });
+
+  test('slug가 null이면 기록하지 않음', () => {
+    renderHook(() => useRecordRecentView(null, 'X'));
+    expect(getRecentViews()).toEqual([]);
+  });
+});

--- a/apps/blog/web/src/hooks/useViewCount.test.ts
+++ b/apps/blog/web/src/hooks/useViewCount.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// 도메인 배럴의 incrementViewCount를 mock (vi.hoisted로 mock 팩토리에서 참조).
+const { incrementViewCount } = vi.hoisted(() => ({
+  incrementViewCount: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('@/domain/analytics', () => ({ incrementViewCount }));
+
+import { useViewCount } from './useViewCount';
+
+function clearAllCookies() {
+  for (const c of document.cookie.split(';')) {
+    const name = c.split('=')[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+  }
+}
+
+beforeEach(() => {
+  incrementViewCount.mockClear();
+  clearAllCookies();
+});
+
+describe('useViewCount', () => {
+  test('첫 조회: 쿠키가 없으면 incrementViewCount(slug) 호출 + 쿠키 set', () => {
+    renderHook(() => useViewCount('my-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+    expect(incrementViewCount).toHaveBeenCalledWith('my-post');
+    expect(document.cookie).toContain('viewed_my-post');
+  });
+
+  test('이미 조회한 글(쿠키 존재): incrementViewCount 미호출', () => {
+    document.cookie = 'viewed_my-post=true; path=/';
+    renderHook(() => useViewCount('my-post'));
+    expect(incrementViewCount).not.toHaveBeenCalled();
+  });
+
+  test('slug가 null이면 아무 동작 안 함', () => {
+    renderHook(() => useViewCount(null));
+    expect(incrementViewCount).not.toHaveBeenCalled();
+  });
+
+  test('레이스 가드: 쿠키를 RPC 전에 set하므로 같은 글 재마운트 시 1회만 호출', () => {
+    // 첫 마운트가 쿠키를 set → 두 번째 마운트는 hasViewed=true로 RPC 차단.
+    renderHook(() => useViewCount('race-post'));
+    renderHook(() => useViewCount('race-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+  });
+
+  test('한글 slug도 쿠키 키 충돌 없이 1회 카운트', () => {
+    renderHook(() => useViewCount('번들러/소개'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+    expect(incrementViewCount).toHaveBeenCalledWith('번들러/소개');
+    // 다른 한글 slug는 별개 키라 영향 없음
+    renderHook(() => useViewCount('번들러/심화'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(2);
+  });
+
+  test('RPC가 reject돼도 throw하지 않고, 쿠키 가드로 재마운트 시 재호출 안 함', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    incrementViewCount.mockRejectedValueOnce(new Error('rpc fail'));
+
+    renderHook(() => useViewCount('fail-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+
+    // 쿠키는 RPC 호출 *전*에 set되므로, reject돼도 재마운트는 차단된다.
+    renderHook(() => useViewCount('fail-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+
+    // .catch(console.error)가 reject를 삼킨다(에러 전파 없음).
+    await vi.waitFor(() => expect(errSpy).toHaveBeenCalled());
+    errSpy.mockRestore();
+  });
+});

--- a/apps/blog/web/src/hooks/useViewCount.ts
+++ b/apps/blog/web/src/hooks/useViewCount.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
-import { incrementViewCount } from '@/domain/analytics/repository';
+import { incrementViewCount } from '@/domain/analytics';
 import {
   slugToViewKey,
   hasViewCookie,
   buildViewCookieStr,
   getViewCookieExpiry,
-} from '../../lib/viewCookie';
+} from '@/lib/viewCookie';
 
 export const useViewCount = (slug: string | null) => {
   useEffect(() => {

--- a/apps/blog/web/vitest.config.ts
+++ b/apps/blog/web/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+/**
+ * 컴포넌트/훅용 vitest 설정 (jsdom 환경).
+ *
+ * domain/lib/scripts의 순수 로직 테스트는 기존 `node --test`가 담당하고,
+ * vitest는 src/ 의 DOM 의존 컴포넌트·훅 테스트만 맡습니다(include 스코프로 분리).
+ * 두 러너는 `pnpm test`에서 순차 실행됩니다.
+ */
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    // tsconfig의 `@/* → ./*` 매핑을 vitest에도 동일 적용하는 프리픽스 alias.
+    // (키에 트레일링 슬래시를 둬 `@/foo`만 매칭하고 `@/`가 아닌 경로엔 닿지 않게 함)
+    alias: {
+      '@/': fileURLToPath(new URL('./', import.meta.url)),
+    },
+  },
+});

--- a/apps/blog/web/vitest.setup.ts
+++ b/apps/blog/web/vitest.setup.ts
@@ -1,0 +1,9 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// @testing-library/jest-dom 매처(toBeInTheDocument 등)를 vitest expect에 등록.
+import '@testing-library/jest-dom/vitest';
+
+// RTL은 전역 afterEach가 있을 때만 cleanup을 자동 등록한다(globals:false라 수동 연결).
+// 테스트 간 마운트된 훅/컴포넌트가 unmount되도록 명시적으로 cleanup을 건다.
+afterEach(cleanup);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,18 @@ importers:
       '@pandacss/dev':
         specifier: 'catalog:'
         version: 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.3.0-canary-a757cb76-20251002(react@19.3.0-canary-a757cb76-20251002))(react@19.3.0-canary-a757cb76-20251002)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -179,6 +191,12 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.2.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.3))
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       concurrently:
         specifier: ^9.2.0
         version: 9.2.1
@@ -191,6 +209,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       supabase:
         specifier: ^2.70.5
         version: 2.88.1
@@ -200,6 +221,9 @@ importers:
       typescript:
         specifier: catalog:typescript5
         version: 5.8.3
+      vitest:
+        specifier: ^4.0.0-beta.15
+        version: 4.1.4(@types/node@25.9.1)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.9.1)(typescript@5.8.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.3))
 
   apps/next.js:
     dependencies:
@@ -403,7 +427,7 @@ importers:
     devDependencies:
       '@pandacss/dev':
         specifier: 'catalog:'
-        version: 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+        version: 1.11.1(typescript@5.8.3)
       '@types/react':
         specifier: catalog:react19
         version: 19.2.15
@@ -521,10 +545,6 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -565,10 +585,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -615,6 +631,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
@@ -1309,6 +1329,10 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2022,6 +2046,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2402,6 +2429,16 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3349,6 +3386,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3465,6 +3506,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -3692,6 +3736,18 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -4082,6 +4138,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4559,6 +4619,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -5211,6 +5275,10 @@ packages:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -5483,6 +5551,10 @@ packages:
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5774,7 +5846,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.4
+      lru-cache: 11.5.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5804,12 +5876,6 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5831,7 +5897,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5876,8 +5942,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -5917,7 +5981,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5925,6 +5989,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@braintree/sanitize-url@7.1.1': {}
 
@@ -6397,6 +6463,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6648,6 +6716,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@pandacss/dev@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@clack/prompts': 0.11.0
+      '@pandacss/config': 1.11.1
+      '@pandacss/logger': 1.11.1
+      '@pandacss/mcp': 1.11.1(typescript@5.8.3)
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
+      '@pandacss/postcss': 1.11.1(typescript@5.8.3)
+      '@pandacss/preset-base': 1.11.1
+      '@pandacss/preset-panda': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      cac: 6.7.14
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - jsdom
+      - supports-color
+      - typescript
+
   '@pandacss/extractor@1.11.1(jsdom@27.4.0)(typescript@5.8.3)':
     dependencies:
       '@pandacss/shared': 1.11.1
@@ -6661,6 +6749,15 @@ snapshots:
     dependencies:
       '@pandacss/shared': 1.11.1
       ts-evaluator: 1.2.0(jsdom@29.1.1)(typescript@5.8.3)
+      ts-morph: 28.0.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/extractor@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/shared': 1.11.1
+      ts-evaluator: 1.2.0(jsdom@27.4.0)(typescript@5.8.3)
       ts-morph: 28.0.0
     transitivePeerDependencies:
       - jsdom
@@ -6708,6 +6805,21 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
       '@pandacss/logger': 1.11.1
       '@pandacss/node': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - jsdom
+      - supports-color
+      - typescript
+
+  '@pandacss/mcp@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@clack/prompts': 0.11.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
+      '@pandacss/logger': 1.11.1
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
       '@pandacss/token-dictionary': 1.11.1
       '@pandacss/types': 1.11.1
       zod: 4.2.1
@@ -6793,6 +6905,44 @@ snapshots:
       - jsdom
       - typescript
 
+  '@pandacss/node@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/config': 1.11.1
+      '@pandacss/core': 1.11.1
+      '@pandacss/generator': 1.11.1
+      '@pandacss/logger': 1.11.1
+      '@pandacss/parser': 1.11.1(typescript@5.8.3)
+      '@pandacss/plugin-lightningcss': 1.11.1
+      '@pandacss/plugin-svelte': 1.11.1
+      '@pandacss/plugin-vue': 1.11.1
+      '@pandacss/reporter': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      browserslist: 4.28.1
+      chokidar: 4.0.3
+      fast-glob: 3.3.3
+      fs-extra: 11.3.2
+      get-tsconfig: 4.13.0
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lodash.merge: 4.6.2
+      look-it-up: 2.1.0
+      outdent: 0.8.0
+      p-limit: 5.0.0
+      package-manager-detector: 1.6.0
+      perfect-debounce: 1.0.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.0
+      pluralize: 8.0.0
+      postcss: 8.5.14
+      prettier: 3.2.5
+      ts-morph: 28.0.0
+      ts-pattern: 5.9.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
   '@pandacss/parser@1.11.1(jsdom@27.4.0)(typescript@5.8.3)':
     dependencies:
       '@pandacss/config': 1.11.1
@@ -6812,6 +6962,20 @@ snapshots:
       '@pandacss/config': 1.11.1
       '@pandacss/core': 1.11.1
       '@pandacss/extractor': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@pandacss/logger': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/types': 1.11.1
+      ts-morph: 28.0.0
+      ts-pattern: 5.9.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/parser@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/config': 1.11.1
+      '@pandacss/core': 1.11.1
+      '@pandacss/extractor': 1.11.1(typescript@5.8.3)
       '@pandacss/logger': 1.11.1
       '@pandacss/shared': 1.11.1
       '@pandacss/types': 1.11.1
@@ -6850,6 +7014,14 @@ snapshots:
   '@pandacss/postcss@1.11.1(jsdom@29.1.1)(typescript@5.8.3)':
     dependencies:
       '@pandacss/node': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      postcss: 8.5.14
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/postcss@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
       postcss: 8.5.14
     transitivePeerDependencies:
       - jsdom
@@ -7099,7 +7271,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -7324,6 +7496,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -7788,6 +7962,20 @@ snapshots:
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
+
+  c8@11.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   cac@6.7.14: {}
 
@@ -8993,6 +9181,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -9161,9 +9355,11 @@ snapshots:
 
   html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.9.0
+      '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -9380,6 +9576,19 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -9737,6 +9946,10 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-extensions@2.0.0: {}
 
@@ -10489,6 +10702,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
@@ -11310,6 +11528,12 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  test-exclude@8.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 13.0.6
+      minimatch: 10.2.5
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -11635,6 +11859,12 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## 개요

블로그 아키텍처 하드닝 **2단계(PR2)** — 도메인 레이어 경계를 **ESLint로 강제**하고
analytics 도메인의 캡슐화를 post 도메인과 일관되게 맞춥니다.

> **스택**: 이 PR은 [#118](https://github.com/Han5991/fe-lab/pull/118)(PR1) 위에 쌓여 있습니다. base가 `fix/blog-correctness`라 PR1 머지 후 자동으로 `main`으로 retarget됩니다.

종합 리뷰에서 측정된 경계 누수 — src에서 `@/domain/analytics/repository`(인프라) 직접 import **4건**, `client.from('post_views')` 직접 호출 **2건** — 을 리팩터로 해소하고, 재발을 lint로 막습니다.

## 리팩터

| 항목 | 내용 |
|------|------|
| **analytics 배럴** | `domain/analytics/index.ts` 신설. 컴포넌트·훅 4곳이 repository를 직접 import하던 것을 배럴 경유로 정리 (post 도메인과 동일 캡슐화) |
| **client.from 제거** | `PopularRail`·`PostsArchive`의 인라인 `client.from('post_views')` → repository `getTopPosts`/신설 `getAllViewCounts` 경유. 중복 쿼리 제거 |
| **AnalyticsRange 단일화** | 도메인·UI 이중 정의 제거 → `domain/analytics` 단일 출처. 훅→UI 역방향 타입 결합 해소 |
| **import 경로 통일** | `useAnalyticsOverview` 등의 `../../domain` 상대경로 → `@/domain` alias |

## ESLint 경계 룰 (무설치)

```
src/**     → @/domain/*/repository 직접 import 금지 (배럴만)
           → client.from()/.rpc() 직접 호출 금지 (repository 경유)
domain/**  → @/src 역방향 import 금지
lib/**     → @/domain·@/src import 금지 (최하위 레이어)
**/*       → consistent-type-imports (warn)
```

위반(repository 4건 + client.from 2건)을 전부 해소 → **`pnpm lint` 0 errors / 0 warnings**.

## 검증

- ✅ `pnpm test` 198 통과 (회귀 없음)
- ✅ `pnpm check-types` / `pnpm lint`(0/0) / `pnpm format:check` 통과
- 🔎 런타임 데이터 페칭 경로(PopularRail/PostsArchive/TopPosts) 변경은 **Vercel 프리뷰 빌드 + 브라우저 렌더 확인**으로 검증

## 의도적 제외 (후속 PR)

- `post/repository.ts`의 `import 'server-only'` 가드 → 빌드타임 node 스크립트(sitemap/rss/search/llms)가 해당 모듈을 import하므로 throw 유발 → **제외**, 경계는 import 룰로 강제
- `new Date(문자열)` 금지 룰 + 8개 호출부 KST 헬퍼 마이그레이션 → 별도 date-safety PR
- `eslint-plugin-import`(`import/no-cycle`·`import/order`) → 설치·대량 reformat 동반이라 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)
