### PR TITLE
Revert: Renovate gitAuthor — Mend 호스팅에서 동작하지 않음

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
   "prConcurrentLimit": 10,
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
-  "gitAuthor": "sangwook <rewq5991@gmail.com>",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 10am on monday"],


### PR DESCRIPTION
#153에서 넣은 `gitAuthor`가 **Mend 호스팅 앱에서는 동작하지 않는 것을 실측으로 확인**했습니다. 그 PR에 "다음 Renovate 커밋의 author를 보고 판단하고, 적용되지 않으면 되돌린다"고 적어둔 대로 되돌립니다.

## 실측

Dependency Dashboard(#150)의 체크박스로 새 PR을 즉시 트리거해 확인했습니다.

```
설정값        sangwook <rewq5991@gmail.com>
실제 author   renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
committer     GitHub <noreply@github.com>
GH user       renovate[bot]
```

## 스키마로도 예측할 수 없었습니다

`renovate-schema.json`을 받아 확인한 결과, `gitAuthor`는 **스키마상 완전히 유효한 옵션**입니다.

```json
{
  "description": "Author to use for Git commits. Must conform to RFC5322.",
  "type": "string"
}
```

스키마 378개 정의 중 self-hosted 제한을 표기한 항목은 `toolSettings` 하나뿐이라, **스키마도 `renovate-config-validator`도 이 설정이 호스팅 환경에서 무시된다는 걸 알려주지 않습니다.** 실제로 돌려보는 것 말고는 확인할 방법이 없었습니다.

동작하지 않는 설정을 남겨두면 다음에 보는 사람이 "적용돼 있다"고 오해하므로 지웁니다.

## 결과

GitHub contributors 그래프에는 `renovate[bot]`이 계속 쌓입니다. GitHub에 봇을 숨기는 설정이 없고 author도 바꿀 수 없으니, 이를 피하려면 Renovate PR을 사람이 직접 cherry-pick해 push하는 수밖에 없습니다 — automerge를 포기한다는 뜻이라 얻는 것보다 잃는 게 큽니다.