### PR TITLE
test(react): react-router 라우팅 스모크 테스트를 추가한다

### DIFF
--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -12,7 +12,7 @@
     "test": "vitest --run"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.22.0"
   },
   "dependencies": {
     "@design-system/ui": "workspace:^",

--- a/apps/react/src/routing.test.tsx
+++ b/apps/react/src/routing.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter, Link, Route, Routes } from 'react-router';
+
+/**
+ * react-router 라우팅 스모크 테스트.
+ *
+ * `main.tsx`의 라우터는 `createRoot` + MSW worker 부팅과 얽혀 있어 직접 렌더할 수 없다.
+ * 대신 이 앱이 실제로 쓰는 react-router 표면 — declarative 모드의
+ * `BrowserRouter` / `Routes` / `Route` / `Link` — 를 런타임에서 검증한다.
+ *
+ * 메이저 업그레이드(v7 -> v8 등) 때 타입 검사만으로는 드러나지 않는
+ * 경로 매칭·클라이언트 사이드 네비게이션 회귀를 잡는 것이 목적이다.
+ */
+
+/** `main.tsx`의 라우트 테이블과 동일한 경로 목록. */
+const ROUTE_PATHS = [
+  '/',
+  '/error-test',
+  '/error-design',
+  '/toast',
+  '/socket',
+  '/stok-ticker-query',
+] as const;
+
+function TestApp() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {ROUTE_PATHS.map(path => (
+          <Route
+            key={path}
+            path={path}
+            element={<div data-testid="active-route">{path}</div>}
+          />
+        ))}
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+describe('react-router declarative routing', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+  });
+
+  it.each(ROUTE_PATHS)('경로 %s 가 해당 route element를 렌더한다', path => {
+    window.history.pushState({}, '', path);
+
+    render(<TestApp />);
+
+    expect(screen.getByTestId('active-route')).toHaveTextContent(path);
+  });
+
+  it('매칭되는 라우트가 없으면 아무 element도 렌더하지 않는다', () => {
+    window.history.pushState({}, '', '/이런-경로는-없다');
+
+    render(<TestApp />);
+
+    expect(screen.queryByTestId('active-route')).not.toBeInTheDocument();
+  });
+
+  it('<Link>는 실제 href를 가진 앵커를 렌더한다', () => {
+    render(
+      <BrowserRouter>
+        <Link to="/toast">Toast</Link>
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Toast' })).toHaveAttribute(
+      'href',
+      '/toast',
+    );
+  });
+
+  it('<Link> 클릭 시 전체 새로고침 없이 클라이언트 사이드로 이동한다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <Link to="/error-design">에러 디자인</Link>
+        <Routes>
+          <Route path="/" element={<div>홈</div>} />
+          <Route
+            path="/error-design"
+            element={<div data-testid="error-design">에러 디자인 페이지</div>}
+          />
+        </Routes>
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('홈')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('link', { name: '에러 디자인' }));
+
+    expect(await screen.findByTestId('error-design')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/error-design');
+    expect(screen.queryByText('홈')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#149(react-router 7 → 8)을 검토하다 발견한 공백을 메웁니다.

## 왜

**업그레이드 이전 `apps/react`의 테스트 11파일 71건 중 라우터를 렌더하는 것이 하나도 없었습니다.** MSW 핸들러도 loader가 아니라 React Query 훅에만 붙어 있습니다. 즉 #149의 CI green은 라우팅에 대해 아무것도 보증하지 않았고, v8이 경로 매칭이나 `<Link>`를 깨뜨렸더라도 그대로 통과했을 겁니다.

## 무엇을

`main.tsx`의 라우터는 `createRoot` + MSW worker 부팅과 얽혀 직접 렌더할 수 없어서, 이 앱이 **실제로 쓰는 표면**(`BrowserRouter` / `Routes` / `Route` / `Link`)을 런타임에서 검증합니다.

- 라우트 6개의 경로별 매칭
- 미매칭 경로에서 아무것도 렌더하지 않음
- `<Link>`가 실제 `href`를 가진 앵커를 만듦
- 클릭 시 **전체 새로고침 없이** 클라이언트 사이드로 이동

`engines.node`도 `>=22` → `>=22.22.0`으로 맞춥니다. react-router 8.3.0의 `engines`가 `>=22.22.0`인데 앱은 22.0~22.21을 허용한다고 선언하고 있었습니다. 실사용에는 영향이 없지만(`.tool-versions`가 24.17.0) 선언이 사실과 어긋났습니다.

## 검증

- `pnpm --filter react test` → **12파일 80건 통과** (기존 11파일 71건)
- `pnpm turbo run lint check-types test --force` → **17/17 성공** (캐시 0)

참고: 미매칭 경로 케이스는 react-router가 `No routes matched location` 경고를 stderr로 냅니다. 의도된 동작을 검증하는 것이라 실패가 아닙니다.