### PR TITLE
fix: 루트 도메인 리디렉션 404 수정 + 블로그 SEO 개선

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(mkdir:*)",
       "WebFetch(domain:github.com)",
       "Bash(pnpm tsc:*)",
-      "Bash(pnpm test:*)"
+      "Bash(pnpm test:*)",
+      "Bash(/usr/bin/git status *)",
+      "Bash(/usr/bin/git diff *)"
     ],
     "deny": []
   }

--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: pr-fix
+description: Address all PR review comments end-to-end — fetch every comment without truncation, fix each (adding regression tests for bugs), run the full test/lint/typecheck suite, adversarially self-review the diff, and produce clean separated commits. Use when working through reviewer or bot feedback on a pull request.
+---
+
+# /pr-fix
+
+Standard loop for turning a reviewed PR into a green, merge-ready state. Encodes the
+adversarial-review-before-commit routine so it doesn't have to be re-explained each session.
+
+## 1. Fetch ALL review comments (no truncation)
+
+- Pull the **complete** set into a file — review comments, review-thread comments, AND issue
+  comments. **Never** pipe to `head`/`tail` (the user's shell also mangles pipes — see CLAUDE.md
+  Shell Environment). A past session silently dropped ~22 comments to a `head -200`.
+- Print the **total count** and confirm nothing was truncated before you start fixing.
+- Write to a file, then read it back:
+  - `gh pr view <num> --json comments,reviews,reviewThreads > /tmp/pr-meta.json`
+  - `gh api repos/{owner}/{repo}/pulls/<num>/comments --paginate > /tmp/pr-review-comments.json`
+
+## 2. Address each comment
+
+- Make the change for every actionable comment.
+- When a comment describes a bug, write a **failing regression test first**, then fix until green.
+- Keep a checklist of addressed vs. intentionally-declined comments (with a reason to reply with).
+
+## 3. Verify
+
+- Run the full relevant **test suite + lint + typecheck**.
+- Verify **every** sibling/fixture file you touched — do not generalize from one. Past "fixes"
+  broke tests (ENOENT, snapshot drift, suite-end vs suite-start timestamps).
+
+## 4. Adversarial self-review
+
+- Re-read your own diff hunting for regressions, missing edge cases, broken snapshots/fixtures —
+  not just a sanity pass. Consider spawning a dedicated reviewer subagent.
+- Fix anything found, then re-run step 3.
+
+## 5. Commit cleanly
+
+- Make **clean, separated commits** grouped by concern.
+- Use `git commit -F <file>` or multiple `-m` flags — **not heredocs** (the shell wraps them).
+- Do **NOT** force-push, delete branches, or rewrite history without explicit approval (the global
+  git-guard hook will also prompt on these).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,51 @@ The enhanced prompts will follow the language of the original prompt (e.g., Kore
 output Korean prompt enhancements, English prompt input will output English prompt enhancements,
 etc.)
 
+## Working Notes for Claude
+
+Operational lessons from past sessions. Follow these to avoid repeated friction.
+
+### Shell Environment
+
+The user's interactive shell runs **scm_breeze + zsh plugins that wrap and sometimes intercept
+`git`, `grep`, `ls`, `cat`, `rm`** and mangle heredocs, pipes, and escapes. Therefore:
+
+- **Commits**: never use heredocs for commit messages — use `git commit -F <file>` or multiple
+  `-m` flags.
+- **Full output matters**: do not pipe to `head`/`tail` when you need the complete result (e.g. PR
+  review comments). Write to a file, then read/count it. A past session silently dropped ~22 review
+  comments to a `head -200`.
+- **Intercepted builtins**: if `ls`/`cat`/`grep`/`git` fail oddly (e.g. exit 127), re-run with
+  `command ls`, `command grep`, or the absolute binary (`/usr/bin/git`). Prefer the dedicated
+  Read/Grep/Glob tools over shell builtins.
+
+### TypeScript / Project Conventions
+
+This repo targets **TypeScript 6 semantics, not TS5.x**. Before explaining or relying on compiler
+behavior (default `types`, `rootDir`, `peerDependencies` promotion vs restore, etc.), **verify it
+against the actual tsconfig/source in this repo** — never carry over TS5 assumptions. Be precise
+about "add" vs "move" vs "promote" when describing dependency/catalog changes; confirm the intent
+rather than guessing.
+
+### Testing & Review
+
+Before committing PR fixes:
+
+1. Run an **adversarial self-review** of your own diff (hunt for regressions, edge cases, broken
+   snapshots/fixtures) — not just a sanity pass. Consider a dedicated reviewer subagent.
+2. Run the **full relevant test suite + lint + typecheck**, and verify **every** sibling/fixture
+   file you touched rather than generalizing from one — past "fixes" broke tests (ENOENT, snapshot
+   drift, suite-end vs suite-start timestamps) that only adversarial review caught.
+3. Produce **clean, separated commits**.
+
+See the `/pr-fix` skill for the full reviewed-PR loop.
+
+### Response Style
+
+When output would be large, chunk it and summarize rather than dumping everything in one message.
+Prefer writing big intermediate results (logs, full comment lists, diffs) to a file and reporting
+the key findings.
+
 ## Repository Overview
 
 This is a Turborepo monorepo containing multiple frontend applications and shared packages for

--- a/apps/blog/web/domain/post/assetUrl.test.ts
+++ b/apps/blog/web/domain/post/assetUrl.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { resolvePostAssetUrl } from './assetUrl';
+
+test('절대 URL(https/data)은 그대로 반환', () => {
+  assert.equal(
+    resolvePostAssetUrl('https://example.com/x.png', 'dir'),
+    'https://example.com/x.png',
+  );
+  assert.equal(
+    resolvePostAssetUrl('data:image/png;base64,AAA', 'dir'),
+    'data:image/png;base64,AAA',
+  );
+});
+
+test('protocol-relative(//)와 앵커(#)는 그대로 반환', () => {
+  assert.equal(
+    resolvePostAssetUrl('//cdn.example.com/x.png'),
+    '//cdn.example.com/x.png',
+  );
+  assert.equal(resolvePostAssetUrl('#section', 'dir'), '#section');
+});
+
+test('루트 경로(/...)는 그대로 반환', () => {
+  assert.equal(
+    resolvePostAssetUrl('/posts/x/pic.png', 'ignored'),
+    '/posts/x/pic.png',
+  );
+});
+
+test('상대 경로 + relativeDir → /posts/{dir}/{file}', () => {
+  assert.equal(
+    resolvePostAssetUrl('./pic.png', 'series-a'),
+    '/posts/series-a/pic.png',
+  );
+  assert.equal(
+    resolvePostAssetUrl('img/start.png', 'feconf'),
+    '/posts/feconf/img/start.png',
+  );
+});
+
+test('루트 레벨 포스트(relativeDir 없음)도 /posts/ 프리픽스 유지', () => {
+  assert.equal(
+    resolvePostAssetUrl('./pnpm.img_1.png'),
+    '/posts/pnpm.img_1.png',
+  );
+  assert.equal(resolvePostAssetUrl('pnpm.img.png', ''), '/posts/pnpm.img.png');
+});
+
+test('한글/공백 relativeDir는 세그먼트별 percent-encoding', () => {
+  assert.equal(
+    resolvePostAssetUrl('./img.png', 'nextjs deploy'),
+    '/posts/nextjs%20deploy/img.png',
+  );
+  assert.equal(
+    resolvePostAssetUrl('./img.png', '회고'),
+    '/posts/%ED%9A%8C%EA%B3%A0/img.png',
+  );
+});

--- a/apps/blog/web/domain/post/assetUrl.ts
+++ b/apps/blog/web/domain/post/assetUrl.ts
@@ -1,0 +1,19 @@
+import { encodePostSlug } from './utils';
+
+/**
+ * 마크다운 본문 속 상대 URL(이미지 등)을 사이트 경로로 해석합니다.
+ * 사이트 렌더링(MarkdownImage)과 RSS 전문 렌더링(generate-rss)이 공유하는
+ * 단일 소스 — 두 곳의 경로 해석이 드리프트하지 않도록 여기서만 수정합니다.
+ *
+ * - 절대 URL(프로토콜·`//`), 앵커(`#`), 루트 경로(`/...`)는 그대로 반환
+ * - 상대 경로는 sync-posts가 복사하는 public/posts/ 기준으로 변환
+ *   (루트 레벨 포스트는 relativeDir가 없어도 `/posts/` 프리픽스 유지)
+ * - relativeDir는 한글/공백이 흔해 세그먼트별 percent-encoding.
+ *   파일명 부분은 markdown 파서(micromark)가 이미 인코딩하므로 그대로 둔다.
+ */
+export function resolvePostAssetUrl(url: string, relativeDir?: string): string {
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\/)/i.test(url)) return url;
+  const cleaned = url.replace(/^\.\//, '');
+  const prefix = relativeDir ? `${encodePostSlug(relativeDir)}/` : '';
+  return `/posts/${prefix}${cleaned}`;
+}

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -236,6 +236,53 @@ test('rss: 절대 URL 이미지는 그대로 유지', () => {
   assert.ok(xml.includes('src="https://example.com/x.png"'));
 });
 
+test('rss: 루트 레벨 포스트(relativeDir 없음) 이미지도 /posts/ 프리픽스 유지', () => {
+  // sync-posts는 posts/ 루트의 이미지를 public/posts/ 바로 아래로 복사한다.
+  // 예: 'pnpm 10 업그레이드' 글의 ./pnpm.img_1.png → /posts/pnpm.img_1.png
+  const xml = buildRssXml(
+    [makePost({ slug: 'a', content: '![img](./pnpm.img_1.png)' })],
+    OPTS,
+  );
+  assert.ok(xml.includes(`src="${SITE}/posts/pnpm.img_1.png"`));
+});
+
+test('rss: 한글/공백 relativeDir는 percent-encoding됨', () => {
+  const xml = buildRssXml(
+    [
+      makePost({
+        slug: 'a',
+        content: '![img](./pic.png)',
+        relativeDir: 'nextjs deploy',
+      }),
+    ],
+    OPTS,
+  );
+  assert.ok(xml.includes(`src="${SITE}/posts/nextjs%20deploy/pic.png"`));
+});
+
+test('rss: 하위 디렉토리 이미지 경로의 슬래시는 %2F로 인코딩되지 않고 보존', () => {
+  const xml = buildRssXml(
+    [
+      makePost({
+        slug: 'a',
+        content: '![img](img/start.png)',
+        relativeDir: 'feconf',
+      }),
+    ],
+    OPTS,
+  );
+  assert.ok(xml.includes(`src="${SITE}/posts/feconf/img/start.png"`));
+});
+
+test('renderContentHtml: 한글 경로는 단일 인코딩 (이중 인코딩 %25 없음)', () => {
+  const html = renderContentHtml('![img](./한글.png)', SITE, '회고');
+  assert.ok(
+    html.includes(`src="${SITE}/posts/%ED%9A%8C%EA%B3%A0/`),
+    `relativeDir가 인코딩되어야 함: ${html}`,
+  );
+  assert.ok(!html.includes('%25'), `이중 인코딩 감지: ${html}`);
+});
+
 test('renderContentHtml: 루트 상대 경로는 siteUrl만 prefix', () => {
   const html = renderContentHtml('![img](/posts/x/pic.png)', SITE, 'ignored');
   assert.ok(html.includes(`src="${SITE}/posts/x/pic.png"`));

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -288,6 +288,39 @@ test('renderContentHtml: 루트 상대 경로는 siteUrl만 prefix', () => {
   assert.ok(html.includes(`src="${SITE}/posts/x/pic.png"`));
 });
 
+test('renderContentHtml: <callout>은 blockquote + 라벨로 매핑', () => {
+  const html = renderContentHtml(
+    '<callout type="warning">조심하세요</callout>',
+    SITE,
+  );
+  assert.ok(html.includes('<blockquote>'), html);
+  assert.ok(html.includes('<strong>⚠️ Warning</strong>'), html);
+  assert.ok(html.includes('조심하세요'), html);
+  assert.ok(!html.includes('<callout'), 'raw callout 태그가 남으면 안 됨');
+});
+
+test('renderContentHtml: callout title 속성이 라벨을 대체', () => {
+  const html = renderContentHtml(
+    '<callout type="tip" title="꿀팁">내용</callout>',
+    SITE,
+  );
+  assert.ok(html.includes('<strong>💡 꿀팁</strong>'), html);
+});
+
+test('renderContentHtml: 알 수 없는 callout type은 info로 폴백', () => {
+  const html = renderContentHtml('<callout>내용</callout>', SITE);
+  assert.ok(html.includes('<strong>ℹ️ Info</strong>'), html);
+});
+
+test('renderContentHtml: <file-tree>는 pre로 매핑', () => {
+  const html = renderContentHtml(
+    '<file-tree>\nsrc/\n  index.ts\n</file-tree>',
+    SITE,
+  );
+  assert.ok(html.includes('<pre>'), html);
+  assert.ok(!html.includes('<file-tree'), 'raw file-tree 태그가 남으면 안 됨');
+});
+
 test('wrapCdata: ]]> 시퀀스는 CDATA 분할로 안전하게 처리', () => {
   const wrapped = wrapCdata('a]]>b');
   assert.equal(wrapped, '<![CDATA[a]]]]><![CDATA[>b]]>');

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { buildRssXml, escapeXml } from './generate-rss';
+import {
+  buildRssXml,
+  escapeXml,
+  renderContentHtml,
+  wrapCdata,
+} from './generate-rss';
 import type { RssPost } from './generate-rss';
 import { parseScheduledDateKST } from './lib/dates';
 
@@ -178,4 +183,65 @@ test('rss: excerpt가 있으면 <description> 추가, 없으면 생략', () => {
 test('rss: excerpt도 escape됨', () => {
   const xml = buildRssXml([makePost({ slug: 'a', excerpt: 'a & b' })], OPTS);
   assert.ok(xml.includes('<description>a &amp; b</description>'));
+});
+
+test('rss: content 네임스페이스 선언 포함', () => {
+  const xml = buildRssXml([], OPTS);
+  assert.ok(
+    xml.includes('xmlns:content="http://purl.org/rss/1.0/modules/content/"'),
+  );
+});
+
+test('rss: content가 있으면 content:encoded에 HTML 전문 포함', () => {
+  const xml = buildRssXml(
+    [makePost({ slug: 'a', content: '## 소제목\n\n본문 **강조** 텍스트' })],
+    OPTS,
+  );
+  assert.ok(xml.includes('<content:encoded><![CDATA['));
+  assert.ok(xml.includes('<h2>소제목</h2>'));
+  assert.ok(xml.includes('<strong>강조</strong>'));
+  assert.ok(xml.includes(']]></content:encoded>'));
+});
+
+test('rss: content 없으면 content:encoded 생략', () => {
+  const xml = buildRssXml([makePost({ slug: 'a' })], OPTS);
+  assert.ok(!xml.includes('<content:encoded>'));
+});
+
+test('rss: 상대 경로 이미지는 절대 URL로 변환', () => {
+  const xml = buildRssXml(
+    [
+      makePost({
+        slug: 'a',
+        content: '![스크린샷](./pic.png)',
+        relativeDir: 'series-a',
+      }),
+    ],
+    OPTS,
+  );
+  assert.ok(xml.includes(`src="${SITE}/posts/series-a/pic.png"`));
+});
+
+test('rss: 절대 URL 이미지는 그대로 유지', () => {
+  const xml = buildRssXml(
+    [
+      makePost({
+        slug: 'a',
+        content: '![외부](https://example.com/x.png)',
+        relativeDir: 'series-a',
+      }),
+    ],
+    OPTS,
+  );
+  assert.ok(xml.includes('src="https://example.com/x.png"'));
+});
+
+test('renderContentHtml: 루트 상대 경로는 siteUrl만 prefix', () => {
+  const html = renderContentHtml('![img](/posts/x/pic.png)', SITE, 'ignored');
+  assert.ok(html.includes(`src="${SITE}/posts/x/pic.png"`));
+});
+
+test('wrapCdata: ]]> 시퀀스는 CDATA 분할로 안전하게 처리', () => {
+  const wrapped = wrapCdata('a]]>b');
+  assert.equal(wrapped, '<![CDATA[a]]]]><![CDATA[>b]]>');
 });

--- a/apps/blog/web/generate-rss.test.ts
+++ b/apps/blog/web/generate-rss.test.ts
@@ -321,6 +321,27 @@ test('renderContentHtml: <file-tree>는 pre로 매핑', () => {
   assert.ok(!html.includes('<file-tree'), 'raw file-tree 태그가 남으면 안 됨');
 });
 
+test('renderContentHtml: javascript: 등 위험 프로토콜은 기본 sanitizer로 차단', () => {
+  const html = renderContentHtml('[클릭](javascript:alert(1))', SITE);
+  assert.ok(!html.includes('javascript:'), html);
+  // 허용 프로토콜(https)은 그대로 통과
+  const ok = renderContentHtml('[링크](https://example.com/)', SITE);
+  assert.ok(ok.includes('href="https://example.com/"'), ok);
+});
+
+test('rss: fullContentLimit 이후 글은 content:encoded 생략 (피드 크기 제한)', () => {
+  const posts = [
+    makePost({ slug: 'newest', content: '# 최신 글' }),
+    makePost({ slug: 'older', content: '# 옛날 글' }),
+  ];
+  const xml = buildRssXml(posts, { ...OPTS, fullContentLimit: 1 });
+  assert.equal((xml.match(/<content:encoded>/g) || []).length, 1);
+  // 최신(앞쪽) 글만 전문 포함, 이후 글은 item 자체는 유지
+  assert.ok(xml.includes('최신 글'));
+  assert.ok(!xml.includes('옛날 글'));
+  assert.equal((xml.match(/<item>/g) || []).length, 2);
+});
+
 test('wrapCdata: ]]> 시퀀스는 CDATA 분할로 안전하게 처리', () => {
   const wrapped = wrapCdata('a]]>b');
   assert.equal(wrapped, '<![CDATA[a]]]]><![CDATA[>b]]>');

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Markdown from 'react-markdown';
+import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from './lib/constants';
+import { resolvePostAssetUrl } from './domain/post/assetUrl';
 import { parseScheduledDateKST } from './lib/dates';
 import { getAllPosts } from './domain/post/service';
 import { encodePostSlug } from './domain/post/utils';
@@ -36,10 +37,45 @@ export type RssPost = Pick<
   relativeDir?: string;
 };
 
+const CALLOUT_META: Record<string, { icon: string; label: string }> = {
+  info: { icon: 'ℹ️', label: 'Info' },
+  tip: { icon: '💡', label: 'Tip' },
+  warning: { icon: '⚠️', label: 'Warning' },
+  danger: { icon: '🚨', label: 'Danger' },
+};
+
+/**
+ * 피드 리더에는 사이트의 스타일드 컴포넌트가 없으므로 커스텀 마크다운 헬퍼를
+ * 의미가 통하는 표준 HTML로 매핑한다 (사이트 쪽 매핑: PostClient.tsx의
+ * callout → Callout, file-tree → FileTree). figure는 표준 HTML이라 매핑 불필요.
+ */
+const FEED_COMPONENTS = {
+  callout: (props: { type?: string; title?: string; children?: ReactNode }) => {
+    const meta = CALLOUT_META[props.type ?? ''] ?? CALLOUT_META.info;
+    return createElement(
+      'blockquote',
+      null,
+      createElement(
+        'p',
+        null,
+        createElement(
+          'strong',
+          null,
+          `${meta.icon} ${props.title ?? meta.label}`,
+        ),
+      ),
+      props.children,
+    );
+  },
+  'file-tree': (props: { children?: ReactNode }) =>
+    createElement('pre', null, props.children),
+} as unknown as Components;
+
 /**
  * 마크다운 본문을 피드용 HTML로 렌더링합니다.
  * 사이트 렌더링과 동일한 스택(remark-gfm + rehype-raw)을 사용하되,
  * 피드 리더는 사이트 origin을 모르므로 상대 URL을 절대 URL로 변환합니다.
+ * 경로 해석은 사이트(MarkdownImage)와 공유하는 resolvePostAssetUrl 사용.
  */
 export function renderContentHtml(
   content: string,
@@ -52,16 +88,14 @@ export function renderContentHtml(
       {
         remarkPlugins: [remarkGfm],
         rehypePlugins: [rehypeRaw],
+        components: FEED_COMPONENTS,
         urlTransform: (url: string) => {
-          if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(url)) return url;
-          if (url.startsWith('/')) return `${siteUrl}${url}`;
-          const cleaned = url.replace(/^\.\//, '');
-          // sync-posts가 루트 레벨 포스트의 이미지도 public/posts/ 아래로 복사하므로
-          // relativeDir 유무와 무관하게 /posts/ 프리픽스는 항상 유지한다.
-          // 파일명 부분(cleaned)은 markdown 파서가 이미 percent-encoding하므로
-          // 우리 데이터인 relativeDir만 인코딩해 이중 인코딩을 피한다.
-          const prefix = relativeDir ? `${encodePostSlug(relativeDir)}/` : '';
-          return `${siteUrl}/posts/${prefix}${cleaned}`;
+          const resolved = resolvePostAssetUrl(url, relativeDir);
+          // 사이트 상대 경로(/posts/... 등)만 절대 URL로 승격.
+          // protocol-relative(//)는 이미 절대 URL이므로 제외.
+          return resolved.startsWith('/') && !resolved.startsWith('//')
+            ? `${siteUrl}${resolved}`
+            : resolved;
         },
       },
       content,

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -56,9 +56,12 @@ export function renderContentHtml(
           if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(url)) return url;
           if (url.startsWith('/')) return `${siteUrl}${url}`;
           const cleaned = url.replace(/^\.\//, '');
-          return relativeDir
-            ? `${siteUrl}/posts/${relativeDir}/${cleaned}`
-            : `${siteUrl}/${cleaned}`;
+          // sync-posts가 루트 레벨 포스트의 이미지도 public/posts/ 아래로 복사하므로
+          // relativeDir 유무와 무관하게 /posts/ 프리픽스는 항상 유지한다.
+          // 파일명 부분(cleaned)은 markdown 파서가 이미 percent-encoding하므로
+          // 우리 데이터인 relativeDir만 인코딩해 이중 인코딩을 피한다.
+          const prefix = relativeDir ? `${encodePostSlug(relativeDir)}/` : '';
+          return `${siteUrl}/posts/${prefix}${cleaned}`;
         },
       },
       content,

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from './lib/constants';
 import { parseScheduledDateKST } from './lib/dates';
 import { getAllPosts } from './domain/post/service';
@@ -21,7 +26,50 @@ export function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-export type RssPost = Pick<PostSummary, 'slug' | 'title' | 'date' | 'excerpt'>;
+export type RssPost = Pick<
+  PostSummary,
+  'slug' | 'title' | 'date' | 'excerpt'
+> & {
+  /** 마크다운 원문 — 있으면 content:encoded로 전문을 HTML 렌더링해 포함 */
+  content?: string;
+  /** 상대 경로 이미지(`./img.png`)를 절대 URL로 바꿀 때 쓰는 포스트 디렉토리 */
+  relativeDir?: string;
+};
+
+/**
+ * 마크다운 본문을 피드용 HTML로 렌더링합니다.
+ * 사이트 렌더링과 동일한 스택(remark-gfm + rehype-raw)을 사용하되,
+ * 피드 리더는 사이트 origin을 모르므로 상대 URL을 절대 URL로 변환합니다.
+ */
+export function renderContentHtml(
+  content: string,
+  siteUrl: string,
+  relativeDir?: string,
+): string {
+  return renderToStaticMarkup(
+    createElement(
+      Markdown,
+      {
+        remarkPlugins: [remarkGfm],
+        rehypePlugins: [rehypeRaw],
+        urlTransform: (url: string) => {
+          if (/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(url)) return url;
+          if (url.startsWith('/')) return `${siteUrl}${url}`;
+          const cleaned = url.replace(/^\.\//, '');
+          return relativeDir
+            ? `${siteUrl}/posts/${relativeDir}/${cleaned}`
+            : `${siteUrl}/${cleaned}`;
+        },
+      },
+      content,
+    ),
+  );
+}
+
+/** CDATA 종료 시퀀스(`]]>`)가 본문에 있어도 깨지지 않도록 분할 래핑 */
+export function wrapCdata(html: string): string {
+  return `<![CDATA[${html.replace(/\]\]>/g, ']]]]><![CDATA[>')}]]>`;
+}
 
 export interface RssBuildOptions {
   siteUrl?: string;
@@ -52,13 +100,13 @@ export function buildRssXml(
       <title>${escapeXml(post.title)}</title>
       <link>${siteUrl}/posts/${encodePostSlug(post.slug)}/</link>
       <guid isPermaLink="true">${siteUrl}/posts/${encodePostSlug(post.slug)}/</guid>
-      <pubDate>${post.date ? parseScheduledDateKST(post.date).toUTCString() : now.toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}
+      <pubDate>${post.date ? parseScheduledDateKST(post.date).toUTCString() : now.toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}${post.content ? `\n      <content:encoded>${wrapCdata(renderContentHtml(post.content, siteUrl, post.relativeDir))}</content:encoded>` : ''}
     </item>`,
     )
     .join('\n');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>${siteName} | ${siteDescription.split('。')[0]}</title>
     <link>${siteUrl}</link>

--- a/apps/blog/web/generate-rss.ts
+++ b/apps/blog/web/generate-rss.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Markdown, { type Components } from 'react-markdown';
+import Markdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION } from './lib/constants';
@@ -90,7 +90,12 @@ export function renderContentHtml(
         rehypePlugins: [rehypeRaw],
         components: FEED_COMPONENTS,
         urlTransform: (url: string) => {
-          const resolved = resolvePostAssetUrl(url, relativeDir);
+          // react-markdown 기본 sanitizer를 먼저 적용해 javascript: 등
+          // 위험 프로토콜 차단을 유지한다 (커스텀 transform은 기본값을 대체하므로
+          // 생략하면 sanitize가 사라짐 — defense in depth).
+          const safe = defaultUrlTransform(url);
+          if (!safe) return safe;
+          const resolved = resolvePostAssetUrl(safe, relativeDir);
           // 사이트 상대 경로(/posts/... 등)만 절대 URL로 승격.
           // protocol-relative(//)는 이미 절대 URL이므로 제외.
           return resolved.startsWith('/') && !resolved.startsWith('//')
@@ -108,12 +113,20 @@ export function wrapCdata(html: string): string {
   return `<![CDATA[${html.replace(/\]\]>/g, ']]]]><![CDATA[>')}]]>`;
 }
 
+/** content:encoded 전문을 포함할 최신 글 개수 — 피드 크기 무한 증가 방지 */
+const DEFAULT_FULL_CONTENT_LIMIT = 20;
+
 export interface RssBuildOptions {
   siteUrl?: string;
   siteName?: string;
   siteDescription?: string;
   /** lastBuildDate / pubDate fallback 시 사용 — 테스트에서 결정성 확보용 */
   now?: Date;
+  /**
+   * content:encoded를 포함할 앞쪽 아이템 수 (posts는 최신순 정렬 가정 —
+   * getAllPosts가 sortByDateDesc로 보장). 이후 글은 excerpt만 포함.
+   */
+  fullContentLimit?: number;
 }
 
 /**
@@ -129,15 +142,16 @@ export function buildRssXml(
     siteName = SITE_NAME,
     siteDescription = SITE_DESCRIPTION,
     now = new Date(),
+    fullContentLimit = DEFAULT_FULL_CONTENT_LIMIT,
   } = options;
 
   const rssItems = posts
     .map(
-      post => `    <item>
+      (post, index) => `    <item>
       <title>${escapeXml(post.title)}</title>
       <link>${siteUrl}/posts/${encodePostSlug(post.slug)}/</link>
       <guid isPermaLink="true">${siteUrl}/posts/${encodePostSlug(post.slug)}/</guid>
-      <pubDate>${post.date ? parseScheduledDateKST(post.date).toUTCString() : now.toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}${post.content ? `\n      <content:encoded>${wrapCdata(renderContentHtml(post.content, siteUrl, post.relativeDir))}</content:encoded>` : ''}
+      <pubDate>${post.date ? parseScheduledDateKST(post.date).toUTCString() : now.toUTCString()}</pubDate>${post.excerpt ? `\n      <description>${escapeXml(post.excerpt)}</description>` : ''}${post.content && index < fullContentLimit ? `\n      <content:encoded>${wrapCdata(renderContentHtml(post.content, siteUrl, post.relativeDir))}</content:encoded>` : ''}
     </item>`,
     )
     .join('\n');

--- a/apps/blog/web/src/app/about/page.tsx
+++ b/apps/blog/web/src/app/about/page.tsx
@@ -3,6 +3,7 @@ import { css } from '@design-system/ui-lib/css';
 import type { Metadata } from 'next';
 import {
   SITE_URL,
+  OG_DEFAULT_IMAGE,
   SITE_AUTHOR_GITHUB,
   SITE_AUTHOR_LINKEDIN,
 } from '@/lib/constants';
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
     siteName: 'Frontend Lab',
     images: [
       {
-        url: `${SITE_URL}/og-default.png`,
+        url: `${SITE_URL}${OG_DEFAULT_IMAGE}`,
         width: 1200,
         height: 630,
         alt: 'Frontend Lab Blog',
@@ -36,7 +37,7 @@ export const metadata: Metadata = {
     title: '소개 | Frontend Lab',
     description:
       '프론트엔드 엔지니어 한상욱(Sangwook Han). Mantine 27 PRs, Node.js 코어 기여, gemini-cli 74% 성능 개선. FEConf 2025 발표자.',
-    images: [`${SITE_URL}/og-default.png`],
+    images: [`${SITE_URL}${OG_DEFAULT_IMAGE}`],
   },
 };
 

--- a/apps/blog/web/src/app/about/page.tsx
+++ b/apps/blog/web/src/app/about/page.tsx
@@ -22,6 +22,21 @@ export const metadata: Metadata = {
       '프론트엔드 엔지니어 한상욱(Sangwook Han). Mantine 27 PRs, Node.js 코어 기여, gemini-cli 74% 성능 개선. FEConf 2025 발표자.',
     url: `${SITE_URL}/about/`,
     siteName: 'Frontend Lab',
+    images: [
+      {
+        url: `${SITE_URL}/og-default.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Frontend Lab Blog',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '소개 | Frontend Lab',
+    description:
+      '프론트엔드 엔지니어 한상욱(Sangwook Han). Mantine 27 PRs, Node.js 코어 기여, gemini-cli 74% 성능 개선. FEConf 2025 발표자.',
+    images: [`${SITE_URL}/og-default.png`],
   },
 };
 

--- a/apps/blog/web/src/app/admin/AdminLayoutClient.tsx
+++ b/apps/blog/web/src/app/admin/AdminLayoutClient.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
+import { Suspense } from 'react';
+import { css } from '@design-system/ui-lib/css';
+
+const AdminGuard = dynamic(
+  () => import('@/src/components/admin/AdminGuard').then(mod => mod.AdminGuard),
+  { ssr: false },
+);
+
+function AuthFallback() {
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minH: '[100vh]',
+      })}
+    >
+      <p>인증 확인 중...</p>
+    </div>
+  );
+}
+
+export function AdminLayoutClient({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isLoginPage =
+    pathname === '/admin/login' || pathname === '/admin/login/';
+
+  const content = isLoginPage ? children : <AdminGuard>{children}</AdminGuard>;
+
+  return <Suspense fallback={<AuthFallback />}>{content}</Suspense>;
+}

--- a/apps/blog/web/src/app/admin/layout.tsx
+++ b/apps/blog/web/src/app/admin/layout.tsx
@@ -1,40 +1,15 @@
-'use client';
+import type { Metadata } from 'next';
+import { AdminLayoutClient } from './AdminLayoutClient';
 
-import dynamic from 'next/dynamic';
-import { usePathname } from 'next/navigation';
-import { Suspense } from 'react';
-import { css } from '@design-system/ui-lib/css';
-
-const AdminGuard = dynamic(
-  () => import('@/src/components/admin/AdminGuard').then(mod => mod.AdminGuard),
-  { ssr: false },
-);
-
-function AuthFallback() {
-  return (
-    <div
-      className={css({
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        minH: '[100vh]',
-      })}
-    >
-      <p>인증 확인 중...</p>
-    </div>
-  );
-}
+// robots.txt의 Disallow는 크롤만 막고 색인은 막지 못하므로 noindex를 명시한다.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isLoginPage =
-    pathname === '/admin/login' || pathname === '/admin/login/';
-
-  const content = isLoginPage ? children : <AdminGuard>{children}</AdminGuard>;
-
-  return <Suspense fallback={<AuthFallback />}>{content}</Suspense>;
+  return <AdminLayoutClient>{children}</AdminLayoutClient>;
 }

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
@@ -87,7 +87,8 @@ describe('buildPostMetadata', () => {
     const og = buildPostMetadata(makePost({ date: '2025-01-02' }), 'a')
       .openGraph as Record<string, unknown>;
     expect(og.type).toBe('article');
-    expect(og.publishedTime).toBe('2025-01-02');
+    // JSON-LD의 datePublished와 동일한 KST ISO 8601 형식
+    expect(og.publishedTime).toBe('2025-01-02T00:00:00+09:00');
     expect(og.url).toBe('/posts/a/');
     const img = (og.images as Array<Record<string, unknown>>)[0];
     expect(img.width).toBe(1200);

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
@@ -58,6 +58,25 @@ describe('toKstIsoDate', () => {
     expect(toKstIsoDate(null)).toBeUndefined();
     expect(toKstIsoDate(undefined)).toBeUndefined();
   });
+
+  test('offset 포함 full-ISO는 suffix 없이 그대로 반환 (invalid ISO 방지)', () => {
+    // validate-posts가 권장하는 형식 — suffix를 덧붙이면
+    // '...+09:00T00:00:00+09:00' 같은 깨진 값이 됐던 회귀 케이스
+    expect(toKstIsoDate('2026-05-24T09:00:00+09:00')).toBe(
+      '2026-05-24T09:00:00+09:00',
+    );
+    expect(toKstIsoDate('2026-05-24T00:00:00Z')).toBe('2026-05-24T00:00:00Z');
+  });
+});
+
+describe('buildPostMetadata: full-ISO date', () => {
+  test('publishedTime도 full-ISO date를 그대로 사용', () => {
+    const og = buildPostMetadata(
+      makePost({ date: '2026-05-24T09:00:00+09:00' }),
+      'a',
+    ).openGraph as Record<string, unknown>;
+    expect(og.publishedTime).toBe('2026-05-24T09:00:00+09:00');
+  });
 });
 
 describe('countWords', () => {

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
@@ -37,11 +37,16 @@ export function buildDescription(
     : post.content;
 }
 
-/** 'YYYY-MM-DD' → KST ISO(`...T00:00:00+09:00`). null/undefined면 undefined. */
+/**
+ * 'YYYY-MM-DD' → KST ISO(`...T00:00:00+09:00`). null/undefined면 undefined.
+ * validate-posts가 권장하는 offset 포함 full-ISO(`2026-05-24T09:00:00+09:00`)는
+ * 이미 완전한 형식이므로 그대로 반환한다 (suffix를 덧붙이면 invalid ISO가 됨).
+ */
 export function toKstIsoDate(
   date: string | null | undefined,
 ): string | undefined {
-  return date ? `${date}T00:00:00+09:00` : undefined;
+  if (!date) return undefined;
+  return date.includes('T') ? date : `${date}T00:00:00+09:00`;
 }
 
 /** 마크다운 본문의 대략적 단어 수(JSON-LD wordCount용). 기호 제거 후 공백 분할. */

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
@@ -68,7 +68,8 @@ export function buildPostMetadata(post: SeoPost, slug: string): Metadata {
       url: `/posts/${slug}/`,
       siteName: 'Frontend Lab Blog',
       type: 'article',
-      publishedTime: post.date || undefined,
+      // JSON-LD(datePublished)와 동일하게 KST 기준 완전한 ISO 8601로 통일
+      publishedTime: toKstIsoDate(post.date),
       images: [
         {
           url: absoluteThumbnailUrl,

--- a/apps/blog/web/src/components/post/MarkdownImage.tsx
+++ b/apps/blog/web/src/components/post/MarkdownImage.tsx
@@ -3,6 +3,7 @@
 import { css } from '@design-system/ui-lib/css';
 import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
+import { resolvePostAssetUrl } from '@/domain/post/assetUrl';
 
 interface MarkdownImageProps {
   src?: string;
@@ -13,13 +14,10 @@ interface MarkdownImageProps {
 /**
  * Markdown 이미지 렌더러.
  * 상대 경로 이미지를 올바른 URL로 변환하고 Zoom 기능을 추가합니다.
+ * 경로 해석은 RSS 전문 렌더링과 공유하는 resolvePostAssetUrl 단일 소스를 사용.
  */
 export function MarkdownImage({ src, alt, relativeDir }: MarkdownImageProps) {
-  let imageSrc = src ?? '';
-
-  if (src && !src.startsWith('http') && !src.startsWith('/')) {
-    imageSrc = `/posts/${relativeDir}/${src}`;
-  }
+  const imageSrc = src ? resolvePostAssetUrl(src, relativeDir) : '';
 
   return (
     <Zoom>

--- a/apps/next.js/next.config.test.ts
+++ b/apps/next.js/next.config.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+// Next가 리디렉션을 실제로 매칭/컴파일할 때 쓰는 내부 유틸을 그대로 사용해
+// next.config 리디렉션 규칙의 동작을 잠근다. 과거 파일 경로에 후행 슬래시가
+// 붙어 sitemap.xml이 6개월간 404였던 회귀(Search Console 색인 실패)를 방지.
+import { getPathMatch } from 'next/dist/shared/lib/router/utils/path-match';
+import { prepareDestination } from 'next/dist/shared/lib/router/utils/prepare-destination';
+import nextConfig from './next.config';
+
+async function resolveRedirect(pathname: string): Promise<string | null> {
+  const redirects = await nextConfig.redirects!();
+  for (const rule of redirects) {
+    const matcher = getPathMatch(rule.source, {
+      removeUnnamedParams: true,
+      strict: true,
+    });
+    const params = matcher(pathname);
+    if (!params) continue;
+    const { newUrl, parsedDestination } = prepareDestination({
+      appendParamsToQuery: false,
+      destination: rule.destination,
+      params,
+      query: {},
+    });
+    return `${parsedDestination.protocol}//${parsedDestination.hostname}${newUrl}`;
+  }
+  return null;
+}
+
+describe('blog 리디렉션 규칙', () => {
+  test('루트는 blog 루트로', async () => {
+    expect(await resolveRedirect('/')).toBe('https://blog.sangwook.dev/');
+  });
+
+  test.each(['/sitemap.xml', '/robots.txt', '/rss.xml'])(
+    '루트 레벨 파일 %s 은 후행 슬래시 없이 전달 (GitHub Pages 404 방지)',
+    async path => {
+      expect(await resolveRedirect(path)).toBe(
+        `https://blog.sangwook.dev${path}`,
+      );
+    },
+  );
+
+  test('하위 경로 파일도 슬래시 인코딩(%2F) 없이 그대로 전달', async () => {
+    // gemini 리뷰 지적 케이스: 커스텀 정규식 param이 다중 세그먼트를 캡처할 때
+    // 목적지 컴파일에서 %2F로 인코딩되지 않는지 잠근다.
+    expect(await resolveRedirect('/assets/logo.png')).toBe(
+      'https://blog.sangwook.dev/assets/logo.png',
+    );
+    expect(await resolveRedirect('/posts/img/pic.png')).toBe(
+      'https://blog.sangwook.dev/posts/img/pic.png',
+    );
+  });
+
+  test('확장자 없는 일반 경로는 후행 슬래시를 붙여 전달', async () => {
+    expect(await resolveRedirect('/posts/some-post')).toBe(
+      'https://blog.sangwook.dev/posts/some-post/',
+    );
+    expect(await resolveRedirect('/about')).toBe(
+      'https://blog.sangwook.dev/about/',
+    );
+  });
+
+  test('파일 규칙이 catch-all 규칙보다 먼저 온다 (순서 회귀 방지)', async () => {
+    const redirects = await nextConfig.redirects!();
+    const fileRuleIdx = redirects.findIndex(r =>
+      r.source.includes('a-zA-Z0-9'),
+    );
+    const catchAllIdx = redirects.findIndex(r => r.source === '/:path+');
+    expect(fileRuleIdx).toBeGreaterThan(-1);
+    expect(catchAllIdx).toBeGreaterThan(-1);
+    expect(fileRuleIdx).toBeLessThan(catchAllIdx);
+  });
+});

--- a/apps/next.js/next.config.ts
+++ b/apps/next.js/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: '/:path(.+\\.[a-zA-Z0-9]+)',
+        destination: 'https://blog.sangwook.dev/:path',
+        permanent: true,
+      },
+      {
         source: '/:path+',
         destination: 'https://blog.sangwook.dev/:path+/',
         permanent: true,

--- a/apps/next.js/next.config.ts
+++ b/apps/next.js/next.config.ts
@@ -10,6 +10,13 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        // 파일 경로(sitemap.xml, robots.txt, 이미지 등)는 후행 슬래시 없이 전달 —
+        // GitHub Pages는 파일에 슬래시가 붙으면 404 (과거 6개월 색인 실패 원인).
+        // 주의: "마지막 세그먼트에 점이 있으면 파일"이라는 휴리스틱이므로
+        //  - 점 포함 슬러그(/vue-3.0 등)는 파일로 오분류되고
+        //  - 확장자 없는 well-known 파일(/.well-known/...)은 매칭되지 않는다.
+        // 현재 블로그 경로에는 둘 다 없음 — 해당 경로 도입 시 확장자 allowlist로
+        // 좁힐 것. 동작은 next.config.test.ts가 잠근다.
         source: '/:path(.+\\.[a-zA-Z0-9]+)',
         destination: 'https://blog.sangwook.dev/:path',
         permanent: true,


### PR DESCRIPTION
## 문제

Google Search Console에서 `https://sangwook.dev/`가 반년 이상 **"리디렉션 오류"**로 색인 실패 중이었습니다.

원인: `apps/next.js`의 리디렉션 규칙이 모든 경로에 후행 슬래시를 강제로 붙여서, 확장자가 있는 파일 경로가 깨졌습니다.

- `sangwook.dev/sitemap.xml` → 308 → `blog.sangwook.dev/sitemap.xml/` → **404**
- `robots.txt`, `rss.xml`도 동일 패턴으로 전부 404
- Google이 참조하는 사이트맵 경로가 계속 404라 색인 파이프라인이 막혀 있었음

## 수정

확장자가 있는 경로는 후행 슬래시 없이 전달하는 규칙을 기존 규칙 앞에 추가:

```ts
{
  source: '/:path(.+\\.[a-zA-Z0-9]+)',
  destination: 'https://blog.sangwook.dev/:path',
  permanent: true,
},
```

## 검증

로컬 `next build` + `next start`로 확인:

| 요청 | 리디렉션 결과 |
| :-- | :-- |
| `/sitemap.xml` | `blog.sangwook.dev/sitemap.xml` (슬래시 없음 → 200) ✅ |
| `/robots.txt` | `blog.sangwook.dev/robots.txt` ✅ |
| `/posts/some-post/` | `blog.sangwook.dev/posts/some-post/` ✅ |
| `/` | `blog.sangwook.dev/` ✅ |

## 함께 포함 — 블로그 SEO 개선 (점검 후속)

테크니컬 SEO 점검에서 나온 개선 사항 전부 적용:

1. **`/admin` noindex** — robots.txt `Disallow`는 크롤만 막고 색인은 못 막으므로 `robots: { index: false, follow: false }` 메타 추가 (layout을 서버 컴포넌트로 분리, 클라이언트 로직은 `AdminLayoutClient`로 이동)
2. **RSS 본문 전문 포함** — `content:encoded`(CDATA)로 마크다운을 HTML 렌더링해 포함. 사이트와 동일한 스택(react-markdown + remark-gfm + rehype-raw) 재사용, 상대 경로 이미지 → 절대 URL 변환. 테스트 8개 추가
3. **`article:published_time` ISO 통일** — JSON-LD의 `datePublished`와 동일한 KST ISO 8601(`2026-03-16T00:00:00+09:00`) 형식으로
4. **`/about` OG 이미지 + twitter card 추가**

검증: 테스트 490개 통과(신규 포함), lint/typecheck 클린, 프로덕션 빌드 후 `out/` 산출물에서 4가지 모두 반영 확인, rss.xml XML 유효성 검증 완료 (704K).

- CLAUDE.md 작업 노트, `.claude` 권한 설정, pr-fix 스킬 (별도 커밋)

## 리뷰 반영

- **회귀 테스트** (`next.config.test.ts`): Next 내부 매칭/컴파일 유틸로 리디렉션 동작 잠금 (claude 리뷰)
- **RSS 이미지 URL 버그 2건**: 루트 레벨 포스트 `/posts/` 프리픽스 유지 + `relativeDir` percent-encoding (claude 리뷰)
- **`toKstIsoDate` full-ISO 버그**: 'T' 포함 date에 suffix 중복 부착 방지 (claude 리뷰)
- **공용 헬퍼 추출**: `resolvePostAssetUrl`로 사이트/RSS 경로 해석 단일화 — 부수 효과로 사이트의 루트 포스트 이미지 경로도 정규화
- **RSS 커스텀 헬퍼 매핑**: `<callout>` → blockquote+라벨, `<file-tree>` → pre
- gemini의 `%2F` 인코딩 지적은 3중 검증(로컬/routes-manifest/Next 내부 유틸) 결과 재현 불가로 반려

## 머지 후 할 일 (Search Console)

1. Sitemaps에 `https://blog.sangwook.dev/sitemap.xml` 제출
2. `https://sangwook.dev/` 색인 생성 요청 → "페이지가 리디렉션됨"으로 바뀌면 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
