### PR TITLE
fix(deps): brace-expansion·js-yaml을 major 점프 없이 패치 라인으로 올린다

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,8 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/runtime': 7.29.2
   '@tootallnate/once': 3.0.1
-  brace-expansion@1: 1.1.13
+  brace-expansion@1: 1.1.16
+  brace-expansion@5: 5.0.8
   diff@4: 4.0.4
   dompurify: 3.4.12
   fast-uri: 3.1.4
@@ -40,7 +41,8 @@ overrides:
   form-data@2: 2.5.5
   form-data@4: 4.0.5
   glob@10: 10.5.0
-  js-yaml@3: 3.14.2
+  js-yaml@3: 3.15.0
+  js-yaml@4: 4.3.0
   mdast-util-to-hast: 13.2.1
   minimatch@3: 3.1.5
   picomatch@2: 2.3.2
@@ -2536,12 +2538,12 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3926,12 +3928,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@27.4.0:
@@ -6442,7 +6444,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8137,12 +8139,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9391,7 +9393,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -9776,12 +9778,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -10507,11 +10509,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,12 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@babel/runtime': 7.29.2
   '@tootallnate/once': 3.0.1
-  'brace-expansion@1': 1.1.13
+  # v2부터 CJS default export가 함수 → named export 객체로 바뀌었다. minimatch@3
+  # (eslint가 끌어온다)이 require('brace-expansion')을 함수로 호출하므로 v1을 유지한다.
+  # 1.1.16에서 DoS advisory(GHSA-3jxr-9vmj-r5cp)가 패치됐다.
+  'brace-expansion@1': 1.1.16
+  # @pandacss/dev → ts-morph → minimatch@10이 쓰는 v5 라인. 5.0.7 미만이 같은 advisory 대상.
+  'brace-expansion@5': 5.0.8
   'diff@4': 4.0.4
   dompurify: 3.4.12
   fast-uri: 3.1.4
@@ -14,7 +19,12 @@ overrides:
   'form-data@2': 2.5.5
   'form-data@4': 4.0.5
   'glob@10': 10.5.0
-  'js-yaml@3': 3.14.2
+  # gray-matter@4.0.3이 yaml.safeLoad/safeDump(v3 API)를 모듈 로드 시점에 바인딩한다.
+  # v4는 이 둘을 throw 스텁으로 남겨서 올리면 프론트매터 파싱이 전부 죽는다.
+  # CVE-2026-53550(GHSA-h67p-54hq-rp68)은 v3 라인에도 3.15.0으로 백포트됐다.
+  'js-yaml@3': 3.15.0
+  # @eslint/eslintrc가 끌어오는 v4 라인. 같은 advisory가 4.0.0~4.1.1을 대상으로 한다.
+  'js-yaml@4': 4.3.0
   mdast-util-to-hast: 13.2.1
   'minimatch@3': 3.1.5
   'picomatch@2': 2.3.2

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,13 @@
       "platformAutomerge": true
     },
     {
+      "description": "brace-expansion·js-yaml overrides는 소비자가 요구하는 major 라인에 묶여 있다. minimatch@3(eslint 경유)은 brace-expansion v1의 CJS 콜러블 export를, gray-matter는 js-yaml v3의 safeLoad를 각각 요구한다. major를 올리면 lint와 프론트매터 파싱이 즉시 죽으므로 제안 자체를 막는다. advisory는 두 라인 모두 백포트가 있어 major 없이 닫힌다",
+      "matchDepTypes": ["pnpm-workspace.overrides"],
+      "matchPackageNames": ["brace-expansion", "js-yaml"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "major는 자동 머지하지 않고 deps-major 라벨을 붙인다 — 이 라벨이 붙은 PR만 claude-code-review.yml이 리뷰한다",
       "matchUpdateTypes": ["major"],
       "addLabels": ["deps-major"],


### PR DESCRIPTION
Renovate가 연 보안 PR #147·#148이 **둘 다 CI를 깨뜨렸습니다.** 원인이 같습니다 — overrides로 고정된 transitive 의존성을 major 경계 너머로 밀어올렸는데, 그 경계가 바로 이 selector들이 존재하는 이유였습니다.

## 왜 깨졌나

| PR | 시도 | 결과 |
| :--- | :--- | :--- |
| #147 | `brace-expansion@1` 1.1.13 → **5.0.8** | v2부터 CJS default export가 함수 → named export 객체. `minimatch@3`(eslint 경유)이 `require()` 결과를 함수로 호출 → `TypeError: expand is not a function`, lint 3개 즉사 |
| #148 | `js-yaml@3` 3.14.2 → **4.3.0** | `gray-matter@4.0.3`이 로드 시점에 `safeLoad`/`safeDump`를 바인딩하는데 v4는 throw 스텁. 프론트매터 파싱 전멸 → 테스트 56건 실패 |

`gray-matter`는 2019년 이후 릴리스가 없어 상류 수정본도 없습니다.

## 어떻게 고쳤나

두 advisory 모두 **원래 라인에 백포트가 있어 major 없이 닫힙니다.**

```
brace-expansion@1  1.1.13 → 1.1.16   GHSA-3jxr-9vmj-r5cp
js-yaml@3          3.14.2 → 3.15.0   GHSA-h67p-54hq-rp68
```

덤으로 **원래 PR들이 놓친 같은 advisory의 다른 major 라인**도 닫았습니다. `@pandacss/dev → ts-morph → minimatch@10`이 쓰는 `brace-expansion 5.0.5`와 `@eslint/eslintrc`가 끌어오는 `js-yaml 4.1.1`이 각각 취약 범위였습니다 — #147·#148을 그대로 머지했어도 이건 남았을 겁니다.

```
brace-expansion@5  신규 5.0.8
js-yaml@4          신규 4.3.0
```

`renovate.json`에는 이 두 패키지 overrides의 major 제안을 끄는 규칙을 넣어 같은 실패가 반복되지 않게 했습니다.

## 남는 것

`brace-expansion` v1의 OOM advisory는 **1.1.17**에서 패치되는데 오늘 배포라 pnpm 11의 `minimumReleaseAge` 정책(24시간)에 막힙니다. 정책을 예외로 뚫는 대신 하루 뒤 Renovate가 v1 라인 patch로 올리게 둡니다 — 해당 경로는 eslint 툴체인이라 프로덕션 번들에 들어가지 않습니다.

## 검증

- `pnpm install --frozen-lockfile` 통과
- `pnpm turbo run lint check-types test --force` → **17/17 성공** (캐시 0)
- `pnpm audit`에서 js-yaml 항목 전부 소멸

머지되면 #147·#148은 닫습니다.