### PR TITLE
ci(renovate): pnpm overrides·catalog도 automerge 대상에 넣는다

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,13 @@
       "platformAutomerge": true
     },
     {
+      "description": "pnpm-workspace.yaml의 overrides·catalog도 minor/patch까지 자동 머지. overrides는 대부분 transitive 의존성의 보안 패치이고, catalog는 전역 고정이라 영향 범위가 넓지만 CI가 lint·types·test를 모두 돌린다. 이 규칙이 없으면 depType이 dependencies/devDependencies 어느 쪽도 아니라 automerge가 전혀 걸리지 않는다",
+      "matchDepTypes": ["pnpm-workspace.overrides", "/^pnpm\\.catalog\\./"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
       "description": "@types/*는 타입 정의뿐이라 minor까지 자동 머지",
       "matchPackageNames": ["/^@types\\//"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
보안 PR 9건이 열렸는데 automerge가 한 건도 걸리지 않았습니다.

## 원인

`pnpm-workspace.yaml`의 항목들은 depType이 다릅니다.

| 위치 | depType |
| :--- | :--- |
| `overrides:` | `pnpm-workspace.overrides` |
| `catalog:` | `pnpm.catalog.default` |
| 각 앱 `package.json` | `dependencies` / `devDependencies` |

기존 규칙은 `dependencies`/`devDependencies`만 매칭해서, overrides·catalog는 전부 비켜갔습니다. 이 저장소는 보안 패치 대상 대부분(dompurify·postcss·qs·fast-uri·brace-expansion·js-yaml)이 `overrides:`에 있어 automerge가 사실상 무력했습니다.

## 변경

`matchDepTypes`에 `pnpm-workspace.overrides`와 `/^pnpm\\.catalog\\./`를 추가합니다.

- catalog에는 next·react·typescript 같은 전역 고정이 들어 있어 영향 범위가 넓지만, CI가 lint·check-types·test를 모두 돌리므로 minor까지 허용했습니다
- major는 뒤에 오는 규칙이 automerge를 다시 끄므로 영향받지 않습니다
- catalog 매칭을 정규식으로 둬서 나중에 named catalog를 도입해도 규칙을 고칠 필요가 없습니다