### PR TITLE
ci: Renovate 자동화 복구 — 봇 PR 리뷰·프리뷰 차단 + automerge 확대

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,26 @@ on:
 
 jobs:
   claude-review:
+    # 봇이 연 PR은 원칙적으로 리뷰하지 않되, major 업데이트만 예외로 받는다.
+    #
+    # claude-code-action은 non-human actor를 거부한다
+    # ("Workflow initiated by non-human actor: renovate (type: Bot)").
+    # 그대로 두면 의존성 PR마다 실패한 체크가 붙는다.
+    #
+    # minor/patch의 판정 기준은 "코드 품질"이 아니라 "올려도 안 깨지나"이고
+    # 그건 CI가 본다 — diff도 대부분 lockfile이라 리뷰할 코드가 없다.
+    # 반면 major는 release note를 이 저장소 코드와 대조할 가치가 있으므로,
+    # renovate.json이 붙이는 deps-major 라벨을 보고 리뷰를 돌린다.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' ||
+      contains(github.event.pull_request.labels.*.name, 'deps-major')
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/apps/blog/web/vercel.json
+++ b/apps/blog/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "renovate/**": false
+    }
+  }
+}

--- a/apps/next.js/vercel.json
+++ b/apps/next.js/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "renovate/**": false
+    }
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,13 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
   "rangeStrategy": "bump",
+  "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 10am on monday"],
-    "semanticCommitScope": "deps"
+    "semanticCommitScope": "deps",
+    "automerge": true,
+    "platformAutomerge": true
   },
   "packageRules": [
     {
@@ -67,10 +70,38 @@
       "semanticCommitScope": "ci"
     },
     {
+      "description": "devDependencies의 minor/patch는 자동 머지",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "description": "프로덕션 의존성은 patch만 자동 머지",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "@types/*는 타입 정의뿐이라 minor까지 자동 머지",
+      "matchPackageNames": ["/^@types\\//"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "GitHub Actions의 minor/patch도 자동 머지",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "major는 자동 머지하지 않고 deps-major 라벨을 붙인다 — 이 라벨이 붙은 PR만 claude-code-review.yml이 리뷰한다",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["deps-major"],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "group:definitelyTyped",
+    "group:jsUnitTest",
+    "group:nextjsMonorepo"
+  ],
   "timezone": "Asia/Seoul",
   "schedule": ["before 10am on monday"],
   "prHourlyLimit": 2,
@@ -10,61 +17,22 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 10am on monday"],
-    "semanticCommitScope": "deps",
     "automerge": true,
     "platformAutomerge": true
   },
   "packageRules": [
     {
-      "matchPackageNames": ["/^@types\\//"],
-      "groupName": "types",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "matchPackageNames": [
-        "eslint",
-        "typescript-eslint",
-        "/^eslint-/",
-        "/^@eslint\\//"
-      ],
-      "groupName": "eslint",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "matchPackageNames": [
-        "jest",
-        "vitest",
-        "ts-jest",
-        "babel-jest",
-        "msw",
-        "jsdom",
-        "/^jest-/",
-        "/^@testing-library\\//"
-      ],
-      "groupName": "testing",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "matchPackageNames": ["next", "eslint-config-next", "/^@next\\//"],
-      "groupName": "next",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "matchPackageNames": ["react", "react-dom", "react-router"],
-      "groupName": "react",
-      "semanticCommitScope": "deps"
-    },
-    {
+      "description": "프리셋에 없는 그룹 — TanStack",
       "matchPackageNames": ["/^@tanstack\\//"],
-      "groupName": "tanstack",
-      "semanticCommitScope": "deps"
+      "groupName": "tanstack"
     },
     {
+      "description": "프리셋에 없는 그룹 — Panda CSS",
       "matchPackageNames": ["/^@pandacss\\//"],
-      "groupName": "panda",
-      "semanticCommitScope": "deps"
+      "groupName": "panda"
     },
     {
+      "description": "GitHub Actions는 ci scope로 묶는다 (기본 scope는 deps)",
       "matchManagers": ["github-actions"],
       "groupName": "ci",
       "semanticCommitScope": "ci"


### PR DESCRIPTION
## 배경

Renovate가 마이그레이션(#106) 이후 2개월 넘게 PR을 한 건도 만들지 않았습니다. 원인은 GitHub App 미설치가 아니라 **Mend의 Silent 모드**였습니다 — App은 설치돼 있었고 job도 2~3일 간격으로 정상 실행 중이었지만, Silent 모드가 PR·이슈 생성을 막고 있었습니다. Mend가 신규 설치에 적용하는 기본값입니다.

대시보드에서 Silent를 끄고 `Automated PRs`를 켜자 60초 만에 첫 PR(#141, dompurify 보안 업데이트)이 열렸습니다. 그런데 그 PR을 보니 자동화를 막는 요소가 셋 더 있었습니다.

## 변경

### 1. 봇 PR에서 Claude 리뷰를 건너뛴다 (major는 예외)

`claude-code-action`은 봇이 트리거한 워크플로우를 거부합니다.

```
Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot).
```

그대로 두면 의존성 PR마다 실패 체크가 붙고, 체크가 green이어야 발동하는 automerge까지 막힙니다. 의존성 PR에서 판정할 것은 "코드 품질"이 아니라 "올려도 안 깨지나"이고 그건 CI가 봅니다 — diff도 대부분 lockfile이라 리뷰할 코드가 없습니다.

다만 **major는 예외**입니다. release note를 저장소 코드와 대조하는 건 CI가 못 하는 일이라, `renovate.json`이 붙이는 `deps-major` 라벨이 있는 PR만 리뷰합니다.

### 2. `renovate/**` 브랜치의 Vercel 프리뷰 배포를 끈다

의존성 PR마다 `ant-blog`, `fe-lab-next-js` 두 프로젝트가 프리뷰를 빌드하고 있었습니다. `git.deploymentEnabled`로 차단합니다(minimatch 문법). 두 프로젝트의 root directory가 각각 `apps/blog/web`, `apps/next.js`라 `vercel.json`도 두 곳에 둡니다.

### 3. automerge 범위 확대 + 수동 그룹 규칙 정리

- 프로덕션 patch, `@types` minor/patch, GitHub Actions minor/patch, `lockFileMaintenance`까지 automerge 대상에 추가
- major는 automerge를 끄고 `deps-major` 라벨을 붙임
- 수동 그룹 규칙 5개를 내장 프리셋으로 교체 (`group:definitelyTyped`, `group:jsUnitTest`, `group:nextjsMonorepo`). `eslint`·`react`는 `config:recommended`가 이미 커버하므로 규칙 자체를 삭제
- 각 규칙의 `semanticCommitScope: "deps"` 제거 — Renovate 기본값이라 중복이었습니다

## 저장소 설정 (이 PR 밖에서 함께 적용)

| 항목 | 변경 |
| :--- | :--- |
| Mend 대시보드 | Silent mode OFF, Automated PRs ON |
| repo 설정 | `allow_auto_merge` true — 이게 꺼져 있어 `platformAutomerge`가 무력화 상태였습니다 |
| `main` branch protection | `Lint / Types / Tests`만 required status check. admin 우회 허용이라 직접 push는 그대로 가능합니다 |
| 라벨 | `deps-major` 생성 |

branch protection이 특히 중요합니다. required check가 하나도 없으면 Renovate는 브랜치의 **모든** 체크가 green이길 기다리므로, Vercel PENDING 같은 부수 체크 하나가 automerge를 멈춥니다. CI만 required로 지정하면 나머지 상태와 무관하게 머지됩니다.

## 확인 방법

`renovate.json` 변경은 base 브랜치 기준으로 읽히므로, 프리셋 그룹핑이 의도대로 도는지는 **머지 후** Dependency Dashboard에서 확인할 수 있습니다. 이 PR 자체는 사람이 연 PR이라 Claude 리뷰가 정상 동작하는지 보는 검증도 됩니다.
