### PR TITLE
test(blog): 예약 발행(scheduled) 경계 결정적 테스트 + now 주입

### DIFF
--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -66,10 +66,12 @@ test('contract: 모든 글은 readMin >= 1', () => {
 test('contract: 공개 글(getAllPosts)은 isPostVisible 기준 일치 (slug 집합 비교)', () => {
   // count만 비교하면 "잘못된 글이 잘못된 글로 대체"되는 필터 버그를 놓침.
   // slug 집합을 정렬해서 deepEqual로 비교해야 실제 동등성을 검증할 수 있음.
+  // now를 고정 주입해 두 평가 사이에 scheduled 경계가 교차하는 플레이크를 제거.
+  const now = new Date();
   const all = getAllPostsIncludingHidden();
-  const visible = getAllPosts();
+  const visible = getAllPosts(now);
   const expected = all.filter(p =>
-    isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }),
+    isPostVisible({ status: p.status, scheduledDate: p.scheduledDate }, now),
   );
   const visibleSlugs = visible.map(p => p.slug).sort();
   const expectedSlugs = expected.map(p => p.slug).sort();

--- a/apps/blog/web/domain/post/service.ts
+++ b/apps/blog/web/domain/post/service.ts
@@ -20,10 +20,10 @@ function toPostSummary(post: PostData): PostSummary {
 /**
  * 공개된 포스트만 반환합니다 (published, 일정 지난 scheduled 포함).
  */
-export function getAllPosts(): PostData[] {
-  // 화살표로 감싸 isPostVisible의 2번째 인자에 Array.filter의 index가
-  // now로 잘못 주입되는 것을 막는다(index 주입 시 scheduled가 항상 비공개됨).
-  return readAllPosts().filter(post => isPostVisible(post));
+export function getAllPosts(now: Date = new Date()): PostData[] {
+  // 화살표로 감싸 Array.filter의 index가 isPostVisible의 now에 주입되는 것을 방지.
+  // now는 주입 가능(기본 빌드 시각) — 테스트가 고정 시각으로 경계를 검증할 수 있음.
+  return readAllPosts().filter(post => isPostVisible(post, now));
 }
 
 /**

--- a/apps/blog/web/domain/post/service.ts
+++ b/apps/blog/web/domain/post/service.ts
@@ -21,7 +21,9 @@ function toPostSummary(post: PostData): PostSummary {
  * 공개된 포스트만 반환합니다 (published, 일정 지난 scheduled 포함).
  */
 export function getAllPosts(): PostData[] {
-  return readAllPosts().filter(isPostVisible);
+  // 화살표로 감싸 isPostVisible의 2번째 인자에 Array.filter의 index가
+  // now로 잘못 주입되는 것을 막는다(index 주입 시 scheduled가 항상 비공개됨).
+  return readAllPosts().filter(post => isPostVisible(post));
 }
 
 /**

--- a/apps/blog/web/domain/post/visibility.test.ts
+++ b/apps/blog/web/domain/post/visibility.test.ts
@@ -51,41 +51,78 @@ test('알 수 없는 status는 비공개', () => {
   assert.equal(isPostVisible({ status: 'unknown-value' }), false);
 });
 
-// --- KST 날짜 파싱 회귀 테스트 ---
-// 'YYYY-MM-DD' 형식의 scheduledDate는 KST 자정 기준으로 공개 여부가 결정됩니다.
-// JS Date 기본 동작(UTC 자정)으로 파싱하면 KST 기준보다 9시간 빨리 공개되는 버그.
+// --- 예약 발행(scheduled) 경계 — now 주입으로 결정적 검증 ---
+// 'YYYY-MM-DD' scheduledDate는 KST 자정 기준으로 공개됩니다. UTC 자정으로 파싱하면
+// KST보다 9시간 빨리 공개되는 버그(commit 0e2df5a 클래스)가 됩니다.
+// 이전 테스트는 6년 이상 떨어진 날짜를 써서 9시간 shift를 실제로 구분하지 못했으나
+// (KST/UTC 어느 쪽이든 결과 동일), now를 주입해 경계를 정확히 잠급니다.
 
-test('scheduled: YYYY-MM-DD — KST 자정 직후(= UTC 전날 15:00:01)면 공개', () => {
-  // scheduledDate는 YYYY-MM-DD 형식으로 KST 날짜를 전달합니다.
-  // 테스트에서는 현재 시각을 제어할 수 없으므로 이미 지난 과거 KST 날짜로 검증합니다.
-  // (KST 자정 = UTC 전날 15:00이므로, 충분히 지난 날짜라면 항상 공개여야 합니다.)
-  const pastKSTDate = '2020-01-01'; // 이미 지난 날짜
-  assert.equal(
-    isPostVisible({ status: 'scheduled', scheduledDate: pastKSTDate }),
-    true,
-    'KST 기준 과거 날짜는 공개여야 함',
-  );
-});
+const SCHEDULED_KST_DATE = '2026-05-24'; // KST 2026-05-24 00:00 = UTC 2026-05-23 15:00
 
-test('scheduled: YYYY-MM-DD — 오늘 이후 KST 날짜이면 비공개', () => {
-  const futureKSTDate = '2099-12-31'; // 충분히 미래 날짜
+test('scheduled(YYYY-MM-DD): KST 자정 직전이면 비공개', () => {
+  const justBefore = new Date('2026-05-23T14:59:59Z'); // KST 2026-05-23 23:59:59
   assert.equal(
-    isPostVisible({ status: 'scheduled', scheduledDate: futureKSTDate }),
+    isPostVisible(
+      { status: 'scheduled', scheduledDate: SCHEDULED_KST_DATE },
+      justBefore,
+    ),
     false,
-    'KST 기준 미래 날짜는 비공개여야 함',
   );
 });
 
-test('scheduled: YYYY-MM-DD는 UTC 자정이 아닌 KST 자정 기준 — 9시간 shift 버그 없음', () => {
-  // UTC 자정으로 파싱하면 KST 2026-05-24는 UTC 2026-05-24 00:00:00 으로 해석됨.
-  // 하지만 실제로는 KST 자정(UTC 2026-05-23 15:00:00)이어야 합니다.
-  // 이 테스트는 UTC 2026-05-23 15:00:00 ~ UTC 2026-05-24 00:00:00 사이에
-  // 실행하면 두 해석의 차이가 드러나지만, 과거/미래 날짜로 우회합니다.
-  // 핵심: parseScheduledDateKST가 사용되는 한 이 테스트는 항상 통과합니다.
-  const pastKSTDate = '2000-06-15';
-  const result = isPostVisible({
-    status: 'scheduled',
-    scheduledDate: pastKSTDate,
-  });
-  assert.equal(result, true, '과거 KST 날짜(YYYY-MM-DD)는 항상 공개여야 함');
+test('scheduled(YYYY-MM-DD): KST 자정 정각이면 공개 (<= 경계)', () => {
+  const atMidnight = new Date('2026-05-23T15:00:00Z');
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate: SCHEDULED_KST_DATE },
+      atMidnight,
+    ),
+    true,
+  );
+});
+
+test('scheduled(YYYY-MM-DD): KST 자정 직후면 공개', () => {
+  const justAfter = new Date('2026-05-23T15:00:01Z');
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate: SCHEDULED_KST_DATE },
+      justAfter,
+    ),
+    true,
+  );
+});
+
+test('scheduled(YYYY-MM-DD): 9시간 shift 판별 — UTC 자정 파싱으로 회귀하면 깨지는 시점', () => {
+  // now = UTC 2026-05-23 16:00 = KST 2026-05-24 01:00 (KST 자정은 이미 지남).
+  // 올바른 KST 파싱: scheduled(UTC 15:00) <= now(16:00) → 공개.
+  // (버그) UTC 자정 파싱: scheduled가 UTC 2026-05-24 00:00이 되어 now보다 미래 → 비공개.
+  // 즉 parseScheduledDateKST가 UTC로 회귀하면 이 단언이 false가 되어 실패한다.
+  const kstAfterMidnight = new Date('2026-05-23T16:00:00Z');
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate: SCHEDULED_KST_DATE },
+      kstAfterMidnight,
+    ),
+    true,
+    'KST 자정 지난 시점에는 공개여야 함 (UTC 파싱 회귀 시 비공개로 깨짐)',
+  );
+});
+
+test('scheduled(offset 명시 +09:00): 해당 instant 경계로 판단', () => {
+  // '2026-05-24T09:00:00+09:00' = UTC 2026-05-24 00:00:00
+  const scheduledDate = '2026-05-24T09:00:00+09:00';
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate },
+      new Date('2026-05-23T23:59:59Z'),
+    ),
+    false,
+  );
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate },
+      new Date('2026-05-24T00:00:01Z'),
+    ),
+    true,
+  );
 });

--- a/apps/blog/web/domain/post/visibility.test.ts
+++ b/apps/blog/web/domain/post/visibility.test.ts
@@ -121,8 +121,34 @@ test('scheduled(offset 명시 +09:00): 해당 instant 경계로 판단', () => {
   assert.equal(
     isPostVisible(
       { status: 'scheduled', scheduledDate },
+      new Date('2026-05-24T00:00:00Z'), // 정각 == instant, <= 경계
+    ),
+    true,
+  );
+  assert.equal(
+    isPostVisible(
+      { status: 'scheduled', scheduledDate },
       new Date('2026-05-24T00:00:01Z'),
     ),
     true,
+  );
+});
+
+test('비-scheduled status는 now 주입과 무관 (회귀 가드)', () => {
+  const farPast = new Date('2000-01-01T00:00:00Z');
+  const farFuture = new Date('2099-01-01T00:00:00Z');
+  // published는 now·scheduledDate와 무관하게 항상 공개
+  assert.equal(
+    isPostVisible(
+      { status: 'published', scheduledDate: '2099-12-31' },
+      farPast,
+    ),
+    true,
+  );
+  assert.equal(isPostVisible({ status: 'published' }, farFuture), true);
+  // draft는 now·scheduledDate와 무관하게 항상 비공개
+  assert.equal(
+    isPostVisible({ status: 'draft', scheduledDate: '2000-01-01' }, farFuture),
+    false,
   );
 });

--- a/apps/blog/web/domain/post/visibility.ts
+++ b/apps/blog/web/domain/post/visibility.ts
@@ -10,6 +10,9 @@ import { parseScheduledDateKST } from '../../lib/dates';
  *
  * scheduledDate가 'YYYY-MM-DD' 형식이면 KST 자정으로 해석합니다.
  * (JS Date 기본 동작은 UTC 자정 → KST 기준으로 9시간 빨리 공개되는 버그)
+ *
+ * @param now 기준 시각. 프로덕션은 빌드 시각(기본 new Date())을 쓰고,
+ *            테스트는 경계를 결정적으로 검증하기 위해 주입합니다.
  */
 export interface VisibilityData {
   status?: string;
@@ -17,7 +20,10 @@ export interface VisibilityData {
   published?: boolean;
 }
 
-export function isPostVisible(data: VisibilityData): boolean {
+export function isPostVisible(
+  data: VisibilityData,
+  now: Date = new Date(),
+): boolean {
   if (!data.status) {
     return data.published === true;
   }
@@ -30,7 +36,7 @@ export function isPostVisible(data: VisibilityData): boolean {
     case 'scheduled': {
       if (typeof data.scheduledDate !== 'string') return false;
       // 'YYYY-MM-DD' 형식은 KST 자정으로 파싱 (UTC 자정 대신)
-      return parseScheduledDateKST(data.scheduledDate) <= new Date();
+      return parseScheduledDateKST(data.scheduledDate) <= now;
     }
     default:
       return false;


### PR DESCRIPTION
## 개요

**예약 발행(scheduled) 기능을 검증하고, 경계를 결정적으로 테스트**합니다.

## 🔎 검증 결과 (기능 정상)

| 항목 | 결과 |
|---|---|
| **일일 cron 빌드** (`deploy-blog.yml` `'0 9 * * *'` + `timezone: Asia/Seoul`) | ✅ 최근 schedule 런 **7건 모두 success**, 발화 ~00:00 UTC = **KST 09:00** (런 기록으로 timezone 적용 확인) |
| **visibility 로직** (`isPostVisible` scheduled 분기) | ✅ `parseScheduledDateKST(scheduledDate) <= now` — KST 자정 기준 정확 |
| **빌드 산출물 제외** (미래 scheduled가 sitemap에 없음) | ✅ `contract.test`가 실제 글로 이미 보장 |
| **validate-posts** (offset 없는 scheduledDate 차단) | ✅ #122에서 테스트됨 |

## 리팩터

- **`isPostVisible(data, now = new Date())`** — `now` 주입 파라미터 추가(프로덕션은 빌드 시각). KST 자정 경계를 결정적으로 테스트 가능.
- **`getAllPosts`**: `filter(isPostVisible)` → `filter(p => isPostVisible(p))`. `Array.filter`의 index가 `now`로 잘못 주입되면 **scheduled가 영영 비공개**되는 함정을 차단(이제 시그니처상 `filter(isPostVisible)`는 타입 에러로도 잡힘).

## 테스트 (`visibility.test.ts` 교체/추가)

- KST 자정 **직전(비공개) / 정각(`<=` 공개) / 직후(공개)** 경계
- **9시간 shift 판별** 🎯: `now = UTC 16:00`(= KST 익일 01:00)에서 `'YYYY-MM-DD'`가 공개여야 함 — **UTC 자정 파싱으로 회귀하면 비공개가 되어 실패하는** 진짜 차별 테스트. (이전 6년 간격 테스트는 KST/UTC 결과가 같아 shift를 못 잡던 것을 교체)
- offset 명시(`+09:00`) instant 경계

## 검증
- ✅ `pnpm test`: node **352 → 354** + vitest 38, 전부 통과
- ✅ `check-types`(service.ts filter) / `lint`(0/0) / `format` 통과
- ✅ `pnpm lint:posts` 정상(예약글 검증 게이트 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
