### PR TITLE
ci(renovate): Renovate 커밋 author를 저장소 소유자로 지정한다

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
   "prConcurrentLimit": 10,
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
+  "gitAuthor": "sangwook <rewq5991@gmail.com>",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 10am on monday"],


### PR DESCRIPTION
GitHub contributors 그래프는 커밋 author를 집계합니다. squash 머지를 해도 Renovate PR의 author는 `renovate[bot]`으로 남습니다.

```
05c19e7  author: renovate[bot]   committer: GitHub   dompurify (#141)
4d7b973  author: renovate[bot]   committer: GitHub   vite (#146)
```

GitHub에는 contributors에서 봇을 숨기는 설정이 없어서, author 자체를 바꾸는 것 외에 방법이 없습니다.

## 변경

`gitAuthor`를 저장소 소유자로 지정합니다.

## 검증이 필요한 부분

**Mend 호스팅 앱에서 이 설정이 실제로 적용되는지 문서로 확인하지 못했습니다.** 공식 문서의 해당 섹션을 읽지 못해 self-hosted 전용 제한이 있는지 알 수 없습니다. 다음 Renovate 커밋의 author를 보고 판단하고, 적용되지 않으면 되돌리겠습니다.

## 남는 것

과거 커밋(dependabot 18건, renovate 2건)은 히스토리 rewrite 없이 바꿀 수 없습니다. main 607커밋에 협업자도 있어 force push는 하지 않습니다.