### PR TITLE
test(blog): vitest+jsdom+RTL 컴포넌트/훅 테스트 인프라 (PR4)

### DIFF
--- a/apps/blog/web/lib/dates.test.ts
+++ b/apps/blog/web/lib/dates.test.ts
@@ -7,6 +7,7 @@ import {
   getKSTCutoffDate,
   getKSTDateISO,
   hasAmbiguousTimezone,
+  msUntilKSTMidnight,
   parseScheduledDateKST,
 } from './dates';
 
@@ -155,4 +156,24 @@ test('getKSTCutoffDate: todayKST 미제공 시 현재 KST 기준', () => {
   const cutoff = getKSTCutoffDate('7days');
   const today = getKSTDateISO();
   assert.equal(addDaysISO(cutoff, 7), today);
+});
+
+// --- msUntilKSTMidnight ---
+
+test('msUntilKSTMidnight: KST 23:00이면 1시간 + 60초', () => {
+  // KST 2026-05-08 23:00 = UTC 14:00 → 다음 자정까지 1시간
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T14:00:00Z'));
+  assert.equal(ms, 60 * 60 * 1000 + 60_000);
+});
+
+test('msUntilKSTMidnight: KST 00:01이면 거의 24시간(정확히 24h - 1min + 60s)', () => {
+  // KST 2026-05-09 00:01 = UTC 2026-05-08 15:01 → 다음 자정까지 23h59m
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T15:01:00Z'));
+  assert.equal(ms, 24 * 60 * 60 * 1000); // (86400000 - 60000) + 60000
+});
+
+test('msUntilKSTMidnight: KST 자정 정각이면 60초만(경계 비퇴행)', () => {
+  // KST 2026-05-09 00:00:00 = UTC 2026-05-08 15:00:00 → 이미 자정이라 여유 60초만
+  const ms = msUntilKSTMidnight(new Date('2026-05-08T15:00:00Z'));
+  assert.equal(ms, 60_000);
 });

--- a/apps/blog/web/lib/dates.ts
+++ b/apps/blog/web/lib/dates.ts
@@ -133,3 +133,17 @@ export function getKSTCutoffDate(
   if (filterType === '7days') return addDaysISO(today, -7);
   return addDaysISO(today, -30);
 }
+
+/**
+ * 주어진 시점에서 다음 KST 자정까지 남은 밀리초(+60초 여유).
+ *
+ * 자정 정각에 OS 타이머가 약간 일찍 발화하는 경우를 대비해 60초를 더합니다.
+ * useAnalyticsOverview가 자정마다 차트 윈도우를 리셋하는 setTimeout 스케줄에 씁니다.
+ * now를 주입받아 결정적으로 테스트할 수 있습니다.
+ */
+export function msUntilKSTMidnight(now: Date = new Date()): number {
+  const kstOffset = 9 * 60 * 60 * 1000; // 9시간
+  const nowKST = now.getTime() + kstOffset;
+  const midnightKST = Math.ceil(nowKST / 86400000) * 86400000;
+  return midnightKST - nowKST + 60_000;
+}

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -11,7 +11,9 @@
     "lint": "eslint .",
     "lint:posts": "npx tsx scripts/validate-posts.ts",
     "check-types": "tsc --noEmit",
-    "test": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
+    "test": "pnpm test:node && pnpm test:vitest",
+    "test:node": "node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
+    "test:vitest": "vitest run",
     "test:coverage": "c8 --reporter=text --reporter=text-summary --exclude='**/*.test.ts' --exclude='**/*.config.*' --exclude='**/database.types.ts' node --import tsx --test 'domain/**/*.test.ts' 'lib/**/*.test.ts' 'scripts/**/*.test.ts' 'generate-*.test.ts' 'sync-posts.test.ts'",
     "new-post": "npx tsx scripts/new-post.ts",
     "supabase-stop": "supabase stop --all --no-backup --debug",
@@ -52,19 +54,26 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@pandacss/dev": "catalog:",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/mdx": "^2.0.13",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^25.8.0",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@vitejs/plugin-react": "^5.0.4",
     "c8": "^11.0.0",
     "concurrently": "^9.2.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "eslint-plugin-react-hooks": "^7.0.0",
+    "jsdom": "^29.1.1",
     "supabase": "^2.70.5",
     "tsx": "^4.22.0",
-    "typescript": "catalog:typescript5"
+    "typescript": "catalog:typescript5",
+    "vitest": "^4.0.0-beta.15"
   }
 }

--- a/apps/blog/web/src/hooks/useAnalyticsOverview.ts
+++ b/apps/blog/web/src/hooks/useAnalyticsOverview.ts
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useEffect } from 'react';
 import { useAdminDashboardData } from './useAdminViews';
-import { getKSTDateISO } from '@/lib/dates';
+import { getKSTDateISO, msUntilKSTMidnight } from '@/lib/dates';
 import {
   computeAnalyticsOverview,
   UNIQUES_ESTIMATE_RATIO,
@@ -12,19 +12,6 @@ import type { AnalyticsRange } from '@/domain/analytics';
 export type { AnalyticsRange };
 export { UNIQUES_ESTIMATE_RATIO };
 export type { AnalyticsOverview } from '@/domain/analytics';
-
-/**
- * KST 자정까지 남은 밀리초를 계산합니다.
- * 자정 + 60s 여유를 두어 날짜 전환 직후 확실히 트리거됩니다.
- */
-function msUntilKSTMidnight(now: Date = new Date()): number {
-  // KST 기준 다음 자정 = UTC 기준 (오늘 15:00 또는 내일 15:00)
-  const kstOffset = 9 * 60 * 60 * 1000; // 9시간
-  const nowKST = now.getTime() + kstOffset;
-  const midnightKST = Math.ceil(nowKST / 86400000) * 86400000;
-  // 여유 60초 추가: 자정 정각에 OS 타이머가 약간 일찍 발화하는 경우 대비
-  return midnightKST - nowKST + 60_000;
-}
 
 /**
  * Supabase admin dashboard 데이터를 가공해 Analytics 페이지에서 쓰는 형태로 반환.

--- a/apps/blog/web/src/hooks/useRecentViews.test.ts
+++ b/apps/blog/web/src/hooks/useRecentViews.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import {
   getRecentViews,
@@ -70,9 +70,23 @@ describe('recordRecentView', () => {
     expect(result.map(r => r.slug)).toEqual(['f', 'e', 'd', 'c', 'b']);
   });
 
-  test('viewedAt에 타임스탬프(number)를 기록', () => {
+  test('viewedAt에 타임스탬프(number)를 기록하고 최신 항목이 더 크거나 같음', () => {
     recordRecentView('a', 'A');
-    expect(typeof getRecentViews()[0].viewedAt).toBe('number');
+    recordRecentView('b', 'B');
+    const result = getRecentViews();
+    expect(typeof result[0].viewedAt).toBe('number');
+    // b가 최신(index 0) → viewedAt이 a(index 1)보다 크거나 같아야 함
+    expect(result[0].viewedAt).toBeGreaterThanOrEqual(result[1].viewedAt);
+  });
+
+  test('setItem이 throw해도(한도 초과/사적 모드) 예외를 삼키고 조용히 반환', () => {
+    const spy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceeded');
+      });
+    expect(() => recordRecentView('a', 'A')).not.toThrow();
+    spy.mockRestore();
   });
 });
 

--- a/apps/blog/web/src/hooks/useRecentViews.test.ts
+++ b/apps/blog/web/src/hooks/useRecentViews.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  getRecentViews,
+  recordRecentView,
+  useRecordRecentView,
+} from './useRecentViews';
+
+const KEY = 'blog_recent_views';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('getRecentViews', () => {
+  test('키가 없으면 빈 배열', () => {
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('손상된 JSON은 빈 배열로 복구', () => {
+    window.localStorage.setItem(KEY, '{not json');
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('배열이 아니면 빈 배열', () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ slug: 'x' }));
+    expect(getRecentViews()).toEqual([]);
+  });
+
+  test('유효하지 않은 항목(비문자열 slug/null/누락)은 필터링', () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify([
+        { slug: 'a', title: 'A', viewedAt: 1 },
+        { slug: 123, title: 'bad' },
+        null,
+        { title: 'no-slug' },
+      ]),
+    );
+    const result = getRecentViews();
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe('a');
+  });
+});
+
+describe('recordRecentView', () => {
+  test('새 항목을 맨 앞(최신)에 추가', () => {
+    recordRecentView('a', 'A');
+    recordRecentView('b', 'B');
+    expect(getRecentViews().map(r => r.slug)).toEqual(['b', 'a']);
+  });
+
+  test('같은 slug 재방문 시 중복 없이 맨 앞으로 이동(타이틀 갱신)', () => {
+    recordRecentView('a', 'A');
+    recordRecentView('b', 'B');
+    recordRecentView('a', 'A again');
+    const result = getRecentViews();
+    expect(result.map(r => r.slug)).toEqual(['a', 'b']);
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe('A again');
+  });
+
+  test('MAX=5개로 제한하고 가장 오래된 것을 제거', () => {
+    for (const s of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      recordRecentView(s, s.toUpperCase());
+    }
+    const result = getRecentViews();
+    expect(result).toHaveLength(5);
+    // 최신순 f,e,d,c,b — 가장 오래된 a가 밀려남
+    expect(result.map(r => r.slug)).toEqual(['f', 'e', 'd', 'c', 'b']);
+  });
+
+  test('viewedAt에 타임스탬프(number)를 기록', () => {
+    recordRecentView('a', 'A');
+    expect(typeof getRecentViews()[0].viewedAt).toBe('number');
+  });
+});
+
+describe('useRecordRecentView', () => {
+  test('마운트 시 slug를 기록', () => {
+    renderHook(() => useRecordRecentView('hello', 'Hello'));
+    expect(getRecentViews().map(r => r.slug)).toEqual(['hello']);
+  });
+
+  test('slug가 null이면 기록하지 않음', () => {
+    renderHook(() => useRecordRecentView(null, 'X'));
+    expect(getRecentViews()).toEqual([]);
+  });
+});

--- a/apps/blog/web/src/hooks/useViewCount.test.ts
+++ b/apps/blog/web/src/hooks/useViewCount.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// 도메인 배럴의 incrementViewCount를 mock (vi.hoisted로 mock 팩토리에서 참조).
+const { incrementViewCount } = vi.hoisted(() => ({
+  incrementViewCount: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('@/domain/analytics', () => ({ incrementViewCount }));
+
+import { useViewCount } from './useViewCount';
+
+function clearAllCookies() {
+  for (const c of document.cookie.split(';')) {
+    const name = c.split('=')[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+  }
+}
+
+beforeEach(() => {
+  incrementViewCount.mockClear();
+  clearAllCookies();
+});
+
+describe('useViewCount', () => {
+  test('첫 조회: 쿠키가 없으면 incrementViewCount(slug) 호출 + 쿠키 set', () => {
+    renderHook(() => useViewCount('my-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+    expect(incrementViewCount).toHaveBeenCalledWith('my-post');
+    expect(document.cookie).toContain('viewed_my-post');
+  });
+
+  test('이미 조회한 글(쿠키 존재): incrementViewCount 미호출', () => {
+    document.cookie = 'viewed_my-post=true; path=/';
+    renderHook(() => useViewCount('my-post'));
+    expect(incrementViewCount).not.toHaveBeenCalled();
+  });
+
+  test('slug가 null이면 아무 동작 안 함', () => {
+    renderHook(() => useViewCount(null));
+    expect(incrementViewCount).not.toHaveBeenCalled();
+  });
+
+  test('레이스 가드: 쿠키를 RPC 전에 set하므로 같은 글 재마운트 시 1회만 호출', () => {
+    // 첫 마운트가 쿠키를 set → 두 번째 마운트는 hasViewed=true로 RPC 차단.
+    renderHook(() => useViewCount('race-post'));
+    renderHook(() => useViewCount('race-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+  });
+
+  test('한글 slug도 쿠키 키 충돌 없이 1회 카운트', () => {
+    renderHook(() => useViewCount('번들러/소개'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+    expect(incrementViewCount).toHaveBeenCalledWith('번들러/소개');
+    // 다른 한글 slug는 별개 키라 영향 없음
+    renderHook(() => useViewCount('번들러/심화'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/blog/web/src/hooks/useViewCount.test.ts
+++ b/apps/blog/web/src/hooks/useViewCount.test.ts
@@ -57,4 +57,20 @@ describe('useViewCount', () => {
     renderHook(() => useViewCount('번들러/심화'));
     expect(incrementViewCount).toHaveBeenCalledTimes(2);
   });
+
+  test('RPC가 reject돼도 throw하지 않고, 쿠키 가드로 재마운트 시 재호출 안 함', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    incrementViewCount.mockRejectedValueOnce(new Error('rpc fail'));
+
+    renderHook(() => useViewCount('fail-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+
+    // 쿠키는 RPC 호출 *전*에 set되므로, reject돼도 재마운트는 차단된다.
+    renderHook(() => useViewCount('fail-post'));
+    expect(incrementViewCount).toHaveBeenCalledTimes(1);
+
+    // .catch(console.error)가 reject를 삼킨다(에러 전파 없음).
+    await vi.waitFor(() => expect(errSpy).toHaveBeenCalled());
+    errSpy.mockRestore();
+  });
 });

--- a/apps/blog/web/vitest.config.ts
+++ b/apps/blog/web/vitest.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
-    // tsconfig의 `@/* → ./*` 매핑을 vitest에도 동일 적용.
-    // 키에 트레일링 슬래시를 둬 `@testing-library/*`를 잘못 매칭하지 않게 함.
+    // tsconfig의 `@/* → ./*` 매핑을 vitest에도 동일 적용하는 프리픽스 alias.
+    // (키에 트레일링 슬래시를 둬 `@/foo`만 매칭하고 `@/`가 아닌 경로엔 닿지 않게 함)
     alias: {
       '@/': fileURLToPath(new URL('./', import.meta.url)),
     },

--- a/apps/blog/web/vitest.config.ts
+++ b/apps/blog/web/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+/**
+ * 컴포넌트/훅용 vitest 설정 (jsdom 환경).
+ *
+ * domain/lib/scripts의 순수 로직 테스트는 기존 `node --test`가 담당하고,
+ * vitest는 src/ 의 DOM 의존 컴포넌트·훅 테스트만 맡습니다(include 스코프로 분리).
+ * 두 러너는 `pnpm test`에서 순차 실행됩니다.
+ */
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    // tsconfig의 `@/* → ./*` 매핑을 vitest에도 동일 적용.
+    // 키에 트레일링 슬래시를 둬 `@testing-library/*`를 잘못 매칭하지 않게 함.
+    alias: {
+      '@/': fileURLToPath(new URL('./', import.meta.url)),
+    },
+  },
+});

--- a/apps/blog/web/vitest.setup.ts
+++ b/apps/blog/web/vitest.setup.ts
@@ -1,2 +1,9 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
 // @testing-library/jest-dom 매처(toBeInTheDocument 등)를 vitest expect에 등록.
 import '@testing-library/jest-dom/vitest';
+
+// RTL은 전역 afterEach가 있을 때만 cleanup을 자동 등록한다(globals:false라 수동 연결).
+// 테스트 간 마운트된 훅/컴포넌트가 unmount되도록 명시적으로 cleanup을 건다.
+afterEach(cleanup);

--- a/apps/blog/web/vitest.setup.ts
+++ b/apps/blog/web/vitest.setup.ts
@@ -1,0 +1,2 @@
+// @testing-library/jest-dom 매처(toBeInTheDocument 등)를 vitest expect에 등록.
+import '@testing-library/jest-dom/vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,18 @@ importers:
       '@pandacss/dev':
         specifier: 'catalog:'
         version: 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.3.0-canary-a757cb76-20251002(react@19.3.0-canary-a757cb76-20251002))(react@19.3.0-canary-a757cb76-20251002)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -179,6 +191,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.2.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.3))
       c8:
         specifier: ^11.0.0
         version: 11.0.0
@@ -194,6 +209,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
         version: 7.0.1(eslint@9.39.4(jiti@2.4.2))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       supabase:
         specifier: ^2.70.5
         version: 2.88.1
@@ -203,6 +221,9 @@ importers:
       typescript:
         specifier: catalog:typescript5
         version: 5.8.3
+      vitest:
+        specifier: ^4.0.0-beta.15
+        version: 4.1.4(@types/node@25.9.1)(jsdom@29.1.1)(msw@2.13.2(@types/node@25.9.1)(typescript@5.8.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.4.2)(tsx@4.22.3))
 
   apps/next.js:
     dependencies:
@@ -406,7 +427,7 @@ importers:
     devDependencies:
       '@pandacss/dev':
         specifier: 'catalog:'
-        version: 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+        version: 1.11.1(typescript@5.8.3)
       '@types/react':
         specifier: catalog:react19
         version: 19.2.15
@@ -524,10 +545,6 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -568,10 +585,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -5833,7 +5846,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.4
+      lru-cache: 11.5.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5863,12 +5876,6 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5890,7 +5897,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5935,8 +5942,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -5976,7 +5981,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6711,6 +6716,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@pandacss/dev@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@clack/prompts': 0.11.0
+      '@pandacss/config': 1.11.1
+      '@pandacss/logger': 1.11.1
+      '@pandacss/mcp': 1.11.1(typescript@5.8.3)
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
+      '@pandacss/postcss': 1.11.1(typescript@5.8.3)
+      '@pandacss/preset-base': 1.11.1
+      '@pandacss/preset-panda': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      cac: 6.7.14
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - jsdom
+      - supports-color
+      - typescript
+
   '@pandacss/extractor@1.11.1(jsdom@27.4.0)(typescript@5.8.3)':
     dependencies:
       '@pandacss/shared': 1.11.1
@@ -6724,6 +6749,15 @@ snapshots:
     dependencies:
       '@pandacss/shared': 1.11.1
       ts-evaluator: 1.2.0(jsdom@29.1.1)(typescript@5.8.3)
+      ts-morph: 28.0.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/extractor@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/shared': 1.11.1
+      ts-evaluator: 1.2.0(jsdom@27.4.0)(typescript@5.8.3)
       ts-morph: 28.0.0
     transitivePeerDependencies:
       - jsdom
@@ -6771,6 +6805,21 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
       '@pandacss/logger': 1.11.1
       '@pandacss/node': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - jsdom
+      - supports-color
+      - typescript
+
+  '@pandacss/mcp@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@clack/prompts': 0.11.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.2.1)
+      '@pandacss/logger': 1.11.1
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
       '@pandacss/token-dictionary': 1.11.1
       '@pandacss/types': 1.11.1
       zod: 4.2.1
@@ -6856,6 +6905,44 @@ snapshots:
       - jsdom
       - typescript
 
+  '@pandacss/node@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/config': 1.11.1
+      '@pandacss/core': 1.11.1
+      '@pandacss/generator': 1.11.1
+      '@pandacss/logger': 1.11.1
+      '@pandacss/parser': 1.11.1(typescript@5.8.3)
+      '@pandacss/plugin-lightningcss': 1.11.1
+      '@pandacss/plugin-svelte': 1.11.1
+      '@pandacss/plugin-vue': 1.11.1
+      '@pandacss/reporter': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/token-dictionary': 1.11.1
+      '@pandacss/types': 1.11.1
+      browserslist: 4.28.1
+      chokidar: 4.0.3
+      fast-glob: 3.3.3
+      fs-extra: 11.3.2
+      get-tsconfig: 4.13.0
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lodash.merge: 4.6.2
+      look-it-up: 2.1.0
+      outdent: 0.8.0
+      p-limit: 5.0.0
+      package-manager-detector: 1.6.0
+      perfect-debounce: 1.0.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.0
+      pluralize: 8.0.0
+      postcss: 8.5.14
+      prettier: 3.2.5
+      ts-morph: 28.0.0
+      ts-pattern: 5.9.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
   '@pandacss/parser@1.11.1(jsdom@27.4.0)(typescript@5.8.3)':
     dependencies:
       '@pandacss/config': 1.11.1
@@ -6875,6 +6962,20 @@ snapshots:
       '@pandacss/config': 1.11.1
       '@pandacss/core': 1.11.1
       '@pandacss/extractor': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      '@pandacss/logger': 1.11.1
+      '@pandacss/shared': 1.11.1
+      '@pandacss/types': 1.11.1
+      ts-morph: 28.0.0
+      ts-pattern: 5.9.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/parser@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/config': 1.11.1
+      '@pandacss/core': 1.11.1
+      '@pandacss/extractor': 1.11.1(typescript@5.8.3)
       '@pandacss/logger': 1.11.1
       '@pandacss/shared': 1.11.1
       '@pandacss/types': 1.11.1
@@ -6913,6 +7014,14 @@ snapshots:
   '@pandacss/postcss@1.11.1(jsdom@29.1.1)(typescript@5.8.3)':
     dependencies:
       '@pandacss/node': 1.11.1(jsdom@29.1.1)(typescript@5.8.3)
+      postcss: 8.5.14
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+
+  '@pandacss/postcss@1.11.1(typescript@5.8.3)':
+    dependencies:
+      '@pandacss/node': 1.11.1(typescript@5.8.3)
       postcss: 8.5.14
     transitivePeerDependencies:
       - jsdom
@@ -7162,7 +7271,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -9246,7 +9355,7 @@ snapshots:
 
   html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.9.0
+      '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
 


### PR DESCRIPTION
## 개요

블로그 아키텍처 하드닝 **4단계(PR4)** — DOM 의존 훅/컴포넌트를 테스트할 수 있는 **두 번째 러너(vitest+jsdom+RTL)**를 도입합니다.

> **스택**: [#118](https://github.com/Han5991/fe-lab/pull/118) → [#119](https://github.com/Han5991/fe-lab/pull/119) → [#120](https://github.com/Han5991/fe-lab/pull/120) 위에 쌓입니다. base가 `test/blog-domain-coverage`라 PR3 머지 후 자동 retarget.

## 러너 분리

| 러너 | 대상 |
|------|------|
| `node --test` (기존) | domain/lib/scripts 순수 로직 |
| **vitest (jsdom)** (신규) | src/ DOM 의존 훅·컴포넌트 |

`pnpm test` = `test:node && test:vitest`로 둘 다 실행. vitest는 react/next.js와 **동일 버전(vitest@4, @testing-library, jsdom@29)으로 정렬**해 모노레포 의존성 분기를 방지.

## 인프라

- `vitest.config.ts`: jsdom 환경, `include: src/**/*.test.{ts,tsx}`(node:test 파일과 분리), tsconfig의 `@/*` alias 동일 적용(키 트레일링 슬래시로 `@testing-library/*` 오매칭 방지).
- `vitest.setup.ts`: jest-dom 매처 등록.

## 훅 테스트 (vitest + RTL)

- **useRecentViews (10)**: `getRecentViews`(손상 JSON/비배열/유효성 필터), `recordRecentView`(dedup·MAX=5·최신순), `useRecordRecentView`(마운트 기록/null skip).
- **useViewCount (5)**: 첫 조회 RPC+쿠키 set, 재방문 차단, null skip, **레이스 가드**(쿠키를 RPC 전 set), 한글 slug 충돌 없음. `incrementViewCount`는 `vi.mock`.

## 순수 헬퍼 추출

- `msUntilKSTMidnight`를 `useAnalyticsOverview`(훅)에서 `lib/dates`로 추출+export → `now` 주입으로 결정적 경계 테스트(23:00/00:01/자정 정각) 3건(node --test).

## 검증

- ✅ `pnpm test`: **node --test 287(+3) + vitest 15 = 302** 통과
- ✅ 전체 모노레포 `pnpm test` 8/8 (react·next.js·blog)
- ✅ `pnpm check-types` / `pnpm lint`(0/0) / `pnpm format:check` 통과

## 후속

- `useAdminViews` joinPostStats 추출+테스트, `SearchDialog` escapeRegex/pickContentSnippet 추출, 컴포넌트 렌더 테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
