### PR TITLE
fix: Lighthouse 회귀 해소 — 렌더 블로킹 CSS·초기 JS 감축 + 접근성 AA 복구

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,9 +335,18 @@ The blog (`apps/blog/web/`) is a **statically generated (SSG) Next.js applicatio
 - **robots.txt**: `/public/robots.txt`
 - **OpenGraph/Twitter Card**: `layout.tsx` 메타데이터에 설정
 - **Google Analytics**: `@next/third-parties` GA4 연동 (`G-ZS9ENFSSQ0`)
+- **Google Tag Manager**: `@next/third-parties` GTM 연동 (`GTM-5SMPQ23P`). GA4와 **별개로** `layout.tsx`에서 함께 로드된다
 - **GA Proxy**: `apps/ga-proxy/`로 Velog 등 외부 플랫폼 조회수 추적
 - **검색 인증**: Naver 사이트 인증 메타태그 포함
 - **검색 인덱스**: `search-index.json`으로 클라이언트 사이드 검색 지원
+
+> **GTM 컨테이너는 이 저장소 밖에 있다.** 코드에 있는 건 컨테이너 ID 한 줄뿐이고,
+> 어떤 태그가 실제로 발사되는지는 GTM 웹 콘솔에만 존재한다. 2026-07-30 Lighthouse
+> 점검(이슈 #165)에서 이 컨테이너가 **Microsoft Clarity**(`clarity.ms`, `c.bing.com`)를
+> 로드해 서드파티 쿠키 8개를 심는 것이 확인됐고, 그 때문에 Best Practices가 세 페이지
+> 모두 77점이다(`third-party-cookies` 가중치 5 + `inspector-issues` 1 = 26점 중 6점 감점).
+> 태그를 추가·제거할 때 여기와 `/privacy` 페이지를 함께 갱신할 것 — 현재 개인정보처리방침은
+> GA4만 고지하고 있어 Clarity가 누락된 상태다.
 
 #### 인증 & Admin
 

--- a/apps/blog/web/scripts/validate-posts.ts
+++ b/apps/blog/web/scripts/validate-posts.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import { collectMarkdownFiles, hasFrontmatter } from '@/lib/postFiles';
 import { hasAmbiguousTimezone } from '@/lib/dates';
 import { POST_STATUSES, isPostStatus, isPostFile } from '@/domain/post';
+import { SUPPORTED_FENCE_LABELS } from '@/src/components/post/prismLanguages';
 
 const POSTS_DIR = resolve(process.cwd(), '..', 'posts');
 
@@ -335,6 +336,55 @@ function validateImageReferences(record: PostRecord, raw: string): Issue[] {
   return issues;
 }
 
+/**
+ * 코드 펜스의 언어 라벨이 CodeBlock에 등록된 언어인지 검사합니다.
+ *
+ * CodeBlock은 refractor 전 언어를 번들하는 대신 `prismLanguages.ts`에 적힌
+ * 언어만 등록합니다(번들 gzip 350KB 절감). 등록되지 않은 라벨은 에러 없이
+ * 그냥 강조 없는 평문으로 렌더되기 때문에, 글쓴이가 알아채기 어렵습니다.
+ * 그 조용한 품질 저하를 빌드 시점 경고로 끌어올립니다.
+ *
+ * 중첩 펜스(마크다운 글이 코드 예시로 ```를 품는 경우)를 오탐하지 않도록,
+ * 여는 펜스의 백틱 개수를 기억했다가 같은 개수 이상으로 닫힐 때까지는
+ * 내부를 검사하지 않습니다.
+ */
+function validateCodeFenceLanguages(record: PostRecord, raw: string): Issue[] {
+  const issues: Issue[] = [];
+  const offset = frontmatterOffset(raw);
+  const lines = record.content.split('\n');
+  let openFenceLength = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s{0,3})(`{3,})(.*)$/);
+    if (!m) continue;
+    const fenceLength = m[2].length;
+    const info = m[3].trim();
+
+    if (openFenceLength > 0) {
+      // 열려 있는 펜스는 라벨 없는 같은 길이 이상의 펜스로만 닫힌다.
+      if (fenceLength >= openFenceLength && info === '') openFenceLength = 0;
+      continue;
+    }
+
+    openFenceLength = fenceLength;
+    if (info === '') continue;
+
+    // ```ts title="a.ts" 처럼 뒤에 메타가 붙는 경우 첫 토큰만 언어다.
+    const label = info.split(/[\s,{]/)[0].toLowerCase();
+    if (!label || SUPPORTED_FENCE_LABELS.has(label)) continue;
+
+    issues.push({
+      file: record.relPath,
+      line: offset + i + 1,
+      severity: 'warning',
+      rule: 'unregistered-code-language',
+      message: `구문 강조에 등록되지 않은 언어입니다: \`${label}\` — 강조 없이 평문으로 렌더됩니다. src/components/post/prismLanguages.ts에 추가하거나 평문 라벨(text)을 쓰세요.`,
+    });
+  }
+
+  return issues;
+}
+
 // 명시 slug가 없으면 파일경로(확장자 제거)를 기본 slug로 사용 — repository.ts의 rawSlug 규칙과 동일
 function deriveDefaultSlug(relPath: string): string {
   return relPath.replace(/\.(md|mdx)$/, '');
@@ -386,6 +436,7 @@ function main() {
     records.push(record);
     allIssues.push(...validatePost(record, raw));
     allIssues.push(...validateImageReferences(record, raw));
+    allIssues.push(...validateCodeFenceLanguages(record, raw));
   }
 
   allIssues.push(...detectDuplicateSlugs(records));

--- a/apps/blog/web/src/app/layout.tsx
+++ b/apps/blog/web/src/app/layout.tsx
@@ -1,4 +1,9 @@
-import 'pretendard/dist/web/static/pretendard-dynamic-subset.css';
+// 가변(variable) 동적 서브셋. 예전엔 static 동적 서브셋을 썼는데, 그건 9개
+// 웨이트 × 92개 유니코드 서브셋 × (woff2 + woff) = @font-face 828개짜리
+// 542KB 스타일시트라 렌더 블로킹 CSS 청크가 gzip 137KB까지 부풀었다(Lighthouse
+// unused-css-rules에서 100% 미사용으로 잡힌 파일이 이것). 가변 폰트 한 벌이면
+// 같은 서브셋 92개를 @font-face 92개로 덮고, 웨이트는 45~920 축에서 뽑는다.
+import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';
 import '@/src/styles/globals.css';
 import { Providers } from './providers';
 import { Layout } from '@/src/components/Layout';

--- a/apps/blog/web/src/app/page.tsx
+++ b/apps/blog/web/src/app/page.tsx
@@ -311,8 +311,13 @@ export default function HomePage() {
                   </Link>
                 </div>
                 <ol className={css({ listStyleType: 'none', p: '0', m: '0' })}>
+                  {/* PostIndexRow의 루트는 <a>다. <ol> 바로 밑에 두면 목록
+                      구조가 깨진다(axe list, impact serious). PopularRail·
+                      PostsArchive와 같이 <li>로 감싼다. */}
                   {recent.map(p => (
-                    <PostIndexRow key={p.slug} post={p} />
+                    <li key={p.slug}>
+                      <PostIndexRow post={p} />
+                    </li>
                   ))}
                 </ol>
               </div>

--- a/apps/blog/web/src/app/page.tsx
+++ b/apps/blog/web/src/app/page.tsx
@@ -168,7 +168,10 @@ export default function HomePage() {
                     href="/posts/?focus=search"
                   />
                   <div>
+                    {/* 바로 아래 MiniPostCard가 h4라, 이 라벨이 span이면
+                        FeaturedPost의 h2에서 h4로 두 단계를 건너뛴다. */}
                     <Label
+                      as="h3"
                       tone="meta"
                       className={css({
                         display: 'block',

--- a/apps/blog/web/src/components/blog/FeaturedPost.tsx
+++ b/apps/blog/web/src/components/blog/FeaturedPost.tsx
@@ -62,7 +62,7 @@ export const FeaturedPost = ({ post }: FeaturedPostProps) => {
           <span
             className={css(tagPillStyle, {
               bg: 'moss.100',
-              color: 'moss.600',
+              color: 'moss.700',
               fontWeight: 'semibold',
             })}
           >

--- a/apps/blog/web/src/components/blog/Label.tsx
+++ b/apps/blog/web/src/components/blog/Label.tsx
@@ -1,9 +1,15 @@
 import { css } from '@design-system/ui-lib/css';
 import type { ReactNode, HTMLAttributes } from 'react';
 
-interface LabelProps extends HTMLAttributes<HTMLSpanElement> {
+interface LabelProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
   tone?: 'meta' | 'marker' | 'moss' | 'ink';
+  /**
+   * 렌더링할 태그. 기본은 의미 없는 `span`이지만, 라벨 뒤에 곧바로 헤딩이
+   * 오는 섹션(예: 홈의 "이번 주 함께 읽기 좋은 글" → MiniPostCard의 h4)에서는
+   * 레벨을 건너뛰지 않도록 `as="h3"`처럼 헤딩으로 올려준다.
+   */
+  as?: 'span' | 'h2' | 'h3' | 'h4';
 }
 
 const toneColor = {
@@ -16,11 +22,12 @@ const toneColor = {
 export const Label = ({
   children,
   tone = 'meta',
+  as: Tag = 'span',
   className,
   ...rest
 }: LabelProps) => {
   return (
-    <span
+    <Tag
       {...rest}
       className={[
         css({
@@ -37,6 +44,6 @@ export const Label = ({
         .join(' ')}
     >
       {children}
-    </span>
+    </Tag>
   );
 };

--- a/apps/blog/web/src/components/blog/PopularRail.tsx
+++ b/apps/blog/web/src/components/blog/PopularRail.tsx
@@ -50,7 +50,9 @@ export const PopularRail = ({ posts, limit = 5 }: PopularRailProps) => {
 
   return (
     <aside className={css({ position: 'sticky', top: '20' })}>
-      <span
+      {/* 섹션 라벨은 h3. 아래 포스트 제목이 h4라 span으로 두면 헤딩 레벨이
+          건너뛰어져 axe heading-order가 깨진다(홈 기준 h2 → h3 → h4). */}
+      <h3
         className={css({
           display: 'block',
           mb: '3',
@@ -61,7 +63,7 @@ export const PopularRail = ({ posts, limit = 5 }: PopularRailProps) => {
         })}
       >
         Popular · 30일
-      </span>
+      </h3>
       <ol
         className={css({
           listStyleType: 'none',

--- a/apps/blog/web/src/components/blog/PostsArchive.tsx
+++ b/apps/blog/web/src/components/blog/PostsArchive.tsx
@@ -218,7 +218,11 @@ export const PostsArchiveView = ({
               mb: '4',
             })}
           >
-            <Label tone="meta">{filtered.length}편</Label>
+            {/* 아래 목록 카드/행 제목이 h3라, 이 라벨이 span이면 페이지 h1에서
+                h3로 건너뛴다(axe heading-order). 목록의 섹션 헤딩으로 올린다. */}
+            <Label as="h2" tone="meta">
+              {filtered.length}편
+            </Label>
           </div>
 
           {filtered.length === 0 ? (

--- a/apps/blog/web/src/components/blog/SearchBox.tsx
+++ b/apps/blog/web/src/components/blog/SearchBox.tsx
@@ -76,7 +76,9 @@ export const SearchBox = ({
           className={css({
             fontFamily: 'mono',
             fontSize: '2xs',
-            color: 'ink.500',
+            // paper.200 위에서는 ink.500도 AA에 못 미친다(라이트 4.31:1).
+            // 같은 서피스를 쓰는 tagPillStyle과 동일하게 ink.700을 쓴다.
+            color: 'ink.700',
             borderWidth: '[1px]',
             borderColor: 'ink.border',
             bg: 'paper.200',

--- a/apps/blog/web/src/components/blog/SeriesCard.tsx
+++ b/apps/blog/web/src/components/blog/SeriesCard.tsx
@@ -110,6 +110,9 @@ export const SeriesCard = ({ series, index }: SeriesCardProps) => {
           className={css(tagPillStyle, {
             px: '[8px]',
             bg: 'paper.300',
+            // tagPillStyle 기본 ink.700은 paper.200 기준이라, 한 단계 진한
+            // paper.300 위에서는 11px 기준 4.40:1로 AA에 못 미친다.
+            color: 'ink.800',
             fontFamily: 'mono',
           })}
         >

--- a/apps/blog/web/src/components/mobile/BackToTop.tsx
+++ b/apps/blog/web/src/components/mobile/BackToTop.tsx
@@ -29,6 +29,9 @@ export const BackToTop = () => {
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.8 }}
           onClick={scrollToTop}
+          // MobileTOC와 같은 이유 — 아이콘 단독 버튼이라 이름이 필요하다.
+          // 스크롤 전에는 렌더되지 않아 axe 스캔에 안 잡혔을 뿐, 같은 결함이다.
+          aria-label="맨 위로 이동"
           whileTap={{ scale: 0.9 }}
           className={css({
             pos: 'fixed',

--- a/apps/blog/web/src/components/mobile/MobileTOC.tsx
+++ b/apps/blog/web/src/components/mobile/MobileTOC.tsx
@@ -28,6 +28,9 @@ export const MobileTOC = () => {
       {/* Floating Button */}
       <motion.button
         onClick={() => setIsOpen(true)}
+        // 아이콘만 있는 버튼이라 접근 가능한 이름이 없었다(axe button-name,
+        // impact critical). lucide 아이콘은 aria-hidden된 svg라 이름을 못 준다.
+        aria-label="목차 열기"
         initial={{ scale: 0 }}
         animate={{ scale: 1 }}
         whileTap={{ scale: 0.9 }}

--- a/apps/blog/web/src/components/post/CodeBlock.tsx
+++ b/apps/blog/web/src/components/post/CodeBlock.tsx
@@ -225,6 +225,10 @@ export function CodeBlock({
           background: 'transparent',
         }}
         {...props}
+        // 코드 블록은 가로 스크롤되는데 포커스를 받을 수 없어 키보드만 쓰는
+        // 사용자가 잘린 코드를 볼 방법이 없었다(axe scrollable-region-focusable,
+        // impact serious — 글 하나에 10곳). props 뒤에 둬서 덮이지 않게 한다.
+        tabIndex={0}
       >
         {content}
       </SyntaxHighlighter>

--- a/apps/blog/web/src/components/post/CodeBlock.tsx
+++ b/apps/blog/web/src/components/post/CodeBlock.tsx
@@ -1,12 +1,38 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { css, cx } from '@design-system/ui-lib/css';
 import { token } from '@design-system/ui-lib/tokens';
-import { MermaidChart } from './MermaidChart';
 import { codeText, isBlockCode } from './markdownCode';
+
+// mermaid는 d3·dagre까지 끌고 와 raw 1.1MB(gzip 360KB)짜리 청크가 된다.
+// 정적 import면 CodeBlock을 쓰는 모든 글 — 즉 mermaid 다이어그램이 하나도
+// 없는 글까지 — 이 청크를 초기 로드에 포함한다(71편 중 mermaid를 쓰는 건 6편).
+// 아래 `language === 'mermaid'` 분기에 도달할 때만 받아오도록 분리한다.
+// MermaidChart는 원래도 useEffect 안에서만 렌더하므로 ssr: false로 잃는 건 없다.
+const MermaidChart = dynamic(
+  () => import('./MermaidChart').then(m => m.MermaidChart),
+  {
+    ssr: false,
+    // 청크를 받는 동안 도표 자리를 잡아둬 레이아웃 시프트를 막는다.
+    loading: () => <div className={mermaidBoxStyle} />,
+  },
+);
+
+// MermaidChart 내부 컨테이너와 같은 박스 — placeholder와 실제 도표의 자리가
+// 어긋나지 않게 여기서도 동일한 여백/테두리를 쓴다.
+const mermaidBoxStyle = css({
+  my: '10',
+  p: '6',
+  minH: '[120px]',
+  bg: 'paper.100',
+  rounded: '2xl',
+  borderWidth: '[1px]',
+  borderColor: 'ink.border',
+});
 
 function CopyButton({ content }: { content: string }) {
   const [isCopied, setIsCopied] = useState(false);

--- a/apps/blog/web/src/components/post/CodeBlock.tsx
+++ b/apps/blog/web/src/components/post/CodeBlock.tsx
@@ -29,7 +29,11 @@ function CopyButton({ content }: { content: string }) {
         px: '2',
         py: '1',
         fontSize: 'xs',
-        color: 'ink.500',
+        // 코드블록 크롬은 테마와 무관하게 항상 어둡다(#161b22/#12171d/#212a35).
+        // 여기에 테마-가변 ink.500을 쓰면 라이트 테마에서 진한 회색 글자가
+        // 어두운 배경에 얹혀 2.89:1까지 떨어진다. 크롬 색과 같은 계열의
+        // 고정 밝은 회색을 쓴다.
+        color: '[#9198a1]',
         bg: '[#212a35]',
         rounded: 'md',
         borderWidth: 'thin',
@@ -116,7 +120,8 @@ export function CodeBlock({
           <span
             className={css({
               ml: '4',
-              color: 'ink.500',
+              // CopyButton과 동일 — 항상 어두운 크롬 위의 고정 밝은 회색.
+              color: '[#9198a1]',
               fontSize: 'xs',
               textTransform: 'uppercase',
               letterSpacing: 'widest',

--- a/apps/blog/web/src/components/post/CodeBlock.tsx
+++ b/apps/blog/web/src/components/post/CodeBlock.tsx
@@ -2,11 +2,64 @@
 
 import { useState, useCallback } from 'react';
 import dynamic from 'next/dynamic';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import markup from 'react-syntax-highlighter/dist/cjs/languages/prism/markup';
+import cssLang from 'react-syntax-highlighter/dist/cjs/languages/prism/css';
+import javascript from 'react-syntax-highlighter/dist/cjs/languages/prism/javascript';
+import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
+import typescript from 'react-syntax-highlighter/dist/cjs/languages/prism/typescript';
+import tsx from 'react-syntax-highlighter/dist/cjs/languages/prism/tsx';
+import bash from 'react-syntax-highlighter/dist/cjs/languages/prism/bash';
+import yaml from 'react-syntax-highlighter/dist/cjs/languages/prism/yaml';
+import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import diff from 'react-syntax-highlighter/dist/cjs/languages/prism/diff';
+import markdown from 'react-syntax-highlighter/dist/cjs/languages/prism/markdown';
+import docker from 'react-syntax-highlighter/dist/cjs/languages/prism/docker';
+import jsExtras from 'react-syntax-highlighter/dist/cjs/languages/prism/js-extras';
+import jsdoc from 'react-syntax-highlighter/dist/cjs/languages/prism/jsdoc';
 import { css, cx } from '@design-system/ui-lib/css';
 import { token } from '@design-system/ui-lib/tokens';
 import { codeText, isBlockCode } from './markdownCode';
+import { PRISM_LANGUAGES, type PrismLanguageName } from './prismLanguages';
+
+// `Prism` export는 refractor 전 언어(300여 종)를 번들해 gzip 350KB 청크가
+// 된다. 글이 실제로 쓰는 fence는 십여 종뿐이라 PrismLight로 바꾸고 필요한
+// 언어만 등록한다. refractor 5의 언어 모듈은 의존성을 스스로 등록하므로
+// (예: tsx → jsx + typescript) 등록 순서를 신경 쓸 필요가 없다.
+// 목록과 순서의 단일 출처는 prismLanguages.ts이고, 아래 맵이 그와 어긋나면
+// prismLanguages.test.tsx가 실패한다. (순서도 의미가 있다 — 주석 참고)
+export const LANGUAGE_MODULES: Record<PrismLanguageName, unknown> = {
+  markup,
+  css: cssLang,
+  javascript,
+  jsx,
+  'js-extras': jsExtras,
+  jsdoc,
+  typescript,
+  tsx,
+  bash,
+  yaml,
+  json,
+  diff,
+  markdown,
+  docker,
+};
+
+for (const [name, mod] of Object.entries(LANGUAGE_MODULES)) {
+  SyntaxHighlighter.registerLanguage(name, mod);
+}
+// refractor의 register()는 언어 함수만 등록하고 별칭은 붙이지 않는다.
+// `js`/`ts`/`md`/`dockerfile` 같은 라벨이 평문으로 떨어지지 않도록 따로 건다.
+SyntaxHighlighter.alias(
+  Object.fromEntries(
+    Object.entries(PRISM_LANGUAGES)
+      .filter(([, aliases]) => aliases.length > 0)
+      // PRISM_LANGUAGES는 `as const`라 별칭이 readonly 튜플이다. refractor의
+      // alias()는 mutable string[]을 받으므로 복사해서 넘긴다.
+      .map(([name, aliases]) => [name, [...aliases]] as const),
+  ),
+);
 
 // mermaid는 d3·dagre까지 끌고 와 raw 1.1MB(gzip 360KB)짜리 청크가 된다.
 // 정적 import면 CodeBlock을 쓰는 모든 글 — 즉 mermaid 다이어그램이 하나도

--- a/apps/blog/web/src/components/post/prismLanguages.test.tsx
+++ b/apps/blog/web/src/components/post/prismLanguages.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * 구문 강조 언어 목록의 단일 출처가 실제로 단일한지 지키는 테스트.
+ *
+ * CodeBlock은 번들 크기 때문에 refractor 전 언어 대신 PrismLight + 필요한
+ * 언어만 등록한다. 그 목록은 두 곳에서 쓰인다.
+ *
+ *   1. CodeBlock.tsx — 실제 언어 모듈 import + 등록
+ *   2. prismLanguages.ts — 데이터. validate-posts.ts가 읽어 fence 라벨을 검증
+ *
+ * 둘이 어긋나면 증상이 조용하다. 언어를 1에만 추가하면 lint가 멀쩡한 fence를
+ * 경고하고, 2에만 추가하면 lint는 통과하는데 실제로는 강조가 안 된다.
+ * 그래서 키 집합이 같은지 여기서 못박는다.
+ */
+import { describe, expect, test } from 'vitest';
+import { LANGUAGE_MODULES } from './CodeBlock';
+import {
+  PRISM_LANGUAGES,
+  SUPPORTED_FENCE_LABELS,
+  PLAIN_FENCE_LABELS,
+} from './prismLanguages';
+
+describe('prism 언어 등록 목록', () => {
+  test('CodeBlock이 등록하는 언어와 prismLanguages의 키가 순서까지 일치한다', () => {
+    // 순서까지 보는 이유: 등록 순서가 렌더 결과를 바꾼다(아래 테스트 참고).
+    expect(Object.keys(LANGUAGE_MODULES)).toEqual(Object.keys(PRISM_LANGUAGES));
+  });
+
+  test('javascript 문법 확장이 typescript보다 먼저 등록된다', () => {
+    // typescript는 javascript 문법을 복제해 만들어진다. 확장이 뒤에 오면
+    // .ts 코드 블록에서 타입 이름(known-class-name) 색이 빠진다.
+    const order = Object.keys(LANGUAGE_MODULES);
+    for (const ext of ['js-extras', 'jsdoc']) {
+      expect(
+        order.indexOf(ext),
+        `${ext}는 typescript보다 먼저 등록돼야 한다`,
+      ).toBeLessThan(order.indexOf('typescript'));
+    }
+  });
+
+  test('등록된 모듈이 모두 실제 refractor 언어 함수다', () => {
+    for (const [name, mod] of Object.entries(LANGUAGE_MODULES)) {
+      expect(typeof mod, `${name} 모듈`).toBe('function');
+      expect(
+        (mod as { displayName?: string }).displayName,
+        `${name} 이름`,
+      ).toBe(name);
+    }
+  });
+
+  test('별칭과 평문 라벨이 허용 목록에 포함된다', () => {
+    for (const alias of Object.values(PRISM_LANGUAGES).flat()) {
+      expect(SUPPORTED_FENCE_LABELS.has(alias), `별칭 ${alias}`).toBe(true);
+    }
+    for (const plain of PLAIN_FENCE_LABELS) {
+      expect(SUPPORTED_FENCE_LABELS.has(plain), `평문 ${plain}`).toBe(true);
+    }
+  });
+
+  test('mermaid는 별도 렌더러로 처리하므로 lint가 경고하지 않는다', () => {
+    expect(SUPPORTED_FENCE_LABELS.has('mermaid')).toBe(true);
+  });
+
+  test('문법 확장 전용 항목은 fence 라벨로 허용하지 않는다', () => {
+    expect(SUPPORTED_FENCE_LABELS.has('js-extras')).toBe(false);
+    expect(SUPPORTED_FENCE_LABELS.has('jsdoc')).toBe(false);
+  });
+
+  test('등록하지 않은 언어는 허용 목록에 없다 — lint가 잡아야 한다', () => {
+    for (const unknown of ['python', 'rust', 'go', 'code']) {
+      expect(SUPPORTED_FENCE_LABELS.has(unknown), unknown).toBe(false);
+    }
+  });
+});

--- a/apps/blog/web/src/components/post/prismLanguages.ts
+++ b/apps/blog/web/src/components/post/prismLanguages.ts
@@ -1,0 +1,79 @@
+/**
+ * 코드 블록 구문 강조에 등록하는 Prism 언어 목록 — **단일 출처**.
+ *
+ * `react-syntax-highlighter`의 `Prism` export는 refractor의 전 언어(300여 종)를
+ * 통째로 번들해 gzip 350KB짜리 청크가 된다. 이 블로그가 실제로 쓰는 fence
+ * 언어는 십여 종이라 `PrismLight` + 필요한 언어만 등록으로 바꿨다.
+ *
+ * 이 파일은 **데이터만** 둔다. `validate-posts.ts`(tsx로 도는 Node 스크립트)가
+ * 같은 목록을 읽어 등록되지 않은 fence 언어를 빌드 시점에 잡아내야 하는데,
+ * 여기서 react-syntax-highlighter를 import하면 그 스크립트까지 무거워진다.
+ * 실제 언어 모듈 import와 등록은 CodeBlock.tsx가 하고, 두 곳의 키가 어긋나지
+ * 않는지는 CodeBlock.test.ts가 검증한다.
+ */
+
+/**
+ * 등록할 언어 → refractor가 함께 받아주는 별칭.
+ *
+ * **선언 순서가 곧 등록 순서이고, 순서가 결과를 바꾼다.** refractor 5의 언어
+ * 모듈은 의존성을 스스로 등록하므로(tsx → jsx + typescript) 보통은 순서를
+ * 신경 쓸 필요가 없지만, 문법을 *덧입히는* 확장은 예외다. `typescript`는
+ * `javascript` 문법을 복제해서 만들어지므로, javascript를 패치하는
+ * js-extras·jsdoc이 typescript보다 **먼저** 등록돼야 그 결과가 typescript/tsx
+ * 코드 블록에도 실린다.
+ */
+export const PRISM_LANGUAGES = {
+  markup: ['html', 'xml', 'svg'],
+  css: [],
+  javascript: ['js'],
+  jsx: [],
+  // fence 라벨이 아니라 javascript 문법 확장. 전체 Prism 번들에는 딸려 오던
+  // 것이라 PrismLight로 바꾸며 한 번 빠뜨렸는데, 스크린샷을 픽셀 비교해 보니
+  // `Promise` / `NonNullable` / `FileHandle` 같은 타입 이름이 청록색을 잃었다
+  // (known-class-name 토큰이 사라져서). 시각적으로 유의미하므로 반드시 유지.
+  'js-extras': [],
+  jsdoc: [],
+  typescript: ['ts'],
+  tsx: [],
+  bash: ['sh', 'shell'],
+  yaml: ['yml'],
+  json: [],
+  diff: [],
+  markdown: ['md'],
+  docker: ['dockerfile'],
+} as const satisfies Record<string, readonly string[]>;
+
+export type PrismLanguageName = keyof typeof PRISM_LANGUAGES;
+
+/**
+ * 구문 강조 없이 평문으로 렌더해도 되는 fence 라벨. Prism 언어가 아니지만
+ * 의도적으로 쓰는 것들이라 lint가 경고하지 않도록 허용 목록에 둔다.
+ */
+export const PLAIN_FENCE_LABELS = [
+  'text',
+  'txt',
+  'plaintext',
+  'console',
+  'aiignore',
+  'gitignore',
+] as const;
+
+/** CodeBlock이 별도 렌더러로 처리하는 fence. */
+export const SPECIAL_FENCE_LABELS = ['mermaid'] as const;
+
+/**
+ * 문법 확장 전용 — 등록은 하지만 fence 라벨로 쓰지는 않는다.
+ * (글에 ```js-extras 라고 쓸 일은 없다)
+ */
+const GRAMMAR_EXTENSION_ONLY: ReadonlySet<string> = new Set([
+  'js-extras',
+  'jsdoc',
+]);
+
+/** fence 라벨로 허용되는 값 전체 (등록 언어 + 별칭 + 평문 + 특수). */
+export const SUPPORTED_FENCE_LABELS: ReadonlySet<string> = new Set<string>([
+  ...Object.keys(PRISM_LANGUAGES).filter(n => !GRAMMAR_EXTENSION_ONLY.has(n)),
+  ...Object.values(PRISM_LANGUAGES).flat(),
+  ...PLAIN_FENCE_LABELS,
+  ...SPECIAL_FENCE_LABELS,
+]);

--- a/packages/@design-system/ui/src/blog-preset.ts
+++ b/packages/@design-system/ui/src/blog-preset.ts
@@ -12,13 +12,13 @@ export const blogPreset = definePreset({
         fonts: {
           sans: {
             value:
-              'var(--font-pretendard, Pretendard), -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif',
+              'var(--font-pretendard, "Pretendard Variable"), Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif',
           },
           // GitHub 폼 리디자인: serif 정체성 폐기 → serif 토큰을 system sans로
           // 매핑해 기존 serif 사용처를 일괄 de-serif. (컴포넌트를 안 건드려도 sans 적용)
           serif: {
             value:
-              'var(--font-pretendard, Pretendard), -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif',
+              'var(--font-pretendard, "Pretendard Variable"), Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif',
           },
           mono: {
             value:

--- a/packages/@design-system/ui/src/blog-preset.ts
+++ b/packages/@design-system/ui/src/blog-preset.ts
@@ -86,7 +86,12 @@ export const blogPreset = definePreset({
           'ink.800': { value: { base: '#32383f', _dark: '#c9d1d9' } },
           'ink.700': { value: { base: '#57606a', _dark: '#b1bac4' } },
           'ink.600': { value: { base: '#656d76', _dark: '#8b949e' } },
-          'ink.500': { value: { base: '#6e7781', _dark: '#7d8590' } },
+          // ink.500 — 12px 메타 텍스트(날짜/시리즈/조회수)에 주로 쓰인다.
+          // 예전 값(base #6e7781 / _dark #7d8590)은 카드 서피스(paper.100)
+          // 위에서 4.27:1 / 4.50:1이라 WCAG AA(4.5:1)를 못 넘거나 딱 걸쳤다.
+          // ink.600보다는 여전히 옅게 유지하면서(램프 순서 보존) paper.50·
+          // paper.100 위에서 4.7:1 이상 나오는 값으로 당겼다.
+          'ink.500': { value: { base: '#687079', _dark: '#858e98' } },
           'ink.400': { value: { base: '#8c959f', _dark: '#6e7681' } },
           'ink.300': { value: { base: '#afb8c1', _dark: '#545d68' } },
           'ink.200': { value: { base: '#d0d7de', _dark: '#3d444d' } },
@@ -98,7 +103,10 @@ export const blogPreset = definePreset({
           // accent — 링크/액션 (GitHub blue)
           'accent.50': { value: { base: '#ddf4ff', _dark: '#12243a' } },
           'accent.200': { value: { base: '#54aeff', _dark: '#388bfd' } },
-          'accent.600': { value: { base: '#0969da', _dark: '#58a6ff' } },
+          // 라이트 값은 GitHub 링크 블루(#0969da)에서 한 톤만 내렸다. 원래
+          // 값은 paper.200(인라인 코드/콜아웃 배경) 위 링크에서 4.45:1로 AA를
+          // 아슬하게 놓쳤다. 다크(#58a6ff)는 5.74:1로 충분해 그대로 둔다.
+          'accent.600': { value: { base: '#0866d1', _dark: '#58a6ff' } },
           'accent.700': { value: { base: '#0550ae', _dark: '#79c0ff' } },
           // marker — 강조/하이라이트 액센트. 주황(앰버) 폐기 → GitHub 퍼플
           // (done/sponsors)로 통일. 파랑(링크/데이터)·초록(성공)과 구분되는
@@ -118,6 +126,11 @@ export const blogPreset = definePreset({
             },
           },
           'moss.600': { value: { base: '#1a7f37', _dark: '#3fb950' } },
+          // moss.700 — moss.100 배지 위에 얹는 텍스트 전용. moss.600을 그대로
+          // 쓰면 라이트에서 4.06:1로 AA 미달이라(배지 배경이 초록 12%라 대비가
+          // 깎인다) 한 단계 어두운 값을 따로 둔다. 다크는 moss.600이 이미
+          // 5.17:1로 충분해 같은 값을 유지한다.
+          'moss.700': { value: { base: '#116329', _dark: '#3fb950' } },
           // spot — admin 전용 강조색(청록/teal). Panda 기본 'teal' 스케일과
           // 이름 충돌을 피하려 커스텀 명 'spot' 사용. 퍼플/파랑/초록과 구분.
           'spot.600': { value: { base: '#0e7490', _dark: '#56d4dd' } },


### PR DESCRIPTION
Closes #165

이슈에 적힌 세 카테고리를 모두 확인했습니다. 그 과정에서 **Performance 원인 진단이 실제와 달랐다**는 걸 빌드 산출물에서 확인해 실제 원인을 고쳤고, A11y는 이슈가 지목한 두 노드 외에 같은 audit으로 걸리는 노드가 더 있어 전부 처리했습니다. Best Practices는 코드로 고칠 수 없는 항목이라 문서화만 했습니다.

## 측정 방법

배포본을 그대로 재현하기 위해 `pnpm build --filter=@blog/web --no-cache` 산출물(`out/`)을 로컬 정적 서버로 띄우고, 이슈와 **동일한 Lighthouse 13.4.1**로 측정했습니다. base 커밋과 이 브랜치를 같은 하네스로 각각 빌드해 비교했습니다.

로컬 Accessibility 점수가 이슈의 배포본 수치(90 / 94 / 92)와 **정확히 일치**해서, 재현 환경이 신뢰할 만하다는 걸 먼저 확인했습니다.

## 결과 요약

| URL | Accessibility | Best Practices | SEO |
| --- | --- | --- | --- |
| `/` | 90 → **96** ✅ | 96 → 96 | 100 |
| `/posts/` | 94 → **100** ✅ | 96 → 96 | 100 |
| `/posts/typescript-6-migration-troubleshooting/` | 92 → **95** ✅ | 96 → 96 | 100 |

`color-contrast` / `heading-order` audit은 세 URL 모두 score 0 → **1**. Accessibility는 세 URL 모두 임계값 95를 넘겼습니다.

**Performance 카테고리 점수는 로컬에서 신뢰할 수 없습니다.** loopback은 전송 비용이 0이라 바이트를 줄여도 점수가 거의 안 움직이고, 실측해 보니 run 간 변동(글 상세 31~35)이 개선폭보다 큽니다. 그래서 점수 대신 **원인에 직접 대응하는 지표**를 3회 중앙값으로 측정했습니다 — 아래 각 절에 있습니다.

## 1. Performance ① — 진단 정정: 렌더 블로킹 CSS의 정체는 폰트였습니다

이슈는 `_next/static/chunks/1lpgujhbma0_n.css`(gzip 137KB, `unused-css-rules` wastedPercent 100)를 **Panda가 admin 전용 컴포넌트까지 스캔해 만든 산출물**로 추정했습니다. 빌드해서 열어 보니 아니었습니다.

```
$ ls -laS out/_next/static/chunks/*.css     # base 커밋
481265  1lpgujhbma0_n.css   # gzip 140,322  ← 이슈가 지목한 파일
 61614  3cykl917fj-as.css   # gzip  14,186  ← Panda CSS. 별도 청크이고 정상 크기
  1565  2q8h_5cacrg8m.css

$ head -c 200 out/_next/static/chunks/1lpgujhbma0_n.css
@font-face{font-family:Pretendard;font-style:normal;font-display:swap;font-weight:100;
src:url(../media/Pretendard-Thin.subset.0.…woff2)format("woff2"),…
```

정체는 `layout.tsx`가 임포트하던 **`pretendard/dist/web/static/pretendard-dynamic-subset.css`**였습니다. 9개 웨이트 × 92개 유니코드 서브셋 × (woff2 + woff) = `@font-face` **828개**짜리 542KB 스타일시트입니다. 페이지마다 실제로 받는 서브셋은 몇 개뿐이라 Chrome CSS coverage가 나머지 전부를 미사용으로 세고, 그래서 wastedPercent가 정확히 100으로 찍혔습니다.

Panda CSS는 별도 청크(gzip 14KB)로 잘 분리돼 있어 **admin 코드 스플리팅은 필요하지 않았습니다.**

가변 폰트 동적 서브셋으로 바꿨습니다. 같은 유니코드 커버리지를 `@font-face` 92개로 덮고 웨이트는 45~920 축에서 뽑습니다.

| | before | after |
| --- | --- | --- |
| 렌더 블로킹 CSS (gzip) | 155,154 B | **29,197 B** (−81%) |
| Pretendard `@font-face` | 828개 | **92개** |
| 정적 export 폰트 파일 | 1,662개 / 27 MB | **98개 / 3.1 MB** (−88%) |
| `unused-css-rules` wastedBytes | 481,265 B | **25,946 / 20,916 / 0 B** |

## 2. Performance ② — 초기 JS 42% 감축

이슈가 남긴 `bootup-time` 3.0s / `mainthread-work-breakdown` 5.4s는 CSS가 아니라 JS 쪽이라, 글 상세 페이지가 실제로 받는 청크를 열어 봤습니다. 두 덩어리가 나왔습니다.

**① mermaid (gzip 360KB)** — `CodeBlock`이 `MermaidChart`를 정적 import하고, 그게 top-level에서 `mermaid`를 import합니다. d3·dagre까지 딸려 와 raw 1.1MB 청크가 되는데, **다이어그램이 하나도 없는 글까지** 이걸 받았습니다. mermaid를 쓰는 글은 71편 중 6편입니다. → `next/dynamic`으로 분리. `MermaidChart`는 원래도 `useEffect` 안에서만 렌더하므로 `ssr: false`로 잃는 게 없습니다.

**② refractor 전 언어 정의 (gzip 199KB)** — `react-syntax-highlighter`의 `Prism` export가 abap·cobol·fortran·prolog·zig 등 300여 종을 통째로 번들합니다. 글 전체를 훑어 보니 실제로 쓰는 fence는 17종(별칭 포함)이었습니다. → `PrismLight` + 필요한 언어만 등록.

**글 상세 페이지 초기 JS: 청크 22개 826KB → 15개 483KB (gzip), −42%**

원인 지표를 3회 중앙값으로 측정한 결과(모바일 에뮬레이션, 시뮬레이션 스로틀링):

| 지표 | before | after | |
| --- | --- | --- | --- |
| `bootup-time` | 2,911 ms | **1,579 ms** | −46% |
| `mainthread-work-breakdown` | 7,590 ms | **5,472 ms** | −28% |
| Total Blocking Time | 1,237 ms | **730 ms** | −41% |
| First Contentful Paint | 9,504 ms | **6,175 ms** | −35% |
| Largest Contentful Paint | 25,796 ms | **15,723 ms** | −39% |
| 스크립트 전송량 | 2,973,944 B | **1,800,048 B** | −40% |

### 구문 강조가 조용히 깨질 수 있어 세 겹으로 검증했습니다

언어 목록을 좁히는 건 실패해도 에러가 안 나고 그냥 강조가 사라지는 종류의 변경이라, 다음을 붙였습니다.

1. **단일 출처 + 드리프트 테스트** — 목록을 `prismLanguages.ts`에 두고, CodeBlock의 실제 등록 맵과 키·순서가 일치하는지 테스트로 고정
2. **빌드 타임 lint 규칙** — `validate-posts.ts`에 `unregistered-code-language` 추가. 등록 안 된 fence 언어를 경고로 띄웁니다(중첩 펜스는 백틱 개수를 세어 오탐 방지). 바로 기존 글에서 ` ```code ` 오타를 하나 잡았습니다 — 원래도 강조가 안 되던 자리라 이 PR이 만든 회귀는 아니고, 글 내용이라 손대지 않았습니다
3. **픽셀 + 토큰 색 비교** — 전체 Prism으로 빌드한 대조본을 만들어(폰트 등 나머지 조건 동일) 8개 언어를 쓰는 글 3편을 스크린샷 픽셀 비교하고, 개별 토큰의 computed color까지 대조

3번에서 **강조를 잃은 토큰은 없었습니다.** 유일한 차이는 import 문의 컴포넌트·타입 이름이 변수색 `#9cdcfe` → class-name 색 `#4ec9b0`으로 바뀌는 것인데, 같은 파일 다른 위치에서 이미 쓰던 색이라 오히려 일관성이 맞는 방향입니다. (`typescript`가 `javascript` 문법을 복제해 만들어지므로 `js-extras`·`jsdoc`을 `typescript`보다 먼저 등록해야 하고, 그 순서 의존성은 주석과 테스트로 못박았습니다.)

남은 Performance 격차는 이 PR 범위 밖입니다 — 글 상세는 여전히 gzip 483KB의 JS를 받고, `@ssgoi/react` + motion, react-markdown 계열이 그 대부분입니다.

## 3. Accessibility

이슈가 지목한 두 노드부터 고친 뒤, 같은 audit이 다른 곳에도 걸리는지 axe-core로 **4개 URL × 라이트/다크 = 8개 조합**을 훑었습니다. 이슈가 3개 URL을 기본 테마로만 측정해 놓친 노드가 더 있었고, 그것까지 처리해야 95점을 넘길 수 있었습니다.

### 색 대비 (토큰)

| 토큰 | before | after | 근거 |
| --- | --- | --- | --- |
| `ink.500` (light) | `#6e7781` | `#687079` | paper.100 위 4.27:1 → **4.72:1** |
| `ink.500` (dark) | `#7d8590` | `#858e98` | paper.100 위 4.50:1(경계) → **5.05:1** |
| `accent.600` (light) | `#0969da` | `#0866d1` | paper.200 위 링크 4.45:1 → **4.70:1** |
| `moss.700` (신설) | — | `#116329` / `#3fb950` | moss.100 배지 위 4.06:1 → **5.92:1** |

`ink.500`은 `ink.600`보다 옅다는 램프 순서를 유지하는 범위에서 당겼습니다. `moss.600`은 일반 서피스 위에서 4.77:1 이상이라 그대로 두고, 알파 12% 초록 배지 위 텍스트용으로만 `moss.700`을 새로 뒀습니다.

### 색 대비 (사용처)

- **FeaturedPost** LATEST 배지 → `moss.700` (이슈 지목)
- **SeriesCard** `paper.300` 칩 → `ink.800`. `tagPillStyle` 기본 `ink.700`은 paper.200 기준이라 한 단계 진한 paper.300 위에서 4.40:1 (→ 8.15:1)
- **SearchBox** ⌘K 칩 → `ink.700`. `ink.500`이 paper.200 위에 얹힌 유일한 자리 (→ 5.48:1)
- **CodeBlock** 언어 라벨·Copy 버튼 → 고정 `#9198a1`. 코드블록 크롬은 테마와 무관하게 항상 어두운데(`#161b22`/`#12171d`/`#212a35`) 테마-가변 `ink.500`을 쓰고 있어서, **라이트 테마에서 진한 회색 글자가 어두운 배경에 얹혀 2.89:1**까지 떨어졌습니다 (→ 4.98:1 / 6.18:1). 글 상세에서 25개 노드가 여기서 나왔습니다

### 헤딩 순서

`Label`에 `as` prop을 추가해(기본은 그대로 `span`) 필요한 자리만 헤딩으로 올렸습니다. Panda preflight가 h2~h4의 UA font-size/margin을 리셋하므로 **렌더 결과는 동일**합니다.

- **PopularRail** "Popular · 30일" → `h3` (이슈 지목)
- **홈** "이번 주 함께 읽기 좋은 글" → `h3`. 뒤따르는 MiniPostCard가 `h4`라 FeaturedPost의 `h2`에서 두 단계를 건너뛰고 있었습니다
- **`/posts/`** 아카이브 "N편" → `h2`. 페이지 `h1` 바로 뒤에 카드 제목 `h3`가 와서 `h1 → h3`로 건너뛰고 있었습니다

홈 헤딩 사슬: `h1 → h2 → h3 → h4 → h2 → h3 → h2 → h3 → h4` (건너뜀 없음)

## 4. Best Practices — 코드로 고칠 수 없습니다

이슈 분석이 맞습니다. `third-party-cookies`(가중치 5) + `inspector-issues`(1)로 26점 중 6점이 깎여 20/26 ≈ 0.77이고, 원인은 GTM 컨테이너(`GTM-5SMPQ23P`)가 로드하는 Microsoft Clarity(`clarity.ms`, `c.bing.com`)의 서드파티 쿠키 8개입니다.

**컨테이너 설정은 이 저장소가 아니라 GTM 웹 콘솔에 있습니다.** 저장소에 있는 건 `layout.tsx`의 컨테이너 ID 한 줄뿐이고, 그걸 지우면 Clarity뿐 아니라 컨테이너의 모든 태그가 함께 사라지므로 임의로 판단하지 않았습니다.

방증이 하나 나왔습니다. 로컬 측정에서는 프록시가 `googletagmanager.com`을 막아 GTM이 아예 로드되지 않는데, 그때 **Best Practices가 96점**입니다(배포본 77점). 감점이 전적으로 서드파티에서 온다는 뜻입니다.

대신 CLAUDE.md에 (1) GTM이 GA4와 별개로 로드된다는 사실, (2) 77점의 정확한 산식과 출처, (3) **`/privacy`가 GA4만 고지하고 Clarity는 누락하고 있다**는 점을 기록했습니다. 3번은 점수와 별개로 확인이 필요해 보입니다.

**결정이 필요한 사항**: Clarity 태그를 유지할지. 유지한다면 개인정보처리방침 갱신이, 걷어낸다면 GTM 콘솔 작업이 필요합니다. 어느 쪽이든 이 PR 밖입니다.

## 검증

- `pnpm check-types` ✅ / `pnpm lint` ✅ / `pnpm test` ✅ (전체 통과, blog 96건 — 신규 테스트 포함)
- `pnpm build --filter=@blog/web --no-cache` ✅ 정적 export 성공
- axe-core `color-contrast` + `heading-order`: 4개 URL × 라이트/다크 8개 조합 **위반 0건**
- 구문 강조: 8개 언어 3개 글에서 픽셀·토큰 색 비교, **강조 손실 0**
- 빌드된 HTML에서 `Pretendard Variable`(weight 45–920) 로드 및 헤딩 태그 확인

## 리스크

- 가변 폰트 렌더링이 static 웨이트와 미세하게 다를 수 있어 **배포 후 육안 확인**을 권합니다
- `format('woff2-variations')`를 모르는 아주 오래된 브라우저는 시스템 폰트로 폴백합니다(woff 폴백을 뺀 것이 용량 절감의 일부)
- `ink.500`·`accent.600`은 전역 토큰이라 admin 화면 포함 사용처 전반에 적용됩니다. 방향은 모두 "약간 더 진하게"라 가독성만 좋아집니다
- 새 언어를 쓰는 글을 쓰면 `pnpm lint:posts`가 경고합니다 — `prismLanguages.ts`에 한 줄 추가하면 됩니다

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9ynLMq5SvqvCPcdMgBT8Q