### PR TITLE
perf(blog): 공개 페이지를 PostgREST 클라이언트로 분리해 gzip 51KB를 줄인다

### DIFF
--- a/apps/blog/web/domain/analytics/admin.ts
+++ b/apps/blog/web/domain/analytics/admin.ts
@@ -1,0 +1,26 @@
+/**
+ * Analytics domain의 **admin 전용** 공개 API
+ *
+ * 공개 배럴(`@/domain/analytics`)과 일부러 분리했습니다. 한 배럴에서 둘 다
+ * re-export하면, 공개 페이지가 admin 함수를 안 쓰더라도 번들러가 인증 세션용
+ * supabase-js를 떨궈내지 못했습니다(실측: 홈 청크에 GoTrueClient·RealtimeClient가
+ * 그대로 남음). `lib/client.ts`의 모듈 최상위 `createClient()` 호출이 부수효과라
+ * adminRepository가 그래프에 닿기만 하면 통째로 유지되기 때문입니다.
+ *
+ * 배럴을 나누면 모듈 그래프 자체가 갈라져 트리셰이킹 품질에 기대지 않아도 됩니다.
+ * admin 화면은 이 배럴을, 그 외에는 `@/domain/analytics`를 씁니다.
+ */
+
+export {
+  getAllPostStats,
+  getAllPostsTrends,
+  getAdminPostsIndex,
+  getPostHourlyDistribution,
+  getPostDowDistribution,
+} from './adminRepository';
+
+export type {
+  AdminPostIndex,
+  PostStatsRow,
+  PostTrendRow,
+} from './adminRepository';

--- a/apps/blog/web/domain/analytics/adminRepository.ts
+++ b/apps/blog/web/domain/analytics/adminRepository.ts
@@ -1,0 +1,121 @@
+/**
+ * Analytics 도메인 중 **admin 전용** 데이터 접근 layer.
+ *
+ * 여기 있는 RPC 4건은 PR #114에서 service_role 한정으로 lockdown 되었기
+ * 때문에 anon key로 직접 호출할 수 없고, admin-analytics Edge Function을
+ * 경유합니다. 그래서 인증 세션이 붙은 `lib/client.ts`(전체 supabase-js)가
+ * 필요합니다.
+ *
+ * 공개 페이지용 함수(repository.ts)와 파일을 분리한 이유는 번들입니다.
+ * 한 파일에 있으면 조회수만 읽는 홈·글 상세도 supabase-js 전체(gzip 45KB)를
+ * 함께 받게 됩니다. 특히 예전에는 모듈 최상위에서 `createAdminApiClient(client)`를
+ * 호출하고 있어서, 번들러가 부수효과로 보고 절대 떨궈내지 못했습니다.
+ * 지금은 첫 호출 때 만들어 그 고정점도 없앴습니다.
+ */
+
+import { client } from '@/lib/client';
+import { createAdminApiClient, type AdminApiClient } from '@/lib/adminApi';
+import type { PostStatus } from '@/domain/post/types';
+import type { HourlyDistribution, DowDistribution } from './types';
+
+export interface AdminPostIndex {
+  slug: string;
+  title: string;
+  date: string | null;
+  status: PostStatus;
+  scheduledDate: string | null;
+}
+
+export interface PostStatsRow {
+  slug: string;
+  total_views: number;
+  today_views: number;
+}
+
+export interface PostTrendRow {
+  slug: string;
+  view_date: string;
+  view_count: number;
+}
+
+/** admin-analytics Edge Function 클라이언트 (첫 호출 때 1회 생성) */
+let adminApiInstance: AdminApiClient | null = null;
+function adminApi(): AdminApiClient {
+  adminApiInstance ??= createAdminApiClient(client);
+  return adminApiInstance;
+}
+
+export async function getAllPostStats(): Promise<PostStatsRow[]> {
+  // admin RPC — service_role 한정. Edge Function 경유.
+  const data = await adminApi().call<PostStatsRow[]>('all_post_stats');
+  return (data ?? []).map(s => ({
+    slug: s.slug,
+    total_views: Number(s.total_views),
+    today_views: Number(s.today_views),
+  }));
+}
+
+export async function getAllPostsTrends(): Promise<PostTrendRow[]> {
+  // admin RPC — service_role 한정. Edge Function 경유.
+  // PostgREST 1000-row cap을 피하기 위해 range 페이지네이션을 Edge Function에 위임합니다.
+  const all: PostTrendRow[] = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const data = await adminApi().call<PostTrendRow[]>('all_posts_trends', {
+      range: [from, from + PAGE - 1] as [number, number],
+    });
+    const rows = data ?? [];
+    all.push(
+      ...rows.map(t => ({
+        slug: t.slug,
+        view_date: t.view_date,
+        view_count: Number(t.view_count),
+      })),
+    );
+    if (rows.length < PAGE) break;
+  }
+  return all;
+}
+
+export async function getAdminPostsIndex(): Promise<AdminPostIndex[]> {
+  // 서버 환경(SSG prerender 포함)에서는 상대 URL fetch가 ERR_INVALID_URL.
+  // 어차피 admin은 클라이언트 hydration 후에만 유효하므로 SSR에선 빈 배열로 대기.
+  if (typeof window === 'undefined') return [];
+  const res = await fetch('/admin-posts-index.json');
+  if (!res.ok) {
+    throw new Error(
+      `admin-posts-index.json fetch failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as AdminPostIndex[];
+}
+
+export async function getPostHourlyDistribution(
+  slug: string,
+): Promise<HourlyDistribution[]> {
+  // admin RPC — service_role 한정. Edge Function 경유.
+  const data = await adminApi().call<HourlyDistribution[]>(
+    'post_hourly_distribution',
+    { slug },
+  );
+  if (!data) return [];
+  return data.map(h => ({
+    hour: Number(h.hour),
+    view_count: Number(h.view_count),
+  }));
+}
+
+export async function getPostDowDistribution(
+  slug: string,
+): Promise<DowDistribution[]> {
+  // admin RPC — service_role 한정. Edge Function 경유.
+  const data = await adminApi().call<DowDistribution[]>(
+    'post_dow_distribution',
+    { slug },
+  );
+  if (!data) return [];
+  return data.map(d => ({
+    dow: Number(d.dow),
+    view_count: Number(d.view_count),
+  }));
+}

--- a/apps/blog/web/domain/analytics/index.ts
+++ b/apps/blog/web/domain/analytics/index.ts
@@ -12,20 +12,14 @@ export * from './types';
 // 순수 계산(use-case) + 공유 타입(AnalyticsRange, AnalyticsOverview 등)
 export * from './service';
 
-// 데이터 접근(Supabase / Edge Function / 정적 JSON). 의도적으로 공개하는 함수만 노출.
+// 데이터 접근(PostgREST). 의도적으로 공개하는 함수만 노출.
+//
+// admin 전용 함수는 여기 없습니다 — `@/domain/analytics/admin` 배럴로 나갔습니다.
+// 한 배럴에 두면 공개 페이지 번들에 인증 세션용 supabase-js가 따라붙습니다
+// (이유는 admin.ts 주석 참고). 이 배럴은 익명 권한으로 되는 것만 담습니다.
 export {
   getTopPosts,
   getAllViewCounts,
-  getAllPostStats,
-  getAllPostsTrends,
-  getAdminPostsIndex,
-  getPostHourlyDistribution,
-  getPostDowDistribution,
   incrementViewCount,
 } from './repository';
-export type {
-  AdminPostIndex,
-  PostStatsRow,
-  PostTrendRow,
-  TopPostRow,
-} from './repository';
+export type { TopPostRow } from './repository';

--- a/apps/blog/web/domain/analytics/repository.ts
+++ b/apps/blog/web/domain/analytics/repository.ts
@@ -1,41 +1,16 @@
 /**
- * Analytics 도메인의 Supabase / 정적 자원 접근 layer.
+ * Analytics 도메인 중 **공개 페이지**가 쓰는 데이터 접근 layer.
  *
  * 컴포넌트와 React 훅은 Supabase client를 직접 호출하지 않고
  * 이 모듈의 함수만 사용합니다.
  *
- * admin RPC 4건(getAllPostStats, getAllPostsTrends, getPostHourlyDistribution,
- * getPostDowDistribution)은 PR #114에서 service_role 한정으로 lockdown 되었기 때문에
- * anon key로 직접 호출할 수 없습니다. admin-analytics Edge Function을 경유합니다.
+ * 여기 있는 3건은 모두 익명(anon) 권한의 순수 PostgREST 호출이라
+ * `lib/publicClient.ts`(PostgREST만)로 충분합니다. 인증 세션이 필요한
+ * admin RPC는 `adminRepository.ts`에 따로 있습니다 — 같은 파일에 두면
+ * 조회수만 읽는 페이지까지 supabase-js 전체를 받게 됩니다.
  */
 
-import { client } from '@/lib/client';
-import { createAdminApiClient } from '@/lib/adminApi';
-import type { PostStatus } from '@/domain/post/types';
-import type { HourlyDistribution, DowDistribution } from './types';
-
-/** admin-analytics Edge Function 클라이언트 (싱글턴) */
-const adminApi = createAdminApiClient(client);
-
-export interface AdminPostIndex {
-  slug: string;
-  title: string;
-  date: string | null;
-  status: PostStatus;
-  scheduledDate: string | null;
-}
-
-export interface PostStatsRow {
-  slug: string;
-  total_views: number;
-  today_views: number;
-}
-
-export interface PostTrendRow {
-  slug: string;
-  view_date: string;
-  view_count: number;
-}
+import { publicDb } from '@/lib/publicClient';
 
 export interface TopPostRow {
   slug: string;
@@ -43,7 +18,7 @@ export interface TopPostRow {
 }
 
 export async function getTopPosts(limit: number): Promise<TopPostRow[]> {
-  const { data } = await client
+  const { data } = await publicDb
     .from('post_views')
     .select('slug, view_count')
     .order('view_count', { ascending: false })
@@ -63,89 +38,15 @@ export async function getTopPosts(limit: number): Promise<TopPostRow[]> {
  * 불필요. 1000편을 넘기면 range 페이지네이션을 추가해야 합니다.
  */
 export async function getAllViewCounts(): Promise<TopPostRow[]> {
-  const { data } = await client.from('post_views').select('slug, view_count');
+  const { data } = await publicDb.from('post_views').select('slug, view_count');
   return (data ?? []).map(d => ({
     slug: d.slug,
     view_count: d.view_count ?? 0,
   }));
 }
 
-export async function getAllPostStats(): Promise<PostStatsRow[]> {
-  // admin RPC — service_role 한정. Edge Function 경유.
-  const data = await adminApi.call<PostStatsRow[]>('all_post_stats');
-  return (data ?? []).map(s => ({
-    slug: s.slug,
-    total_views: Number(s.total_views),
-    today_views: Number(s.today_views),
-  }));
-}
-
-export async function getAllPostsTrends(): Promise<PostTrendRow[]> {
-  // admin RPC — service_role 한정. Edge Function 경유.
-  // PostgREST 1000-row cap을 피하기 위해 range 페이지네이션을 Edge Function에 위임합니다.
-  const all: PostTrendRow[] = [];
-  const PAGE = 1000;
-  for (let from = 0; ; from += PAGE) {
-    const data = await adminApi.call<PostTrendRow[]>('all_posts_trends', {
-      range: [from, from + PAGE - 1] as [number, number],
-    });
-    const rows = data ?? [];
-    all.push(
-      ...rows.map(t => ({
-        slug: t.slug,
-        view_date: t.view_date,
-        view_count: Number(t.view_count),
-      })),
-    );
-    if (rows.length < PAGE) break;
-  }
-  return all;
-}
-
-export async function getAdminPostsIndex(): Promise<AdminPostIndex[]> {
-  // 서버 환경(SSG prerender 포함)에서는 상대 URL fetch가 ERR_INVALID_URL.
-  // 어차피 admin은 클라이언트 hydration 후에만 유효하므로 SSR에선 빈 배열로 대기.
-  if (typeof window === 'undefined') return [];
-  const res = await fetch('/admin-posts-index.json');
-  if (!res.ok) {
-    throw new Error(
-      `admin-posts-index.json fetch failed: ${res.status} ${res.statusText}`,
-    );
-  }
-  return (await res.json()) as AdminPostIndex[];
-}
-
-export async function getPostHourlyDistribution(
-  slug: string,
-): Promise<HourlyDistribution[]> {
-  // admin RPC — service_role 한정. Edge Function 경유.
-  const data = await adminApi.call<HourlyDistribution[]>(
-    'post_hourly_distribution',
-    { slug },
-  );
-  if (!data) return [];
-  return data.map(h => ({
-    hour: Number(h.hour),
-    view_count: Number(h.view_count),
-  }));
-}
-
-export async function getPostDowDistribution(
-  slug: string,
-): Promise<DowDistribution[]> {
-  // admin RPC — service_role 한정. Edge Function 경유.
-  const data = await adminApi.call<DowDistribution[]>('post_dow_distribution', {
-    slug,
-  });
-  if (!data) return [];
-  return data.map(d => ({
-    dow: Number(d.dow),
-    view_count: Number(d.view_count),
-  }));
-}
-
 export async function incrementViewCount(slug: string): Promise<void> {
-  const { error } = await client.rpc('increment_view_count', {
+  const { error } = await publicDb.rpc('increment_view_count', {
     slug_input: slug,
   });
   if (error) throw error;

--- a/apps/blog/web/eslint.config.mjs
+++ b/apps/blog/web/eslint.config.mjs
@@ -58,8 +58,6 @@ const eslintConfig = [
             {
               // adminRepository처럼 접두사가 붙은 것도 함께 막습니다.
               group: [
-                '**/domain/*/repository',
-                '**/domain/*/repository.*',
                 '**/domain/*/*[rR]epository',
                 '**/domain/*/*[rR]epository.*',
               ],

--- a/apps/blog/web/eslint.config.mjs
+++ b/apps/blog/web/eslint.config.mjs
@@ -56,27 +56,35 @@ const eslintConfig = [
         {
           patterns: [
             {
-              group: ['**/domain/*/repository', '**/domain/*/repository.*'],
+              // adminRepository처럼 접두사가 붙은 것도 함께 막습니다.
+              group: [
+                '**/domain/*/repository',
+                '**/domain/*/repository.*',
+                '**/domain/*/*[rR]epository',
+                '**/domain/*/*[rR]epository.*',
+              ],
               message:
-                'repository는 인프라 레이어입니다. domain/<x> 공개 API(배럴, 예: @/domain/analytics)를 통해 접근하세요.',
+                'repository는 인프라 레이어입니다. domain/<x> 공개 API(배럴, 예: @/domain/analytics, @/domain/analytics/admin)를 통해 접근하세요.',
             },
           ],
         },
       ],
-      // 주의: 아래 selector는 식별자 이름(client/supabase)에 매칭하므로, Supabase
-      // 클라이언트를 임의 이름으로 alias하면(예: `client as db`) 우회될 수 있습니다.
-      // 클라이언트 import 자체를 lib/client로 한정하는 컨벤션과 함께 봐야 합니다.
+      // 주의: 아래 selector는 식별자 이름(client/supabase/publicDb)에 매칭하므로,
+      // Supabase 클라이언트를 임의 이름으로 alias하면(예: `client as db`) 우회될
+      // 수 있습니다. 클라이언트 import 자체를 lib/client·lib/publicClient로
+      // 한정하는 컨벤션과 함께 봐야 합니다. 새 클라이언트를 만들면 이 정규식에도
+      // 이름을 추가하세요 — 안 그러면 가드에 구멍이 생깁니다.
       'no-restricted-syntax': [
         'error',
         {
           selector:
-            "CallExpression[callee.property.name='from'][callee.object.name=/^(client|supabase)$/]",
+            "CallExpression[callee.property.name='from'][callee.object.name=/^(client|supabase|publicDb)$/]",
           message:
             'Supabase 데이터 접근은 src에서 직접 하지 말고 domain repository/service(배럴)를 통하세요.',
         },
         {
           selector:
-            "CallExpression[callee.property.name='rpc'][callee.object.name=/^(client|supabase)$/]",
+            "CallExpression[callee.property.name='rpc'][callee.object.name=/^(client|supabase|publicDb)$/]",
           message:
             'Supabase RPC는 src에서 직접 호출하지 말고 domain repository를 통하세요.',
         },

--- a/apps/blog/web/lib/publicClient.test.ts
+++ b/apps/blog/web/lib/publicClient.test.ts
@@ -1,0 +1,155 @@
+/**
+ * publicClient 와이어 계약 테스트.
+ *
+ * 공개 페이지의 Supabase 접근을 `createClient()`(supabase-js 전체)에서
+ * `PostgrestClient`로 바꾸면서, **서버가 받는 HTTP 요청이 이전과 같아야**
+ * 한다는 게 이 교체의 전제였다. 눈으로 맞춘 헤더는 라이브러리가 기본값을
+ * 바꾸는 순간 조용히 어긋난다(실제로 처음 구현에서 Accept-Profile /
+ * Content-Profile을 빠뜨렸고, 지금 이 테스트가 그걸 잡았다).
+ *
+ * 그래서 로컬 echo 서버에 두 클라이언트를 붙여, 공개 페이지가 실제로 하는
+ * 세 호출의 요청(method·경로·쿼리·헤더·본문)을 직접 비교한다.
+ */
+
+import assert from 'node:assert/strict';
+import { test, before, after } from 'node:test';
+import { createServer, type Server } from 'node:http';
+import { createClient } from '@supabase/supabase-js';
+import { PostgrestClient } from '@supabase/postgrest-js';
+
+const KEY = 'test-anon-key';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+let server: Server;
+let baseUrl: string;
+let captured: CapturedRequest[] = [];
+
+/**
+ * 비교에서 제외하는 헤더.
+ * - x-client-info: supabase-js 텔레메트리. 응답에 영향을 주지 않는다.
+ * - 그 외는 Node fetch가 자동으로 붙이는 것들이라 두 쪽이 동일하다.
+ */
+const IGNORED_HEADERS = new Set(['x-client-info']);
+
+function normalize(req: CapturedRequest) {
+  return {
+    method: req.method,
+    url: req.url,
+    body: req.body,
+    // 헤더 순서는 의미가 없고 생성 순서에 따라 갈리므로 정렬해서 비교한다.
+    headers: Object.fromEntries(
+      Object.entries(req.headers)
+        .filter(([k]) => !IGNORED_HEADERS.has(k))
+        .sort(([a], [b]) => a.localeCompare(b)),
+    ),
+  };
+}
+
+before(async () => {
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(req.headers)) {
+        // 요청 내용과 무관하거나 전송 계층이 정하는 헤더는 제외.
+        if (
+          ['host', 'connection', 'content-length', 'accept-encoding'].includes(
+            k,
+          )
+        ) {
+          continue;
+        }
+        headers[k] = Array.isArray(v) ? v.join(',') : (v ?? '');
+      }
+      captured.push({
+        method: req.method ?? '',
+        url: req.url ?? '',
+        headers,
+        body: body || null,
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('[]');
+    });
+  });
+  await new Promise<void>(r =>
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      baseUrl =
+        typeof addr === 'object' && addr ? `http://127.0.0.1:${addr.port}` : '';
+      r();
+    }),
+  );
+});
+
+after(() => server.close());
+
+/** 교체 전: supabase-js 전체 클라이언트 */
+const legacyClient = () => createClient(baseUrl, KEY);
+
+/** 교체 후: lib/publicClient.ts와 **동일한** 생성 방식 */
+const publicClient = () =>
+  new PostgrestClient(`${baseUrl.replace(/\/+$/, '')}/rest/v1`, {
+    headers: { apikey: KEY, Authorization: `Bearer ${KEY}` },
+    schema: 'public',
+  });
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- 두 클라이언트의 제네릭이
+   달라 구조적으로만 같은 쿼리를 태운다. 여기서 검증하는 건 타입이 아니라 와이어다. */
+async function requestOf(run: (c: any) => PromiseLike<unknown>, client: any) {
+  captured = [];
+  await run(client);
+  assert.equal(captured.length, 1, '요청이 정확히 1건이어야 한다');
+  return normalize(captured[0]);
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const SCENARIOS: Array<{
+  name: string;
+  run: (c: any) => PromiseLike<unknown>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}> = [
+  {
+    name: 'getTopPosts',
+    run: c =>
+      c
+        .from('post_views')
+        .select('slug, view_count')
+        .order('view_count', { ascending: false })
+        .limit(5),
+  },
+  {
+    name: 'getAllViewCounts',
+    run: c => c.from('post_views').select('slug, view_count'),
+  },
+  {
+    name: 'incrementViewCount',
+    run: c => c.rpc('increment_view_count', { slug_input: 'hello-world' }),
+  },
+];
+
+for (const { name, run } of SCENARIOS) {
+  test(`${name}: PostgrestClient가 supabase-js와 동일한 요청을 보낸다`, async () => {
+    const legacy = await requestOf(run, legacyClient());
+    const next = await requestOf(run, publicClient());
+    assert.deepEqual(next, legacy);
+  });
+}
+
+test('anon key가 apikey와 Authorization 양쪽에 실린다', async () => {
+  const req = await requestOf(SCENARIOS[0].run, publicClient());
+  assert.equal(req.headers['apikey'], KEY);
+  assert.equal(req.headers['authorization'], `Bearer ${KEY}`);
+});
+
+test('schema를 명시해 Accept-Profile이 빠지지 않는다', async () => {
+  // 이 헤더가 없으면 PostgREST가 서버 기본 스키마로 처리한다. 지금 설정에선
+  // 결과가 같지만, 노출 스키마가 늘어나면 조용히 달라지는 종류의 차이다.
+  const req = await requestOf(SCENARIOS[0].run, publicClient());
+  assert.equal(req.headers['accept-profile'], 'public');
+});

--- a/apps/blog/web/lib/publicClient.ts
+++ b/apps/blog/web/lib/publicClient.ts
@@ -1,0 +1,42 @@
+import { PostgrestClient } from '@supabase/postgrest-js';
+import type { Database } from './database.types';
+
+/**
+ * 공개 페이지 전용 Supabase 데이터 클라이언트 (PostgREST만).
+ *
+ * `lib/client.ts`의 `createClient()`는 생성자에서 Auth·Realtime·Storage·
+ * Functions 클라이언트를 **전부 즉시 인스턴스화**한다. 그래서 조회수 하나만
+ * 읽어도 번들러가 그 넷을 떨궈내지 못하고, 홈·글 목록·글 상세까지 gzip 45KB가
+ * 따라붙었다(그중 realtime+phoenix+storage 18.5KB는 앱 어디서도 호출하지 않는
+ * 죽은 코드였다). 로그인·Edge Function은 `/admin`에서만 쓴다.
+ *
+ * 공개 페이지가 실제로 하는 건 `post_views` 읽기와 `increment_view_count`
+ * RPC뿐이고 둘 다 순수 PostgREST라, 그 부분만 담은 클라이언트를 따로 둔다.
+ * 인증이 필요한 경로는 계속 `lib/client.ts`를 쓴다.
+ *
+ * 헤더는 supabase-js가 세션 없는 요청에 붙이는 것과 동일하게 맞춘다
+ * (`apikey` + anon key를 담은 `Authorization`). 즉 서버가 보는 요청은 그대로다.
+ */
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+// supabase-js의 `new URL('rest/v1', baseUrl)`과 같은 결과. 다만 baseUrl에
+// 후행 슬래시가 없으면 URL 해석이 마지막 세그먼트를 갈아치우므로 직접 맞춘다.
+const restUrl = `${supabaseUrl.replace(/\/+$/, '')}/rest/v1`;
+
+export const publicDb = new PostgrestClient<Database>(restUrl, {
+  headers: {
+    apikey: supabaseKey,
+    Authorization: `Bearer ${supabaseKey}`,
+  },
+  // supabase-js는 db.schema 기본값 'public'을 PostgrestClient에 넘기고, 그게
+  // 요청에 Accept-Profile/Content-Profile 헤더로 나간다. 빼먹으면 PostgREST가
+  // 서버 기본 스키마로 처리해서 — 지금 설정에선 결과가 같지만 — 노출 스키마가
+  // 늘어나는 순간 조용히 달라진다. 명시해서 요청을 바이트 단위로 맞춘다.
+  schema: 'public',
+});

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -25,6 +25,7 @@
     "@giscus/react": "^3.1.0",
     "@next/third-parties": "^16.2.6",
     "@ssgoi/react": "6.4.0",
+    "@supabase/postgrest-js": "^2.103.0",
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.100.10",
     "gray-matter": "^4.0.3",

--- a/apps/blog/web/src/hooks/useAdminViews.ts
+++ b/apps/blog/web/src/hooks/useAdminViews.ts
@@ -3,7 +3,7 @@ import {
   getAdminPostsIndex,
   getAllPostStats,
   getAllPostsTrends,
-} from '@/domain/analytics';
+} from '@/domain/analytics/admin';
 import type { PostStatDetail } from '@/domain/analytics';
 
 export type { PostStatDetail };

--- a/apps/blog/web/src/hooks/usePostDetailStats.ts
+++ b/apps/blog/web/src/hooks/usePostDetailStats.ts
@@ -2,8 +2,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   getPostDowDistribution,
   getPostHourlyDistribution,
-  computeDerivedStats,
-} from '@/domain/analytics';
+} from '@/domain/analytics/admin';
+import { computeDerivedStats } from '@/domain/analytics';
 import { useAdminDashboardData } from './useAdminViews';
 import type {
   PostDetailStats,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@ssgoi/react':
         specifier: 6.4.0
         version: 6.4.0
+      '@supabase/postgrest-js':
+        specifier: ^2.103.0
+        version: 2.103.0
       '@supabase/supabase-js':
         specifier: ^2.89.0
         version: 2.103.0


### PR DESCRIPTION
#168 후속. 거기서 남겨둔 "Supabase 45KB" 항목을 처리합니다.

## 배경 — realtime을 정말 쓰고 있나

공개 페이지가 Supabase에 하는 일은 `post_views` 읽기 2건과 `increment_view_count` RPC 1건, **전부 익명 권한의 순수 PostgREST**입니다. 그런데 `createClient()`는 생성자에서 Auth·Realtime·Storage·Functions 클라이언트를 즉시 인스턴스화해서 번들러가 하나도 떨궈내지 못합니다.

실사용을 전수 조사했습니다.

| 모듈 | gzip | 실사용 |
| --- | --- | --- |
| `@supabase/realtime-js` + `phoenix` | 13.5KB | **0곳** — `.channel()`/`.subscribe()`/`postgres_changes` 전무 |
| `@supabase/storage-js` | 5.0KB | **0곳** |
| `@supabase/auth-js` | 23.0KB | `/admin`만 (AdminGuard, login, logout) |
| `@supabase/functions-js` | — | `/admin`만 (`lib/adminApi.ts`) |
| `@supabase/postgrest-js` | 3.8KB | 공개 페이지 3곳 전부 |

realtime + storage 18.5KB는 **앱 전체에서 단 한 번도 호출하지 않는** 죽은 코드였습니다.

## 결과

| 페이지 | before | after | |
| --- | --- | --- | --- |
| 홈 | 338,603 B | **286,935 B** | −51,668 |
| 글 목록 | 338,603 B | **286,935 B** | −51,668 |
| 글 상세 | 483,806 B | **432,134 B** | −51,672 |

(빌드 산출물 gzip 합계. 각 HTML이 참조하는 청크 전부)

공개 페이지 청크에서 `GoTrueClient`·`RealtimeClient`·`phoenix`가 각 1개 → **0개**로 사라졌고, `/admin` 청크에는 그대로 남아 정상 동작합니다.

```
페이지                    GoTrue  Realtime  phoenix  Postgrest
/                              0         0        0          2
/posts/                        0         0        0          2
/posts/<글>/                   0         0        0          2
/admin/                        1         1        1          2
```

## 막힌 지점 두 개

### ① 배럴 하나로는 안 떨어졌습니다

처음엔 repository만 공개/admin으로 쪼개고, admin 모듈의 최상위 부수효과(`createAdminApiClient(client)`)만 지연 생성으로 바꿨습니다. 빌드해서 청크를 열어보니 **홈에 `GoTrueClient`가 그대로** 있었습니다.

`lib/client.ts`의 최상위 `createClient()` 호출이 부수효과라, 모듈이 그래프에 닿기만 하면 번들러가 유지합니다. 배럴이 admin repository를 re-export하는 한 그래프에 닿습니다.

`@/domain/analytics/admin` 배럴을 따로 만들어 **모듈 그래프 자체를 갈랐습니다.** 트리셰이킹 품질에 기대는 것보다 확실합니다.

### ② 헤더를 하나 빠뜨렸습니다

와이어 호환을 눈으로 맞추지 않고, 로컬 echo 서버에 supabase-js와 PostgrestClient를 나란히 붙여 실제 요청을 비교했습니다. 첫 구현에서 `Accept-Profile: public` / `Content-Profile: public`이 빠진 걸 이 비교가 잡았습니다 — supabase-js가 `db.schema` 기본값 `'public'`을 PostgrestClient에 넘기고 있었습니다.

지금 설정에선 PostgREST 서버 기본 스키마가 `public`이라 결과가 같지만, 노출 스키마가 늘어나는 순간 조용히 달라지는 종류의 차이입니다. `schema: 'public'`을 명시했습니다.

수정 후 세 호출 모두 **method·경로·쿼리·헤더·본문이 완전히 일치**합니다. 차이는 supabase-js 텔레메트리 헤더 `x-client-info` 하나뿐입니다.

```
getTopPosts         GET  /rest/v1/post_views?select=slug%2Cview_count&order=view_count.desc&limit=5
getAllViewCounts    GET  /rest/v1/post_views?select=slug%2Cview_count
incrementViewCount  POST /rest/v1/rpc/increment_view_count  {"slug_input":"..."}
```

## 변경 내용

- **`lib/publicClient.ts`** (신규) — `PostgrestClient`만 쓰는 공개 페이지용 클라이언트. 헤더는 supabase-js가 세션 없는 요청에 붙이는 것과 동일하게 맞춤(`apikey` + anon key `Authorization` + `schema: 'public'`)
- **`domain/analytics/repository.ts`** — 공개 3함수만 남기고 `publicDb` 사용
- **`domain/analytics/adminRepository.ts`** (신규) — admin 5함수. `adminApi`는 첫 호출 때 생성해 최상위 부수효과 제거
- **`domain/analytics/admin.ts`** (신규) — admin 전용 배럴
- **훅 2개** — `useAdminViews` / `usePostDetailStats`가 `@/domain/analytics/admin`에서 import
- **`lib/publicClient.test.ts`** (신규) — 위 와이어 비교를 회귀 테스트로 고정. supabase-js가 기본 헤더를 바꾸면 CI가 잡습니다

### eslint 가드도 함께

설정 주석이 "클라이언트를 다른 이름으로 alias하면 가드가 우회된다"고 경고하고 있어, 새 클라이언트를 추가하면서 구멍을 만들지 않도록 같이 손봤습니다.

- `no-restricted-syntax` 셀렉터에 `publicDb` 추가 — src에서의 직접 데이터 접근 차단 유지
- repository 직접 import 금지 패턴에 `adminRepository`처럼 접두사 붙은 형태 포함

## 검증

- `pnpm check-types` ✅ / `pnpm lint` ✅ / `pnpm test` ✅ (node 483건 — 신규 5건 포함, vitest 96건)
- `pnpm build --filter=@blog/web --no-cache` ✅ 정적 export 성공
- 공개/admin 청크의 supabase 모듈 포함 여부를 빌드 산출물에서 직접 확인 (위 표)

## 리스크

- 공개 페이지 요청은 와이어 단위로 동일하지만, **`x-client-info` 헤더가 빠집니다.** Supabase 대시보드에서 클라이언트별 통계를 보고 있다면 공개 페이지 트래픽의 라벨이 달라집니다
- 익명 요청에 대한 RLS 정책은 그대로입니다(같은 anon key, 같은 `Authorization`)
- `/admin`은 계속 전체 supabase-js를 씁니다 — auth·functions 동작 변화 없음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9ynLMq5SvqvCPcdMgBT8Q