### PR TITLE
ci(vercel): main 프로덕션 배포를 끄고 PR 프리뷰만 남긴다

### DIFF
--- a/apps/blog/web/vercel.json
+++ b/apps/blog/web/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
+      "main": false,
       "renovate/**": false
     }
   }

--- a/apps/next.js/vercel.json
+++ b/apps/next.js/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
+      "main": false,
       "renovate/**": false
     }
   }


### PR DESCRIPTION
automerge를 켠 뒤 의존성 PR이 자동 머지되면서 **오늘 하루에만 Vercel 프로덕션 배포가 28회**(프로젝트당 14회) 돌았습니다. 그런데 이 배포들은 아무도 보지 않습니다.

```
blog.sangwook.dev           server: GitHub.com     ← 실서비스
ant-blog.vercel.app         200, server: Vercel    ← 같은 내용의 사본
fe-lab-next-js.vercel.app   404                    ← 서비스되지 않음
```

블로그 실서비스는 **GitHub Pages**입니다. 게다가 `deploy-blog.yml`은 `paths: ['apps/blog/**']`로 제한돼 있어 **의존성 머지로는 아예 돌지 않습니다.** 진짜 배포처는 조용한데 사본만 28번 빌드된 셈입니다.

## 변경

```json
"deploymentEnabled": {
  "main": false,        // 추가
  "renovate/**": false
}
```

| 상황 | 지금 | 바꾼 뒤 |
| :--- | :--- | :--- |
| 의존성 머지 (main push) | 배포 2회 | **0회** |
| 사용자 PR | 프리뷰 2회 | 프리뷰 유지 |
| Renovate PR | 차단됨 | 차단 유지 |

**PR 프리뷰는 남깁니다.** GitHub Pages에는 프리뷰 기능이 없으니, 블로그 디자인을 머지 전에 눈으로 확인하는 용도로는 값어치가 있습니다.

`fe-lab-next-js`가 404인 건 별개 문제로 남겨둡니다.