### PR TITLE
fix(blog): /posts/ 아카이브 프리렌더 링크 복구 + lastmod 신뢰성 수정

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -79,6 +79,21 @@ jobs:
           NEXT_PUBLIC_PR_COUNT: ${{ steps.pr_count.outputs.count }}
           NODE_ENV: production
 
+      # /posts/ 아카이브는 사이트의 유일한 전체 목록 허브다. PostsArchiveView가
+      # useSearchParams를 쓰는 탓에 프리렌더에서 빠지므로, Suspense fallback이
+      # 스피너로 되돌아가면 이 페이지의 내부 링크가 조용히 0개가 된다.
+      # (실제로 c206b99에서 고친 것이 15ed918 리디자인에서 유실된 적 있음)
+      - name: Verify archive links are prerendered
+        run: |
+          html='apps/blog/web/out/posts/index.html'
+          [[ -f "$html" ]] || { echo "::error::$html 이 없습니다"; exit 1; }
+          count=$(grep -o 'href="/posts/[^"]*"' "$html" | sort -u | wc -l | tr -d ' ')
+          echo "prerendered post links: $count"
+          if (( count < 10 )); then
+            echo "::error::/posts/ 에 프리렌더된 글 링크가 ${count}개뿐입니다 — CSR bail-out 회귀로 아카이브 내부 링크가 사라졌습니다"
+            exit 1
+          fi
+
       - name: Upload to pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -87,6 +87,70 @@ test('sitemap: date도 updatedAt도 없으면 lastmod = today', () => {
   assert.equal(block[1], TODAY);
 });
 
+// --- lastmod 신뢰성 회귀 테스트 ---
+// 매일 cron으로 빌드되는 사이트라, 정적 URL의 lastmod에 빌드 날짜를 넣으면
+// 콘텐츠가 그대로인 날에도 lastmod가 전진한다. Google은 그런 사이트의 lastmod를
+// 통째로 무시하므로, 정적 URL은 콘텐츠에서 파생된 날짜만 써야 한다.
+
+function staticBlock(xml: string, loc: string) {
+  return xml.match(
+    new RegExp(
+      `<url>\\s*<loc>${loc.replace(/[/.]/g, '\\$&')}</loc>([\\s\\S]*?)</url>`,
+    ),
+  );
+}
+
+test('sitemap: 루트/posts의 lastmod는 빌드 날짜가 아니라 최신 글 날짜', () => {
+  const posts = [
+    makePost({ slug: 'old', date: '2025-01-01' }),
+    makePost({ slug: 'newest', date: '2026-02-20' }),
+    makePost({ slug: 'mid', date: '2025-08-15' }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+
+  for (const loc of [`${SITE}/`, `${SITE}/posts/`]) {
+    const block = staticBlock(xml, loc);
+    assert.ok(block, `${loc} block must exist`);
+    assert.match(
+      block[1],
+      /<lastmod>2026-02-20<\/lastmod>/,
+      `${loc}의 lastmod는 최신 글 날짜여야 함`,
+    );
+    assert.ok(
+      !block[1].includes(TODAY),
+      `${loc}의 lastmod에 빌드 날짜가 들어가면 안 됨`,
+    );
+  }
+});
+
+test('sitemap: updatedAt이 가장 최신이면 그 값이 정적 URL lastmod가 됨', () => {
+  const posts = [
+    makePost({ slug: 'a', date: '2026-01-01' }),
+    makePost({ slug: 'b', date: '2025-06-01', updatedAt: '2026-04-09' }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  const block = staticBlock(xml, `${SITE}/`);
+  assert.ok(block);
+  assert.match(block[1], /<lastmod>2026-04-09<\/lastmod>/);
+});
+
+test('sitemap: about은 lastmod를 내보내지 않음 (변경 시점 미상)', () => {
+  const xml = buildSitemapXml([makePost({ slug: 'a' })], TODAY, SITE);
+  const block = staticBlock(xml, `${SITE}/about/`);
+  assert.ok(block, 'about block must exist');
+  assert.ok(
+    !block[1].includes('<lastmod>'),
+    'about에 lastmod가 있으면 매 빌드마다 전진한다',
+  );
+});
+
+test('sitemap: 글이 하나도 없으면 정적 lastmod는 today로 폴백', () => {
+  const xml = buildSitemapXml([], TODAY, SITE);
+  const block = staticBlock(xml, `${SITE}/`);
+  assert.ok(block);
+  assert.match(block[1], new RegExp(`<lastmod>${TODAY}</lastmod>`));
+});
+
 test('getPostPriority: 고우선 slug는 0.8 (HIGH_PRIORITY_SLUGS 전부 0.8)', () => {
   // 상수에서 직접 참조 — slug 목록이 변경되어도 테스트가 자동으로 맞춰짐.
   for (const slug of HIGH_PRIORITY_SLUGS) {

--- a/apps/blog/web/generate-sitemap.test.ts
+++ b/apps/blog/web/generate-sitemap.test.ts
@@ -144,6 +144,48 @@ test('sitemap: about은 lastmod를 내보내지 않음 (변경 시점 미상)', 
   );
 });
 
+test('sitemap: date 없는 글이 섞여도 정적 lastmod가 today로 튀지 않음', () => {
+  // date/updatedAt이 없는 글의 lastmod는 today 폴백값이라 콘텐츠 날짜가 아니다.
+  // 이걸 최댓값 계산에 섞으면 today가 항상 이겨서 lastmod가 매일 전진한다.
+  const posts = [
+    makePost({ slug: 'dated', date: '2026-02-20' }),
+    makePost({ slug: 'undated', date: null, updatedAt: null }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+
+  for (const loc of [`${SITE}/`, `${SITE}/posts/`]) {
+    const block = staticBlock(xml, loc);
+    assert.ok(block, `${loc} block must exist`);
+    assert.match(
+      block[1],
+      /<lastmod>2026-02-20<\/lastmod>/,
+      `${loc}은 date 있는 글의 날짜만 반영해야 함`,
+    );
+    assert.ok(
+      !block[1].includes(TODAY),
+      `${loc}에 빌드 날짜가 새어 들어가면 안 됨`,
+    );
+  }
+
+  // 정작 그 글 자신의 lastmod는 today 폴백을 유지한다.
+  const undated = xml.match(
+    /<url>\s*<loc>https:\/\/example\.dev\/posts\/undated\/<\/loc>\s*<lastmod>([^<]+)<\/lastmod>/,
+  );
+  assert.ok(undated, 'undated post block must exist');
+  assert.equal(undated[1], TODAY);
+});
+
+test('sitemap: 모든 글에 date가 없으면 정적 lastmod는 today로 폴백', () => {
+  const posts = [
+    makePost({ slug: 'a', date: null, updatedAt: null }),
+    makePost({ slug: 'b', date: null, updatedAt: null }),
+  ];
+  const xml = buildSitemapXml(posts, TODAY, SITE);
+  const block = staticBlock(xml, `${SITE}/`);
+  assert.ok(block);
+  assert.match(block[1], new RegExp(`<lastmod>${TODAY}</lastmod>`));
+});
+
 test('sitemap: 글이 하나도 없으면 정적 lastmod는 today로 폴백', () => {
   const xml = buildSitemapXml([], TODAY, SITE);
   const block = staticBlock(xml, `${SITE}/`);

--- a/apps/blog/web/generate-sitemap.ts
+++ b/apps/blog/web/generate-sitemap.ts
@@ -71,13 +71,19 @@ export function buildSitemapXml(
   const entries = posts.map(post => ({
     post,
     lastmod: resolvePostLastmod(post, today),
+    // date/updatedAt이 둘 다 없는 글의 lastmod는 today로 폴백된 값이라
+    // "콘텐츠 날짜"가 아니다. 정적 URL 계산에 섞으면 today가 항상 최댓값이 되어
+    // lastmod가 매일 전진하는 원래 버그로 되돌아간다.
+    hasOwnDate: Boolean(post.updatedAt ?? post.date),
   }));
 
   // 'YYYY-MM-DD'는 사전순 비교가 곧 시간순 비교.
-  const latestContentDate = entries.reduce(
-    (max, entry) => (entry.lastmod > max ? entry.lastmod : max),
-    entries[0]?.lastmod ?? today,
-  );
+  const contentDates = entries
+    .filter(entry => entry.hasOwnDate)
+    .map(entry => entry.lastmod);
+  const latestContentDate = contentDates.length
+    ? contentDates.reduce((max, date) => (date > max ? date : max))
+    : today;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/apps/blog/web/generate-sitemap.ts
+++ b/apps/blog/web/generate-sitemap.ts
@@ -36,49 +36,74 @@ export type SitemapPost = Pick<
 >;
 
 /**
+ * 포스트의 lastmod를 KST 기준 'YYYY-MM-DD'로 해석합니다.
+ *
+ * 'YYYY-MM-DD' 형식을 KST 자정으로 파싱한 뒤, KST 기준 날짜 문자열로 추출합니다.
+ * UTC 자정으로 파싱하면 `toISOString().split('T')[0]`가 전날 날짜를 반환할 수 있습니다.
+ * (예: '2025-12-31' → UTC 자정 파싱 → toISOString() '2025-12-30T15:00:00Z' → '2025-12-30')
+ * getKSTDateISO()는 KST 기준 달력 날짜를 정확히 반환합니다.
+ */
+export function resolvePostLastmod(
+  post: SitemapPost,
+  fallback: string,
+): string {
+  return post.updatedAt
+    ? getKSTDateISO(parseScheduledDateKST(post.updatedAt))
+    : post.date
+      ? getKSTDateISO(parseScheduledDateKST(post.date))
+      : fallback;
+}
+
+/**
  * sitemap.xml 본문을 생성합니다. (정적 페이지 + 포스트 목록)
  * `today`/`siteUrl`을 주입받아 결정성을 확보합니다 (테스트에서 재현 가능하도록).
+ *
+ * 정적 페이지(`/`, `/posts/`)의 lastmod는 빌드 날짜가 아니라 **가장 최근 글의 날짜**를
+ * 씁니다. 이 사이트는 매일 cron으로 빌드되므로 빌드 날짜를 넣으면 콘텐츠가 그대로인
+ * 날에도 lastmod가 전진하고, Google은 그런 사이트의 lastmod 신호를 통째로 무시합니다.
+ * `/about/`은 변경 시점을 알 수 없으므로 lastmod를 생략합니다 (생략은 유효).
  */
 export function buildSitemapXml(
   posts: SitemapPost[],
   today: string,
   siteUrl: string = SITE_URL,
 ): string {
+  const entries = posts.map(post => ({
+    post,
+    lastmod: resolvePostLastmod(post, today),
+  }));
+
+  // 'YYYY-MM-DD'는 사전순 비교가 곧 시간순 비교.
+  const latestContentDate = entries.reduce(
+    (max, entry) => (entry.lastmod > max ? entry.lastmod : max),
+    entries[0]?.lastmod ?? today,
+  );
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>${siteUrl}/</loc>
-    <lastmod>${today}</lastmod>
+    <lastmod>${latestContentDate}</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>${siteUrl}/posts/</loc>
-    <lastmod>${today}</lastmod>
+    <lastmod>${latestContentDate}</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>${siteUrl}/about/</loc>
-    <lastmod>${today}</lastmod>
     <priority>0.7</priority>
   </url>
-  ${posts
-    .map(post => {
-      // 'YYYY-MM-DD' 형식을 KST 자정으로 파싱한 뒤, KST 기준 날짜 문자열로 추출합니다.
-      // UTC 자정으로 파싱하면 `toISOString().split('T')[0]`가 전날 날짜를 반환할 수 있습니다.
-      // (예: '2025-12-31' → UTC 자정 파싱 → toISOString() '2025-12-30T15:00:00Z' → '2025-12-30')
-      // getKSTDateISO()는 KST 기준 달력 날짜를 정확히 반환합니다.
-      const lastmod = post.updatedAt
-        ? getKSTDateISO(parseScheduledDateKST(post.updatedAt))
-        : post.date
-          ? getKSTDateISO(parseScheduledDateKST(post.date))
-          : today;
-      return `
+  ${entries
+    .map(
+      ({ post, lastmod }) => `
   <url>
     <loc>${siteUrl}/posts/${encodePostSlug(post.slug)}/</loc>
     <lastmod>${lastmod}</lastmod>
     <priority>${getPostPriority(post)}</priority>
-  </url>`;
-    })
+  </url>`,
+    )
     .join('')}
 </urlset>`;
 }

--- a/apps/blog/web/src/app/about/page.tsx
+++ b/apps/blog/web/src/app/about/page.tsx
@@ -48,7 +48,9 @@ const jsonLd = {
   url: `${SITE_URL}/about/`,
   name: '한상욱 (Sangwook Han) — About',
   dateCreated: '2024-12-01',
-  dateModified: new Date().toISOString().split('T')[0],
+  // 빌드 시각을 넣으면 매일 cron 빌드마다 "수정됨"으로 보고되어 신호가 무의미해진다.
+  // 이 페이지 내용을 실제로 고칠 때 함께 갱신할 것.
+  dateModified: '2026-07-05',
   mainEntity: {
     '@type': 'Person',
     '@id': `${SITE_URL}/#author`,

--- a/apps/blog/web/src/app/posts/page.tsx
+++ b/apps/blog/web/src/app/posts/page.tsx
@@ -6,7 +6,7 @@ import { getAllPostSummaries } from '@/domain/post';
 import { getAllSeries, getAllTags, getAllYears } from '@/domain/post/aggregate';
 import { SITE_URL } from '@/lib/constants';
 import { safeJsonLd } from '@/lib/jsonLd';
-import { Label, PostsArchiveView } from '@/src/components/blog';
+import { Label, PostListRow, PostsArchiveView } from '@/src/components/blog';
 import { PageBoundary } from '@/src/components/PageBoundary';
 
 export const metadata: Metadata = {
@@ -141,18 +141,20 @@ export default function PostsPage() {
             </div>
           </header>
 
+          {/*
+            PostsArchiveView는 nuqs(useSearchParams)를 쓰므로 output: 'export'의
+            빌드 타임 프리렌더 대상에서 빠진다 (BAILOUT_TO_CLIENT_SIDE_RENDERING).
+            즉 out/posts/index.html에 구워지는 건 아래 fallback이 전부다.
+            스피너를 두면 아카이브 허브의 내부 링크가 0개가 되므로, 글 목록을 여기서
+            프리렌더해 링크를 남긴다. (브라우저에서 하이드레이션되면 인터랙티브 뷰로 교체)
+            회귀 이력: c206b99에서 도입 → 15ed918(리디자인)에서 유실 → 재도입.
+          */}
           <Suspense
             fallback={
-              <div
-                className={css({
-                  py: '12',
-                  textAlign: 'center',
-                  fontFamily: 'mono',
-                  fontSize: 'xs',
-                  color: 'ink.500',
-                })}
-              >
-                노트 불러오는 중…
+              <div>
+                {posts.map(post => (
+                  <PostListRow key={post.slug} post={post} />
+                ))}
               </div>
             }
           >


### PR DESCRIPTION
## 배경

GSC 색인 실패 원인을 조사하다 발견한 **코드로 고칠 수 있는 결함 2건**을 수정합니다.

조사 결과 색인 실패의 주된 원인은 코드가 아니라 과거 이력(2025-06-28 배포 트리거 사망으로 6개월 미배포 → 2025-12-25 슬러그 34개 전면 교체 → 2026-01-02 도메인 이전 → apex 탈취)이었습니다. 다만 아래 2건은 지금도 실제로 크롤러가 보는 결과를 망가뜨리고 있어 분리해 고칩니다.

현재 상태 참고: 크롤 허용 `예`, 색인 생성 허용 `예`, canonical 정상, 수동 조치·보안 문제 없음. 기술적 차단은 없는 상태입니다.

## 1. `/posts/` 아카이브의 프리렌더 링크 복구

`PostsArchiveView`가 nuqs(`useSearchParams`)를 쓰므로 `output: 'export'`의 빌드 타임 프리렌더에서 제외됩니다(`BAILOUT_TO_CLIENT_SIDE_RENDERING`). 그래서 `out/posts/index.html`에 실제로 구워지는 건 Suspense fallback이 전부인데, 그 자리에 스피너만 있었습니다.

결과적으로 사이트의 **유일한 전체 목록 허브**가 크롤러에게는 내부 링크 0개짜리 페이지였습니다. 홈에 노출되는 18편 외 나머지는 글 하단 prev/next 체인 말고 정적 인링크가 없었습니다.

| | 이전 | 이후 |
|:--|--:|--:|
| `out/posts/index.html` | 85,931 bytes | 188,827 bytes |
| 고유 글 링크 | **0개** | **42개** |

fallback에서 목록을 프리렌더하고, 브라우저에서 하이드레이션되면 기존 인터랙티브 뷰로 교체되므로 UX는 그대로입니다.

**회귀 이력**: 이 수정은 `c206b99`(2026-03-20)에서 한 번 도입됐다가 `15ed918`(리디자인) 때 유실됐습니다. 같은 일이 반복되지 않도록 배포 워크플로우에 링크 개수 검증 스텝을 추가했습니다.

## 2. `lastmod`가 매일 cron 빌드마다 전진하던 문제

sitemap 정적 URL 3개와 about JSON-LD `dateModified`가 빌드 시각에서 파생되고 있었습니다. 매일 00:00 UTC cron 빌드가 돌기 때문에, 콘텐츠가 그대로인 날에도 "수정됨"으로 보고돼 왔습니다.

실제로 `apps/blog` 마지막 커밋은 2026-07-05인데 라이브 sitemap의 정적 3개는 `2026-07-24`를 가리켰습니다 — **소스 변경 0인 20일간 lastmod가 20번 전진**했습니다. Google은 lastmod가 실제 변경과 무관하게 움직이면 그 사이트의 lastmod 신호를 통째로 무시합니다.

- `/`, `/posts/` → 가장 최근 글의 날짜 (새 글이 올라오면 두 목록이 실제로 바뀌므로 일치)
- `/about/` → `lastmod` 생략 (생략은 유효)
- about JSON-LD `dateModified` → 고정값

포스트 URL의 lastmod는 원래부터 `updatedAt ?? date` 기반이라 변경 없습니다. 해당 로직만 `resolvePostLastmod`로 추출해 공유합니다.

## 검증

- `pnpm test:node` — **445 pass / 0 fail** (신규 회귀 테스트 4건 포함)
- `pnpm lint`, `pnpm check-types` — 통과
- 실제 빌드 후 `out/` 산출물 직접 확인 (위 표)
- CI 가드 스크립트 로컬 dry-run — 43개 감지, PASS

## 이 PR로 해결되지 않는 것

색인 회복 자체는 코드 밖의 일입니다. 별도로 필요한 조치:

- `www.sangwook.dev`가 **307 임시 리디렉션** (→apex→blog, 2홉) — 색인 신호를 이전하지 않음. Vercel 도메인 설정에서 permanent로 전환 필요
- 와일드카드 `*` ALIAS DNS 레코드 잔존 (탈취 경로 추정) — `blog` CNAME이 별도로 있어 제거해도 블로그는 정상
- GSC 사이트맵 재제출 (2026-06-21 이후 재읽기 멈춤)
- 외부 백링크 0건 — GSC 링크 보고서 기준

🤖 Generated with [Claude Code](https://claude.com/claude-code)
