### PR TITLE
fix(blog): 예약 시각이 지난 글을 admin 배지에서 공개로 표시

### DIFF
--- a/apps/blog/web/domain/post/visibility.test.ts
+++ b/apps/blog/web/domain/post/visibility.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { isPostVisible } from './visibility';
+import { isPostVisible, resolvePostState } from './visibility';
 
 test('status가 없으면 비공개 (fail-closed)', () => {
   assert.equal(isPostVisible({}), false);
@@ -196,4 +196,159 @@ test('비-scheduled status는 now 주입과 무관 (회귀 가드)', () => {
     isPostVisible({ status: 'draft', scheduledDate: '2000-01-01' }, farFuture),
     false,
   );
+});
+
+// --- resolvePostState: 화면에 보여줄 "현재 상태" ---
+// status는 발행 의도의 기록이고, 배지는 지금 공개인지를 말해야 합니다.
+// admin PostAccordion이 이 규칙을 자체 구현했다가 아래 두 케이스를 놓쳐서,
+// 이미 공개돼 조회수가 쌓이는 글을 몇 달째 "예약"으로 표시했습니다.
+
+test('resolvePostState: published/draft는 status 그대로', () => {
+  const now = new Date('2026-05-24T00:00:00Z');
+  assert.equal(resolvePostState({ status: 'published' }, now), 'published');
+  assert.equal(resolvePostState({ status: 'draft' }, now), 'draft');
+  // date가 미래여도 published면 공개 상태
+  assert.equal(
+    resolvePostState({ status: 'published', date: '2099-01-01' }, now),
+    'published',
+  );
+});
+
+test('resolvePostState: 예약 시각이 지나면 published (원본 status는 scheduled 그대로)', () => {
+  const post = { status: 'scheduled', scheduledDate: '2026-05-24' };
+  assert.equal(
+    resolvePostState(post, new Date('2026-05-23T15:00:01Z')),
+    'published',
+  );
+  // 파생 계산일 뿐 입력을 건드리지 않는다 — 원본은 예약으로 남는다.
+  assert.equal(post.status, 'scheduled');
+});
+
+test('resolvePostState: 예약 시각 전이면 scheduled', () => {
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', scheduledDate: '2026-05-24' },
+      new Date('2026-05-23T14:59:59Z'), // KST 2026-05-23 23:59:59
+    ),
+    'scheduled',
+  );
+});
+
+test('resolvePostState(회귀): scheduledDate 없이 date만 있어도 지나면 published', () => {
+  // 이 버그의 본체. scheduledDate는 "시각까지 지정할 때만" 쓰는 선택 필드라
+  // 대부분의 예약 글에는 없다. scheduledDate가 있을 때만 승격하는 구현은
+  // 이런 글을 영원히 '예약'으로 남긴다.
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', date: '2026-03-03' },
+      new Date('2026-07-27T00:00:00Z'),
+    ),
+    'published',
+  );
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', date: '2026-03-03' },
+      new Date('2026-03-02T00:00:00Z'),
+    ),
+    'scheduled',
+  );
+});
+
+test('resolvePostState(회귀): KST 자정 경계 — UTC 파싱으로 회귀하면 깨진다', () => {
+  // now = UTC 2026-05-23 16:00 = KST 2026-05-24 01:00 (KST 자정은 지났다).
+  // native Date로 'YYYY-MM-DD'를 파싱하면 UTC 자정(=KST 09:00)이 되어 아직 scheduled로 보인다.
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', date: '2026-05-24' },
+      new Date('2026-05-23T16:00:00Z'),
+    ),
+    'published',
+    'KST 자정을 지났으면 공개 상태여야 함',
+  );
+  // 반대편 경계: KST 자정 9시간 전에는 아직 예약이어야 한다.
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', date: '2026-05-24' },
+      new Date('2026-05-23T06:00:00Z'), // KST 2026-05-23 15:00
+    ),
+    'scheduled',
+  );
+});
+
+test('resolvePostState: scheduledDate가 date보다 우선', () => {
+  // date는 지났지만 scheduledDate가 미래면 아직 예약
+  assert.equal(
+    resolvePostState(
+      {
+        status: 'scheduled',
+        date: '2020-01-01',
+        scheduledDate: '2099-01-01T00:00:00Z',
+      },
+      new Date('2026-05-24T00:00:00Z'),
+    ),
+    'scheduled',
+  );
+});
+
+test('resolvePostState: 공개 시각이 없는 예약 글은 계속 scheduled', () => {
+  const now = new Date('2026-05-24T00:00:00Z');
+  assert.equal(resolvePostState({ status: 'scheduled' }, now), 'scheduled');
+  assert.equal(
+    resolvePostState({ status: 'scheduled', date: null }, now),
+    'scheduled',
+  );
+  // analytics의 PostStatDetail은 빈 값을 null로 정규화해 넘긴다.
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', scheduledDate: null, date: null },
+      now,
+    ),
+    'scheduled',
+  );
+});
+
+test('resolvePostState: scheduledDate가 null이면 date로 폴백', () => {
+  // PostStatDetail이 실제로 넘기는 형태 (scheduledDate: string | null)
+  assert.equal(
+    resolvePostState(
+      { status: 'scheduled', scheduledDate: null, date: '2026-03-03' },
+      new Date('2026-07-27T00:00:00Z'),
+    ),
+    'published',
+  );
+});
+
+test('resolvePostState: status 누락·미지 값은 draft (fail-closed)', () => {
+  const now = new Date('2026-05-24T00:00:00Z');
+  assert.equal(resolvePostState({}, now), 'draft');
+  assert.equal(resolvePostState({ status: 'unknown-value' }, now), 'draft');
+  // 미지 status에 과거 date가 있어도 공개로 승격되지 않는다.
+  assert.equal(
+    resolvePostState({ status: 'archived', date: '2000-01-01' }, now),
+    'draft',
+  );
+});
+
+test('resolvePostState는 isPostVisible과 같은 규칙을 쓴다 (계약)', () => {
+  const now = new Date('2026-05-24T00:00:00Z');
+  const cases = [
+    {},
+    { status: 'published' },
+    { status: 'draft' },
+    { status: 'unknown' },
+    { status: 'scheduled' },
+    { status: 'scheduled', date: '2020-01-01' },
+    { status: 'scheduled', date: '2099-01-01' },
+    { status: 'scheduled', scheduledDate: '2020-01-01', date: '2099-01-01' },
+    { status: 'scheduled', scheduledDate: '2099-01-01', date: '2020-01-01' },
+    { status: 'scheduled', scheduledDate: null, date: '2020-01-01' },
+    { status: 'draft', date: '2000-01-01' },
+  ];
+  for (const data of cases) {
+    assert.equal(
+      resolvePostState(data, now) === 'published',
+      isPostVisible(data, now),
+      `공개 판정이 갈라짐: ${JSON.stringify(data)}`,
+    );
+  }
 });

--- a/apps/blog/web/domain/post/visibility.ts
+++ b/apps/blog/web/domain/post/visibility.ts
@@ -29,7 +29,9 @@ export function isPostFile<T extends { status?: unknown }>(
 
 export interface VisibilityData {
   status?: string;
-  scheduledDate?: string;
+  // analytics의 PostStatDetail은 빈 값을 null로 정규화해 들고 옵니다.
+  // `scheduledDate ?? date` 폴백이 null도 그대로 처리하므로 타입만 넓혀 받습니다.
+  scheduledDate?: string | null;
   date?: string | null;
 }
 
@@ -67,4 +69,31 @@ export function isPostVisible(
     default:
       return false;
   }
+}
+
+/**
+ * 포스트의 **현재 상태**를 계산합니다. 화면에 상태 배지를 그릴 때 씁니다.
+ *
+ * `status`(frontmatter)는 "언제 내보내기로 했는가"라는 **발행 의도**의 기록이고,
+ * 사람이 화면에서 알고 싶은 것은 "지금 공개인가"입니다. 예약 시각이 지난 글은
+ * 원본이 `scheduled`로 남아 있어도 이미 공개된 상태이므로 `'published'`를
+ * 반환합니다. 원본 frontmatter를 `published`로 되돌리지는 않습니다 — 그러면
+ * 예약 발행이었다는 사실이 파일에서 사라지고, 커밋 전 기간을 커버할 파생 판정도
+ * 여전히 필요해 규칙이 두 벌이 됩니다.
+ *
+ * 공개 판정은 `isPostVisible`에 위임합니다. 이 규칙을 복사해서 쓰면 `date` 폴백이나
+ * KST 파싱 중 하나가 빠진 채 갈라집니다 — admin 상태 배지가 실제로 그렇게 깨져서,
+ * 이미 공개돼 조회수가 쌓이는 글을 몇 달째 "예약"으로 표시하고 있었습니다.
+ *
+ * @param data
+ * @param now 기준 시각. 테스트는 경계를 결정적으로 검증하기 위해 주입합니다.
+ */
+export function resolvePostState(
+  data: VisibilityData,
+  now: Date = new Date(),
+): PostStatus {
+  if (isPostVisible(data, now)) return 'published';
+  // 아직 공개 전인 예약 글만 'scheduled'.
+  // status 누락·미지 값은 isPostVisible과 같은 이유로 draft 취급(fail-closed)입니다.
+  return data.status === 'scheduled' ? 'scheduled' : 'draft';
 }

--- a/apps/blog/web/src/app/admin/components/PostAccordion.tsx
+++ b/apps/blog/web/src/app/admin/components/PostAccordion.tsx
@@ -22,9 +22,10 @@ import {
 import Link from 'next/link';
 import { token } from '@design-system/ui-lib/tokens';
 import { motion, AnimatePresence } from 'motion/react';
-import { formatMonthDayISO } from '@/lib/dates';
+import { formatMonthDayISO, parseScheduledDateKST } from '@/lib/dates';
 import { DateRangeControls, useDateFilter } from './DateRangeControls';
 import { encodePostSlug } from '@/domain/post/utils';
+import { resolvePostState } from '@/domain/post/visibility';
 
 interface Props {
   post: PostStatDetail;
@@ -34,16 +35,12 @@ export function PostAccordion({ post }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const briefStats = useMemo(() => computeBriefStats(post), [post]);
 
-  const computedStatus = useMemo(() => {
-    if (
-      post.status === 'scheduled' &&
-      post.scheduledDate &&
-      new Date(post.scheduledDate) <= new Date()
-    ) {
-      return 'published';
-    }
-    return post.status;
-  }, [post.status, post.scheduledDate]);
+  // frontmatter의 status(발행 의도)가 아니라 **지금 실제로 공개 중인지**로 배지를
+  // 그립니다. 판정은 도메인 함수 하나에 위임합니다 — 예전에는 이 자리에서 규칙을
+  // 다시 구현하다 `date` 폴백과 KST 파싱을 둘 다 놓쳤습니다.
+  const state = resolvePostState(post);
+  // scheduledDate는 시각까지 지정할 때만 쓰는 선택 필드라 보통은 date가 공개 시각입니다.
+  const publishAt = post.scheduledDate ?? post.date;
 
   const {
     filterType,
@@ -61,14 +58,14 @@ export function PostAccordion({ post }: Props) {
   }));
 
   const statusStyle =
-    computedStatus === 'published'
+    state === 'published'
       ? {
           bg: 'paper.100' as const,
           color: 'moss.600' as const,
           borderColor: 'ink.border' as const,
           label: '공개',
         }
-      : computedStatus === 'draft'
+      : state === 'draft'
         ? {
             bg: 'paper.100' as const,
             color: 'ink.500' as const,
@@ -79,11 +76,9 @@ export function PostAccordion({ post }: Props) {
             bg: 'paper.100' as const,
             color: 'spot.600' as const,
             borderColor: 'ink.border' as const,
-            label: post.scheduledDate
-              ? new Date(post.scheduledDate).toLocaleDateString('ko-KR', {
-                  timeZone: 'Asia/Seoul',
-                })
-              : '예약',
+            // 공개 예정일은 옆 날짜 칼럼에 이미 있으므로 배지는 상태만 말합니다.
+            // 정확한 시각은 title 툴팁으로.
+            label: '예약',
           };
 
   return (
@@ -145,29 +140,29 @@ export function PostAccordion({ post }: Props) {
           >
             <ExternalLink size={12} />
           </Link>
-          {computedStatus && (
-            <span
-              className={css({
-                fontSize: 'xs',
-                fontWeight: 'semibold',
-                px: '2',
-                py: '0.5',
-                rounded: 'full',
-                flexShrink: 0,
-                bg: statusStyle.bg,
-                color: statusStyle.color,
-                borderWidth: '[1px]',
-                borderColor: statusStyle.borderColor,
-              })}
-              title={
-                computedStatus === 'scheduled' && post.scheduledDate
-                  ? `예약: ${new Date(post.scheduledDate).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })}`
-                  : undefined
-              }
-            >
-              {statusStyle.label}
-            </span>
-          )}
+          <span
+            className={css({
+              fontSize: 'xs',
+              fontWeight: 'semibold',
+              px: '2',
+              py: '0.5',
+              rounded: 'full',
+              flexShrink: 0,
+              bg: statusStyle.bg,
+              color: statusStyle.color,
+              borderWidth: '[1px]',
+              borderColor: statusStyle.borderColor,
+            })}
+            title={
+              state === 'scheduled' && publishAt
+                ? // 'YYYY-MM-DD'를 native Date에 넣으면 UTC 자정으로 파싱돼
+                  // KST 09:00으로 잘못 표시됩니다.
+                  `예약: ${parseScheduledDateKST(publishAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })}`
+                : undefined
+            }
+          >
+            {statusStyle.label}
+          </span>
           <span
             className={css({
               fontWeight: 'semibold',

--- a/apps/blog/web/src/app/posts/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/posts/[...slug]/page.tsx
@@ -100,12 +100,7 @@ export default async function PostPage({ params }: Props) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
       />
-      {showHiddenBanner && (
-        <PreviewBanner
-          status={post.status}
-          scheduledDate={post.scheduledDate}
-        />
-      )}
+      {showHiddenBanner && <PreviewBanner post={post} />}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }}

--- a/apps/blog/web/src/app/preview/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/preview/[...slug]/page.tsx
@@ -46,7 +46,11 @@ export default async function PreviewPage({ params }: Props) {
 
   return (
     <>
-      <PreviewBanner status={post.status} scheduledDate={post.scheduledDate} />
+      <PreviewBanner
+        status={post.status}
+        scheduledDate={post.scheduledDate}
+        date={post.date}
+      />
       <PostClient
         post={post}
         thumbnailUrl={post.thumbnail ? thumbnailUrl : undefined}

--- a/apps/blog/web/src/app/preview/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/preview/[...slug]/page.tsx
@@ -46,11 +46,7 @@ export default async function PreviewPage({ params }: Props) {
 
   return (
     <>
-      <PreviewBanner
-        status={post.status}
-        scheduledDate={post.scheduledDate}
-        date={post.date}
-      />
+      <PreviewBanner post={post} />
       <PostClient
         post={post}
         thumbnailUrl={post.thumbnail ? thumbnailUrl : undefined}

--- a/apps/blog/web/src/components/preview/PreviewBanner.test.tsx
+++ b/apps/blog/web/src/components/preview/PreviewBanner.test.tsx
@@ -14,20 +14,25 @@ const bannerText = () => screen.getByRole('status').textContent ?? '';
 
 describe('PreviewBanner', () => {
   test('draft는 비공개 배너를 보여준다', () => {
-    render(<PreviewBanner status="draft" />);
+    render(<PreviewBanner post={{ status: 'draft', date: null }} />);
     expect(bannerText()).toContain('Draft Preview');
   });
 
   test('published는 발행 배너를 보여준다', () => {
-    render(<PreviewBanner status="published" date="2026-03-03" />);
+    render(
+      <PreviewBanner post={{ status: 'published', date: '2026-03-03' }} />,
+    );
     expect(bannerText()).toContain('Published Preview');
   });
 
   test('scheduled: scheduledDate가 있으면 그 값을 공개 시각으로 보여준다', () => {
     render(
       <PreviewBanner
-        status="scheduled"
-        scheduledDate="2026-05-24T09:00:00+09:00"
+        post={{
+          status: 'scheduled',
+          scheduledDate: '2026-05-24T09:00:00+09:00',
+          date: '2026-05-24',
+        }}
       />,
     );
     expect(bannerText()).toContain('예약 발행 (2026-05-24T09:00:00+09:00)');
@@ -35,7 +40,9 @@ describe('PreviewBanner', () => {
 
   test('scheduled(회귀): scheduledDate가 없으면 date로 폴백한다', () => {
     // 이 폴백이 없으면 date만 가진 예약 글이 전부 "날짜 없음"으로 뜬다.
-    render(<PreviewBanner status="scheduled" date="2026-03-03" />);
+    render(
+      <PreviewBanner post={{ status: 'scheduled', date: '2026-03-03' }} />,
+    );
     expect(bannerText()).toContain('예약 발행 (2026-03-03)');
     expect(bannerText()).not.toContain('날짜 없음');
   });
@@ -43,9 +50,11 @@ describe('PreviewBanner', () => {
   test('scheduled: scheduledDate가 date보다 우선한다', () => {
     render(
       <PreviewBanner
-        status="scheduled"
-        scheduledDate="2026-05-24"
-        date="2020-01-01"
+        post={{
+          status: 'scheduled',
+          scheduledDate: '2026-05-24',
+          date: '2020-01-01',
+        }}
       />,
     );
     expect(bannerText()).toContain('예약 발행 (2026-05-24)');
@@ -53,7 +62,15 @@ describe('PreviewBanner', () => {
   });
 
   test('scheduled: 공개 시각이 아예 없으면 날짜 없음', () => {
-    render(<PreviewBanner status="scheduled" date={null} />);
+    render(<PreviewBanner post={{ status: 'scheduled', date: null }} />);
     expect(bannerText()).toContain('날짜 없음');
+  });
+
+  test('post를 통째로 넘기므로 호출부가 필드를 빠뜨릴 수 없다', () => {
+    // 낱개 props였을 때 호출부 두 곳 중 하나가 date를 빠뜨려도 타입이 통과했다.
+    // Pick<PostSummary, ...>로 묶으면 date 누락이 컴파일 에러가 된다.
+    const post = { status: 'scheduled' as const, date: '2026-03-03' };
+    render(<PreviewBanner post={post} />);
+    expect(bannerText()).toContain('2026-03-03');
   });
 });

--- a/apps/blog/web/src/components/preview/PreviewBanner.test.tsx
+++ b/apps/blog/web/src/components/preview/PreviewBanner.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * dev 전용 미리보기 배너의 라벨 규칙.
+ *
+ * 이 배너는 admin 배지와 반대로 **status 원문**을 보여줍니다(발행 의도 확인용).
+ * 다만 공개 시각은 `scheduledDate ?? date`로 폴백해야 합니다 — scheduledDate는
+ * 시각까지 지정할 때만 쓰는 선택 필드라, 폴백이 없으면 date만 가진 예약 글이
+ * 전부 "날짜 없음"으로 표시됩니다.
+ */
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PreviewBanner } from './PreviewBanner';
+
+const bannerText = () => screen.getByRole('status').textContent ?? '';
+
+describe('PreviewBanner', () => {
+  test('draft는 비공개 배너를 보여준다', () => {
+    render(<PreviewBanner status="draft" />);
+    expect(bannerText()).toContain('Draft Preview');
+  });
+
+  test('published는 발행 배너를 보여준다', () => {
+    render(<PreviewBanner status="published" date="2026-03-03" />);
+    expect(bannerText()).toContain('Published Preview');
+  });
+
+  test('scheduled: scheduledDate가 있으면 그 값을 공개 시각으로 보여준다', () => {
+    render(
+      <PreviewBanner
+        status="scheduled"
+        scheduledDate="2026-05-24T09:00:00+09:00"
+      />,
+    );
+    expect(bannerText()).toContain('예약 발행 (2026-05-24T09:00:00+09:00)');
+  });
+
+  test('scheduled(회귀): scheduledDate가 없으면 date로 폴백한다', () => {
+    // 이 폴백이 없으면 date만 가진 예약 글이 전부 "날짜 없음"으로 뜬다.
+    render(<PreviewBanner status="scheduled" date="2026-03-03" />);
+    expect(bannerText()).toContain('예약 발행 (2026-03-03)');
+    expect(bannerText()).not.toContain('날짜 없음');
+  });
+
+  test('scheduled: scheduledDate가 date보다 우선한다', () => {
+    render(
+      <PreviewBanner
+        status="scheduled"
+        scheduledDate="2026-05-24"
+        date="2020-01-01"
+      />,
+    );
+    expect(bannerText()).toContain('예약 발행 (2026-05-24)');
+    expect(bannerText()).not.toContain('2020-01-01');
+  });
+
+  test('scheduled: 공개 시각이 아예 없으면 날짜 없음', () => {
+    render(<PreviewBanner status="scheduled" date={null} />);
+    expect(bannerText()).toContain('날짜 없음');
+  });
+});

--- a/apps/blog/web/src/components/preview/PreviewBanner.tsx
+++ b/apps/blog/web/src/components/preview/PreviewBanner.tsx
@@ -4,14 +4,24 @@ import type { PostStatus } from '@/domain/post/types';
 interface Props {
   status: PostStatus;
   scheduledDate?: string;
+  date?: string | null;
 }
 
-export function PreviewBanner({ status, scheduledDate }: Props) {
+/**
+ * 이 배너는 admin 배지와 달리 **status(발행 의도)를 그대로** 보여줍니다.
+ * `/preview`는 "아직 안 나간 글이 어떻게 보이는지" 확인하는 dev 전용 화면이라,
+ * 파일에 뭐라고 적혀 있는지가 궁금한 정보이기 때문입니다.
+ * "지금 공개인가"를 보여주는 쪽은 `resolvePostState`를 쓰는 admin 배지입니다.
+ */
+export function PreviewBanner({ status, scheduledDate, date }: Props) {
+  // scheduledDate는 시각까지 지정할 때만 쓰는 선택 필드라 대부분의 예약 글에는
+  // 없습니다. 폴백 없이 scheduledDate만 보면 그 글들이 전부 "날짜 없음"이 됩니다.
+  const publishAt = scheduledDate ?? date;
   const label =
     status === 'draft'
       ? 'Draft Preview — 비공개 (status: draft)'
       : status === 'scheduled'
-        ? `Scheduled Preview — 예약 발행 (${scheduledDate ?? '날짜 없음'})`
+        ? `Scheduled Preview — 예약 발행 (${publishAt ?? '날짜 없음'})`
         : 'Published Preview';
 
   return (

--- a/apps/blog/web/src/components/preview/PreviewBanner.tsx
+++ b/apps/blog/web/src/components/preview/PreviewBanner.tsx
@@ -1,10 +1,14 @@
 import { css } from '@design-system/ui-lib/css';
-import type { PostStatus } from '@/domain/post/types';
+import type { PostSummary } from '@/domain/post/types';
 
+/**
+ * 공개 시각 판정에 필요한 필드를 **한 덩어리로** 받습니다.
+ * 필드를 낱개로 받으면 호출부에서 하나를 빠뜨려도 타입이 통과합니다 —
+ * 실제로 `date`를 안 넘기는 호출부가 있어 예약 글 배너가 "날짜 없음"으로 떴습니다.
+ * (`HiddenPostBadge`도 같은 이유로 post를 통째로 받습니다)
+ */
 interface Props {
-  status: PostStatus;
-  scheduledDate?: string;
-  date?: string | null;
+  post: Pick<PostSummary, 'status' | 'scheduledDate' | 'date'>;
 }
 
 /**
@@ -13,10 +17,11 @@ interface Props {
  * 파일에 뭐라고 적혀 있는지가 궁금한 정보이기 때문입니다.
  * "지금 공개인가"를 보여주는 쪽은 `resolvePostState`를 쓰는 admin 배지입니다.
  */
-export function PreviewBanner({ status, scheduledDate, date }: Props) {
+export function PreviewBanner({ post }: Props) {
+  const { status } = post;
   // scheduledDate는 시각까지 지정할 때만 쓰는 선택 필드라 대부분의 예약 글에는
   // 없습니다. 폴백 없이 scheduledDate만 보면 그 글들이 전부 "날짜 없음"이 됩니다.
-  const publishAt = scheduledDate ?? date;
+  const publishAt = post.scheduledDate ?? post.date;
   const label =
     status === 'draft'
       ? 'Draft Preview — 비공개 (status: draft)'


### PR DESCRIPTION
## 문제

admin 대시보드에서 예약 발행 글이 공개 시각을 한참 지난 뒤에도 계속 "예약" 배지로 표시됐습니다. 실제 사이트에서는 이미 공개돼 조회수가 쌓이고 있는 글이라, 화면만 거짓말을 하고 있던 상태입니다.

## 원인

`PostAccordion`이 공개 판정을 도메인 함수 대신 자체 구현하면서 규칙 두 가지를 놓쳤습니다.

```ts
post.status === 'scheduled' &&
  post.scheduledDate &&
  new Date(post.scheduledDate) <= new Date();
```

1. **`scheduledDate`가 있을 때만 승격** — `scheduledDate`는 시각까지 지정할 때만 쓰는 선택 필드고, `isPostVisible`은 `scheduledDate ?? date`로 폴백합니다. 실제로 예약 글 2건 모두 `scheduledDate` 없이 `date`만 갖고 있어서 영원히 "예약"으로 남았습니다.
2. **`new Date('YYYY-MM-DD')`가 UTC 자정으로 파싱** — `parseScheduledDateKST`를 쓰지 않아 KST 기준보다 9시간 일찍 넘어갑니다.

## 변경

| 파일 | 내용 |
| :--- | :--- |
| `domain/post/visibility.ts` | `resolvePostState()` 추가. 공개 판정은 `isPostVisible`에 위임해 규칙이 갈라질 수 없게 함. `VisibilityData.scheduledDate`를 `string \| null`로 확장 (analytics가 빈 값을 null로 정규화해 넘김) |
| `admin/components/PostAccordion.tsx` | 자체 판정 제거 → 도메인 함수 사용. 배지 라벨을 "예약"으로 통일하고(공개 예정일은 옆 날짜 칼럼에 이미 있음) 툴팁의 UTC 파싱도 수정 |
| `components/preview/PreviewBanner.tsx` | `date` 폴백 추가. 같은 원인으로 예약 글 미리보기가 항상 "날짜 없음"으로 떴습니다 |
| `preview/[...slug]/page.tsx` | 배너에 `date` 전달 |

`PreviewBanner`는 admin 배지와 달리 **`status` 원문을 그대로** 보여주도록 유지했습니다. `/preview`는 "파일에 뭐라고 적혀 있나"를 확인하는 dev 전용 화면이라 역할이 반대입니다. 그 의도를 주석에 남겼습니다.

`HiddenPostBadge`는 이미 `isPostVisible`을 쓰고 있어 건드리지 않았습니다.

## 원본 frontmatter는 그대로 둡니다

`status: scheduled`를 `published`로 덮어쓰는 방식(스케줄러가 커밋)도 검토했지만 택하지 않았습니다.

- `isPostVisible`은 어차피 필요합니다. 커밋 사이 기간을 파생 판정이 커버해야 하므로 **규칙이 두 벌**이 됩니다. 그게 이번 버그가 난 방식 그대로입니다.
- `deploy-blog.yml`이 `apps/blog/**`에 걸려 있어 봇 커밋이 배포를 재트리거합니다.
- cron이 한 번 실패하면 소스는 `scheduled`, 사이트는 공개로 갈라집니다.
- `date: 2026-03-03` + `status: published`가 되면 예약 발행이었는지 그날 쓴 글인지 구분이 사라집니다.

`status`는 발행 의도의 기록이고, 현재 공개 여부는 파생값이라는 기존 설계(`visibility.ts` 주석, CLAUDE.md)를 그대로 따릅니다.

## 테스트

- `visibility.test.ts` — `resolvePostState` 회귀 테스트 10개
  - `scheduledDate` 없이 `date`만 있는 예약 글이 지나면 `published` ← 이번 버그
  - KST 자정 경계 양쪽 (UTC 파싱으로 회귀하면 깨지도록 시각 선정)
  - `resolvePostState(x) === 'published'` ⟺ `isPostVisible(x)` 계약을 11개 케이스로 검증
- `PreviewBanner.test.tsx` (신규) — 라벨 규칙 6개, `date` 폴백 회귀 포함

```
node --test : 476 passed / 0 failed
vitest      :  88 passed / 0 failed
tsc --noEmit: 통과
eslint      : 통과
```

실제 포스트 데이터로 확인한 변화:

```
date        | scheduledDate | 이전 | 이후 | 제목
2026-07-02  | -             | 예약 | 공개 | TypeScript 6 업그레이드인 줄 알았는데…
2026-03-03  | -             | 예약 | 공개 | [번들러 만들기] 4. 소스맵…
```

## 후속 (이 PR 범위 밖)

`scheduledDate`는 현 배포 구조에서 표현력이 없는 필드입니다. cron이 하루 한 번(KST 09:00)이고 SSG라, 몇 시를 적든 실제 공개는 09:00 빌드 시점입니다. 별도 PR에서 상태 모델 정리와 함께 걷어낼 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
