### PR TITLE
feat(blog): frontmatter `date`를 필수로 검증한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,13 +272,13 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
    | :-------------- | :--: | :------------------------------------------------------------------------------------------------------------------------- |
    | `status`        |  ✅  | `published` \| `draft` \| `scheduled`. **이 키가 없으면 포스트가 아니라 메타 노트로 간주되어 빌드에서 통째로 제외됩니다.** |
    | `title`         |  ✅  | 없으면 파일명으로 폴백하지만 `lint:posts`가 에러                                                                           |
-   | `date`          |      | `'YYYY-MM-DD'`. `scheduled`일 때는 공개 시각으로도 쓰임                                                                    |
+   | `date`          |  ✅  | `'YYYY-MM-DD'`. 목록 정렬·아카이브·sitemap·RSS가 모두 사용하고, `scheduled`일 때는 공개 시각이기도 함. 없으면 `missing-date` 에러 |
    | `slug`          |      | URL. 없으면 파일 경로에서 유도                                                                                             |
    | `excerpt`       |      | 없으면 본문 앞 160자                                                                                                       |
    | `thumbnail`     |      | 없으면 빌드 시 OG 카드(`/og/{slug}.png`) 자동 생성                                                                         |
    | `tags`          |      | 문자열 배열. 문자열 아닌 원소가 섞이면 태그 전체가 무시됨                                                                  |
    | `updatedAt`     |      | Schema.org `dateModified`, sitemap `lastmod`에 사용                                                                        |
-   | `scheduledDate` |      | **시각까지 지정할 때만.** 날짜만이면 `date`로 충분                                                                         |
+   | `scheduledDate` |      | **시각까지 지정할 때만.** 날짜만이면 `date`로 충분. 이걸 써도 `date`는 여전히 필수                                          |
 
    `series`는 frontmatter가 아니라 **폴더 경로**로 결정됩니다(`repository.ts`).
 
@@ -297,7 +297,7 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
    > `published`가 남아 있으면 `lint:posts`가 `legacy-published-field` 에러를 냅니다.
 
 3. **빌드 전 처리** (`prebuild` → `scripts/build-content.ts` 통합 진입점):
-   - `validate-posts.ts`: frontmatter 필수 필드, 폐기된 `published` 필드, `scheduled`의 공개 시각 존재 여부, 끊긴 이미지, 중복 slug 검사 (prebuild에서만 실행, predev에서는 skip)
+   - `validate-posts.ts`: frontmatter 필수 필드(`status`·`title`·`date`), 폐기된 `published` 필드, 날짜 형식/timezone 모호성, 끊긴 이미지, 중복 slug 검사 (prebuild에서만 실행, predev에서는 skip)
    - `sync-posts.mjs`: 포스트 디렉토리의 이미지/미디어 파일을 `public/posts/`에 복사 (mtime 기반 incremental — 변경분만 복사)
    - `generate-sitemap.ts`: 발행된 글 목록으로 `sitemap.xml` 생성
    - `generate-rss.ts`: RSS 피드(`rss.xml`) 생성

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,17 +268,17 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
    **Frontmatter 전체 목록** — 여기 없는 키는 `lint:posts`가 `unknown-frontmatter-key`로
    경고합니다. `domain/post/types.ts`의 `RawFrontmatter`가 단일 출처입니다.
 
-   | 키              | 필수 | 설명                                                                                                                       |
-   | :-------------- | :--: | :------------------------------------------------------------------------------------------------------------------------- |
-   | `status`        |  ✅  | `published` \| `draft` \| `scheduled`. **이 키가 없으면 포스트가 아니라 메타 노트로 간주되어 빌드에서 통째로 제외됩니다.** |
-   | `title`         |  ✅  | 없으면 파일명으로 폴백하지만 `lint:posts`가 에러                                                                           |
+   | 키              | 필수 | 설명                                                                                                                              |
+   | :-------------- | :--: | :-------------------------------------------------------------------------------------------------------------------------------- |
+   | `status`        |  ✅  | `published` \| `draft` \| `scheduled`. **이 키가 없으면 포스트가 아니라 메타 노트로 간주되어 빌드에서 통째로 제외됩니다.**        |
+   | `title`         |  ✅  | 없으면 파일명으로 폴백하지만 `lint:posts`가 에러                                                                                  |
    | `date`          |  ✅  | `'YYYY-MM-DD'`. 목록 정렬·아카이브·sitemap·RSS가 모두 사용하고, `scheduled`일 때는 공개 시각이기도 함. 없으면 `missing-date` 에러 |
-   | `slug`          |      | URL. 없으면 파일 경로에서 유도                                                                                             |
-   | `excerpt`       |      | 없으면 본문 앞 160자                                                                                                       |
-   | `thumbnail`     |      | 없으면 빌드 시 OG 카드(`/og/{slug}.png`) 자동 생성                                                                         |
-   | `tags`          |      | 문자열 배열. 문자열 아닌 원소가 섞이면 태그 전체가 무시됨                                                                  |
-   | `updatedAt`     |      | Schema.org `dateModified`, sitemap `lastmod`에 사용                                                                        |
-   | `scheduledDate` |      | **시각까지 지정할 때만.** 날짜만이면 `date`로 충분. 이걸 써도 `date`는 여전히 필수                                          |
+   | `slug`          |      | URL. 없으면 파일 경로에서 유도                                                                                                    |
+   | `excerpt`       |      | 없으면 본문 앞 160자                                                                                                              |
+   | `thumbnail`     |      | 없으면 빌드 시 OG 카드(`/og/{slug}.png`) 자동 생성                                                                                |
+   | `tags`          |      | 문자열 배열. 문자열 아닌 원소가 섞이면 태그 전체가 무시됨                                                                         |
+   | `updatedAt`     |      | Schema.org `dateModified`, sitemap `lastmod`에 사용                                                                               |
+   | `scheduledDate` |      | **시각까지 지정할 때만.** 날짜만이면 `date`로 충분. 이걸 써도 `date`는 여전히 필수                                                |
 
    `series`는 frontmatter가 아니라 **폴더 경로**로 결정됩니다(`repository.ts`).
 

--- a/apps/blog/web/scripts/validate-posts.test.ts
+++ b/apps/blog/web/scripts/validate-posts.test.ts
@@ -128,11 +128,38 @@ test('validatePost: status가 유효하지 않아도 나머지 검사를 계속�
   assert.ok(!found.includes('meta-file-skipped'));
 });
 
-test('validatePost: scheduled인데 scheduledDate도 date도 없음 → scheduled-without-date', () => {
+// ── date 필수 ────────────────────────────────────────────────────────────────
+// date는 목록 정렬·아카이브·sitemap·RSS가 모두 읽고, scheduled의 공개 시각이기도
+// 하다. 예전에는 없어도 조용히 통과했다.
+
+test('validatePost: date 누락 → missing-date', () => {
   assert.ok(
-    rules({ title: 'x', status: 'scheduled' }).includes(
-      'scheduled-without-date',
-    ),
+    rules({ title: 'x', status: 'published' }).includes('missing-date'),
+  );
+  assert.ok(rules({ title: 'x', status: 'draft' }).includes('missing-date'));
+});
+
+test('validatePost: scheduled인데 date가 없으면 missing-date (영원히 비공개)', () => {
+  // 예전 scheduled-without-date 규칙을 대체한다. date가 필수가 되면서
+  // "scheduledDate도 date도 없음" 조건이 missing-date에 완전히 포섭됐다.
+  const issues = validatePost(
+    rec({ title: 'x', status: 'scheduled' }),
+    '---\ntitle: x\n---\n',
+  );
+  const found = issues.filter(i => i.rule === 'missing-date');
+  assert.equal(found.length, 1, 'missing-date가 정확히 하나여야 함(중복 없음)');
+  assert.match(found[0].message, /영원히 비공개/);
+  assert.ok(!issues.some(i => i.rule === 'scheduled-without-date'));
+});
+
+test('validatePost: scheduledDate만 있고 date가 없으면 missing-date', () => {
+  // 공개 시각은 scheduledDate로 정해지지만 정렬·아카이브·표시는 여전히 date를 본다.
+  assert.ok(
+    rules({
+      title: 'x',
+      status: 'scheduled',
+      scheduledDate: '2026-06-01T09:00:00+09:00',
+    }).includes('missing-date'),
   );
 });
 
@@ -200,6 +227,7 @@ test('validatePost: scheduledDate offset 명시 → 이슈 없음', () => {
     rules({
       title: 'x',
       status: 'scheduled',
+      date: '2026-06-01',
       scheduledDate: '2026-06-01T09:00:00+09:00',
     }),
     [],
@@ -226,11 +254,21 @@ test('validatePost: 알 수 없는 frontmatter 키 → unknown-frontmatter-key (
 
 test('validatePost: 절대/http thumbnail은 fs 검사 없이 통과', () => {
   assert.deepEqual(
-    rules({ title: 'x', status: 'published', thumbnail: '/abs.png' }),
+    rules({
+      title: 'x',
+      status: 'published',
+      date: '2025-01-01',
+      thumbnail: '/abs.png',
+    }),
     [],
   );
   assert.deepEqual(
-    rules({ title: 'x', status: 'published', thumbnail: 'https://cdn/x.png' }),
+    rules({
+      title: 'x',
+      status: 'published',
+      date: '2025-01-01',
+      thumbnail: 'https://cdn/x.png',
+    }),
     [],
   );
 });

--- a/apps/blog/web/scripts/validate-posts.ts
+++ b/apps/blog/web/scripts/validate-posts.ts
@@ -138,7 +138,22 @@ export function validatePost(record: PostRecord, raw: string): Issue[] {
     });
   }
 
-  if (data.date != null) {
+  // `date`는 선택 필드가 아닙니다. 목록 정렬(filtering.ts), 아카이브 연도 필터,
+  // sitemap lastmod, RSS pubDate가 모두 이 값을 읽고, `status: scheduled`는 이 값을
+  // 공개 시각으로 씁니다(visibility.ts). 없으면 목록에서 날짜가 비고 예약 글은
+  // 영원히 비공개가 되는데, 지금까지는 아무 경고 없이 통과했습니다.
+  if (data.date == null) {
+    issues.push({
+      file: relPath,
+      line: findFrontmatterLine(raw, 'date'),
+      severity: 'error',
+      rule: 'missing-date',
+      message:
+        data.status === 'scheduled'
+          ? '`date` 필드가 필요합니다. `status: scheduled`는 `date`를 공개 시각으로 쓰므로, 없으면 영원히 비공개 처리됩니다.'
+          : '`date` 필드가 필요합니다. 목록 정렬·아카이브·sitemap·RSS가 모두 이 값을 사용합니다.',
+    });
+  } else {
     const dateValid =
       data.date instanceof Date ||
       (typeof data.date === 'string' && !Number.isNaN(Date.parse(data.date)));
@@ -208,18 +223,11 @@ export function validatePost(record: PostRecord, raw: string): Issue[] {
   }
 
   if (data.status === 'scheduled') {
-    // 공개 시각은 scheduledDate가 있으면 그것, 없으면 date (visibility.ts와 동일 규칙).
-    // 둘 다 없으면 영원히 비공개가 되므로 에러로 막습니다.
-    if (typeof data.scheduledDate !== 'string' && data.date == null) {
-      issues.push({
-        file: relPath,
-        line: findFrontmatterLine(raw, 'status'),
-        severity: 'error',
-        rule: 'scheduled-without-date',
-        message:
-          '`status: scheduled`에는 `scheduledDate` 또는 `date` 중 하나가 필요합니다. 둘 다 없으면 영원히 비공개 처리됩니다. (시각까지 지정할 때만 `scheduledDate`를 쓰고, 날짜만 쓸 거면 `date`로 충분합니다)',
-      });
-    } else if (
+    // 공개 시각이 아예 없는 경우는 위의 missing-date가 잡습니다. 예전에는 여기서
+    // scheduled-without-date로 따로 검사했지만, date가 필수가 되면서 그 조건
+    // (`scheduledDate도 date도 없음`)은 missing-date에 완전히 포섭돼 같은 파일에
+    // 에러 두 개가 뜰 뿐이었습니다.
+    if (
       typeof data.scheduledDate === 'string' &&
       Number.isNaN(Date.parse(data.scheduledDate))
     ) {


### PR DESCRIPTION
## 배경

`date`는 사실상 필수 필드인데도 `validate-posts`가 누락을 잡지 못했습니다.

| 쓰는 곳 | 근거 |
| :--- | :--- |
| 목록 정렬 | `filtering.ts:58,61` |
| 아카이브 연도 필터 | `filtering.ts:47` |
| sitemap `lastmod` / RSS `pubDate` | 생성 스크립트 |
| **`status: scheduled`의 공개 시각** | `visibility.ts` (`scheduledDate ?? date`) |

없으면 목록에서 날짜가 비고, 예약 글은 공개 시각이 없어 **영원히 비공개**가 됩니다. 그런데도 지금까지는 아무 경고 없이 통과했습니다.

## 변경

`date`가 없으면 `missing-date` 에러를 냅니다. status에 따라 메시지를 다르게 했습니다.

- `published` / `draft` → 목록 정렬·아카이브·sitemap·RSS가 모두 이 값을 사용한다
- `scheduled` → 위 + **없으면 영원히 비공개 처리된다**

### `scheduled-without-date` 규칙을 흡수했습니다

기존에 이런 규칙이 있었습니다.

```ts
if (typeof data.scheduledDate !== 'string' && data.date == null)
  → 'scheduled-without-date'
```

`missing-date`(`data.date == null`)가 이 조건을 **완전히 포섭**합니다. 남겨두면 `status: scheduled` + `date` 없는 글에 에러가 두 개 뜨고, 예외 케이스가 없어 중복을 피할 방법도 없습니다. 그래서 제거하고 "영원히 비공개" 경고는 `missing-date` 메시지로 옮겼습니다.

### 부수 효과

`scheduledDate`만 있고 `date`가 없는 글도 이제 에러입니다. 공개 시각은 `scheduledDate`가 정하지만 정렬·아카이브·표시는 여전히 `date`를 보기 때문입니다. **해당하는 글은 0건**이라 실제 영향은 없습니다.

## 테스트

신규 3개:

- `published` / `draft`에서 `date` 누락 → `missing-date`
- `scheduled`에서 `date` 누락 → `missing-date`가 **정확히 1건**(중복 없음), 메시지에 "영원히 비공개" 포함, `scheduled-without-date`는 나오지 않음
- `scheduledDate`만 있고 `date` 없음 → `missing-date`

기존 3개 수정:

- `scheduled-without-date` 테스트를 `missing-date`로 대체
- "이슈 없음"을 단언하던 두 테스트(`scheduledDate offset 명시`, `절대/http thumbnail`)에 `date` 추가

```
node --test : 478 passed / 0 failed
lint:posts  : 52개 검사, 에러 0건 (경고 3건은 기존 메타 노트)
tsc --noEmit: 통과
eslint      : 통과
```

## 맥락

`status` enum을 `published: boolean` + `date` 조합으로 바꾸는 후속 작업의 선행 단계입니다. 그 모델에서는 `date`가 공개 여부 판정의 근거가 되므로 누락이 곧 판정 불가입니다. 지금 모델에서도 `date`는 이미 필수에 가까워서 먼저 잠가둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
