### PR TITLE
perf(blog): 썸네일을 WebP로 굽고 이미지 로딩 힌트를 지정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ yarn-error.log*
 /.idea/
 /apps/blog/web/public/posts/
 /apps/blog/web/public/og/
+/apps/blog/web/public/thumbs/
 /apps/blog/web/.cache/
 
 gha-creds-*.json

--- a/apps/blog/web/domain/post/thumbnail.test.ts
+++ b/apps/blog/web/domain/post/thumbnail.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { resolveThumbnailUrl, resolveAbsoluteThumbnailUrl } from './thumbnail';
+import {
+  resolveThumbnailUrl,
+  resolveAbsoluteThumbnailUrl,
+  resolveThumbnailSrc,
+  isOptimizableThumbnail,
+  thumbnailWebpRelPath,
+} from './thumbnail';
 
 // 인코딩 결과 상수 (실제 encodeURIComponent / encodePostSlug 출력으로 확정)
 const ENC_BUNDLER = '%EB%B2%88%EB%93%A4%EB%9F%AC'; // '번들러'
@@ -179,5 +185,92 @@ test('resolveAbsoluteThumbnailUrl: http URL은 prefix 없이 그대로', () => {
       p({ thumbnail: 'http://example.com/x.png', relativeDir: 'dir' }),
     ),
     'http://example.com/x.png',
+  );
+});
+
+// ── isOptimizableThumbnail ───────────────────────────────────────────────────
+
+test('isOptimizableThumbnail: posts/ 상대 png/jpg/jpeg만 대상', () => {
+  assert.equal(isOptimizableThumbnail('a-thumb.png'), true);
+  assert.equal(isOptimizableThumbnail('a.jpg'), true);
+  assert.equal(isOptimizableThumbnail('a.jpeg'), true);
+  assert.equal(isOptimizableThumbnail('A-THUMB.PNG'), true);
+});
+
+test('isOptimizableThumbnail: 생성 OG 카드·절대 경로·외부 URL은 제외', () => {
+  assert.equal(isOptimizableThumbnail('/og/my-post.png'), false);
+  assert.equal(isOptimizableThumbnail('/other/x.png'), false);
+  assert.equal(isOptimizableThumbnail('https://cdn/x.png'), false);
+  assert.equal(isOptimizableThumbnail('http://cdn/x.png'), false);
+});
+
+test('isOptimizableThumbnail: 없거나 변환 대상 아닌 확장자는 제외', () => {
+  assert.equal(isOptimizableThumbnail(undefined), false);
+  assert.equal(isOptimizableThumbnail(''), false);
+  assert.equal(isOptimizableThumbnail('x.svg'), false);
+  assert.equal(isOptimizableThumbnail('x.webp'), false);
+  assert.equal(isOptimizableThumbnail('x.gif'), false);
+});
+
+// ── thumbnailWebpRelPath ─────────────────────────────────────────────────────
+
+test('thumbnailWebpRelPath: relativeDir을 붙이고 확장자를 webp로 교체', () => {
+  assert.equal(
+    thumbnailWebpRelPath(
+      p({ thumbnail: 'a-thumb.png', relativeDir: 'bundler' }),
+    ),
+    'bundler/a-thumb.webp',
+  );
+});
+
+test('thumbnailWebpRelPath: relativeDir이 비면 파일명만 (인코딩하지 않은 원시 경로)', () => {
+  assert.equal(
+    thumbnailWebpRelPath(p({ thumbnail: 'a.jpeg', relativeDir: '' })),
+    'a.webp',
+  );
+});
+
+test('thumbnailWebpRelPath: 대상이 아니면 null', () => {
+  assert.equal(thumbnailWebpRelPath(p({ thumbnail: '/og/x.png' })), null);
+  assert.equal(thumbnailWebpRelPath(p({})), null);
+});
+
+// ── resolveThumbnailSrc ──────────────────────────────────────────────────────
+
+test('resolveThumbnailSrc: 상대 png는 /thumbs/ 아래 webp로', () => {
+  assert.equal(
+    resolveThumbnailSrc(
+      p({ thumbnail: 'a-thumb.png', relativeDir: 'bundler' }),
+    ),
+    '/thumbs/bundler/a-thumb.webp',
+  );
+});
+
+test('resolveThumbnailSrc: 한글 relativeDir은 세그먼트별 인코딩 (구분자 보존)', () => {
+  assert.equal(
+    resolveThumbnailSrc(p({ thumbnail: 'a.png', relativeDir: '번들러/3편' })),
+    `/thumbs/${ENC_BUNDLER}/${ENC_3PYEON}/a.webp`,
+  );
+});
+
+test('resolveThumbnailSrc: 대상이 아니면 resolveThumbnailUrl과 같은 결과', () => {
+  // 생성 OG 카드
+  assert.equal(resolveThumbnailSrc(p({})), '/og/my-post.png');
+  // 외부 URL
+  assert.equal(
+    resolveThumbnailSrc(p({ thumbnail: 'https://cdn/x.png' })),
+    'https://cdn/x.png',
+  );
+  // 절대 경로
+  assert.equal(
+    resolveThumbnailSrc(p({ thumbnail: '/og/other.png' })),
+    '/og/other.png',
+  );
+});
+
+test('resolveThumbnailSrc: 파일명의 공백은 인코딩', () => {
+  assert.equal(
+    resolveThumbnailSrc(p({ thumbnail: 'my thumb.png', relativeDir: 'dir' })),
+    '/thumbs/dir/my%20thumb.webp',
   );
 });

--- a/apps/blog/web/domain/post/thumbnail.ts
+++ b/apps/blog/web/domain/post/thumbnail.ts
@@ -24,6 +24,55 @@ export function resolveThumbnailUrl(
   return `/posts/${dir}${encodeURIComponent(thumbnail)}`;
 }
 
+/** 빌드 시 WebP 최적화본을 만들 수 있는 원본 확장자 */
+const OPTIMIZABLE_EXT = /\.(?:png|jpe?g)$/i;
+
+/**
+ * 최적화 대상 판정: posts/ 안의 실제 이미지 파일을 가리키는 thumbnail만.
+ *
+ * 외부 URL(http)과 절대 경로(`/og/*` 생성 카드 포함)는 제외합니다. 생성 OG
+ * 카드는 satori가 이미 적정 크기로 만들고, 외부 URL은 우리가 변환할 수 없습니다.
+ */
+export function isOptimizableThumbnail(thumbnail?: string): boolean {
+  if (!thumbnail) return false;
+  if (thumbnail.startsWith('http') || thumbnail.startsWith('/')) return false;
+  return OPTIMIZABLE_EXT.test(thumbnail);
+}
+
+/**
+ * 최적화본의 `public/thumbs/` 기준 상대 경로(인코딩 전). 대상이 아니면 null.
+ * scripts/generate-thumbnails.ts와 이 모듈이 같은 규칙을 공유하기 위한 단일 출처입니다.
+ */
+export function thumbnailWebpRelPath(
+  post: Pick<PostData, 'thumbnail' | 'relativeDir'>,
+): string | null {
+  const { thumbnail, relativeDir } = post;
+  if (!isOptimizableThumbnail(thumbnail)) return null;
+  const name = thumbnail!.replace(OPTIMIZABLE_EXT, '.webp');
+  return relativeDir ? `${relativeDir}/${name}` : name;
+}
+
+/**
+ * 화면에 실제로 띄울 이미지 URL. 최적화본이 있으면 그쪽(`/thumbs/*.webp`),
+ * 아니면 원본 해석 결과로 폴백합니다.
+ *
+ * generate-thumbnails가 발행 글의 모든 대상 썸네일에 대해 생성을 보장하므로
+ * (og-images와 같은 계약) 여기서 존재 여부를 확인하지 않습니다.
+ *
+ * OG/Schema.org 메타에는 이 함수가 아니라 resolveAbsoluteThumbnailUrl을
+ * 그대로 쓰세요 — 일부 소셜 크롤러가 WebP를 렌더링하지 못합니다.
+ */
+export function resolveThumbnailSrc(
+  post: Pick<PostData, 'thumbnail' | 'relativeDir' | 'slug'>,
+): string {
+  if (!isOptimizableThumbnail(post.thumbnail)) {
+    return resolveThumbnailUrl(post);
+  }
+  const name = post.thumbnail!.replace(OPTIMIZABLE_EXT, '.webp');
+  const dir = post.relativeDir ? `${encodePostSlug(post.relativeDir)}/` : '';
+  return `/thumbs/${dir}${encodeURIComponent(name)}`;
+}
+
 /**
  * 절대 URL 형태의 thumbnail URL을 반환합니다. (Schema.org, OG 등에 사용)
  */

--- a/apps/blog/web/package.json
+++ b/apps/blog/web/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react-hooks": "^7.0.0",
     "jsdom": "^29.1.1",
     "satori": "^0.26.0",
+    "sharp": "0.35.3",
     "supabase": "^2.110.0",
     "tsx": "^4.22.0",
     "typescript": "catalog:",

--- a/apps/blog/web/scripts/build-content.test.ts
+++ b/apps/blog/web/scripts/build-content.test.ts
@@ -31,13 +31,14 @@ test('buildPhases: 기본 — validate 게이트 phase + 병렬 generate phase',
     'search-index',
     'sitemap',
     'sync-posts',
+    'thumbnails',
   ]);
 });
 
 test('buildPhases: skip-validate면 generate phase만', () => {
   const phases = buildPhases({ skipValidate: true, force: false });
   assert.equal(phases.length, 1);
-  assert.ok(phases[0].length >= 6);
+  assert.ok(phases[0].length >= 7);
 });
 
 test('buildPhases: force 플래그는 sync-posts에만 전달', () => {

--- a/apps/blog/web/scripts/build-content.ts
+++ b/apps/blog/web/scripts/build-content.ts
@@ -54,6 +54,13 @@ export function buildPhases(flags: Flags): Step[][] {
       args: ['scripts/generate-og-images.ts'],
     },
     {
+      // posts/를 읽어 public/thumbs/에만 쓰므로 sync-posts(public/posts/)와
+      // 병렬로 돌아도 서로의 산출물에 손대지 않는다.
+      label: 'thumbnails',
+      cmd: 'tsx',
+      args: ['scripts/generate-thumbnails.ts'],
+    },
+    {
       label: 'search-index',
       cmd: 'tsx',
       args: ['scripts/generate-search-index.ts'],

--- a/apps/blog/web/scripts/generate-thumbnails.test.ts
+++ b/apps/blog/web/scripts/generate-thumbnails.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  collectTasks,
+  findOrphanWebps,
+  thumbnailContentHash,
+  MAX_WIDTH,
+  WEBP_QUALITY,
+} from './generate-thumbnails';
+
+// ── collectTasks ─────────────────────────────────────────────────────────────
+
+test('collectTasks: posts/ 상대 이미지만 대상으로 뽑는다', () => {
+  const tasks = collectTasks([
+    { thumbnail: 'a-thumb.png', relativeDir: 'bundler' },
+    { thumbnail: '/og/generated.png', relativeDir: 'bundler' },
+    { thumbnail: 'https://cdn/x.png', relativeDir: '' },
+    { thumbnail: undefined, relativeDir: 'bundler' },
+  ]);
+  assert.deepEqual(tasks, [
+    { sourceRel: 'bundler/a-thumb.png', outputRel: 'bundler/a-thumb.webp' },
+  ]);
+});
+
+test('collectTasks: relativeDir이 비면 파일명만 경로로 쓴다', () => {
+  const tasks = collectTasks([{ thumbnail: 'top.png', relativeDir: '' }]);
+  assert.deepEqual(tasks, [{ sourceRel: 'top.png', outputRel: 'top.webp' }]);
+});
+
+test('collectTasks: 같은 이미지를 여러 글이 써도 한 번만 변환한다', () => {
+  const tasks = collectTasks([
+    { thumbnail: 'shared.png', relativeDir: 'dir' },
+    { thumbnail: 'shared.png', relativeDir: 'dir' },
+  ]);
+  assert.equal(tasks.length, 1);
+});
+
+test('collectTasks: 한글 디렉터리도 원시 경로 그대로 (인코딩은 URL 쪽 책임)', () => {
+  const tasks = collectTasks([{ thumbnail: 'a.png', relativeDir: '아키텍처' }]);
+  assert.deepEqual(tasks, [
+    { sourceRel: '아키텍처/a.png', outputRel: '아키텍처/a.webp' },
+  ]);
+});
+
+test('collectTasks: 대상이 없으면 빈 배열', () => {
+  assert.deepEqual(collectTasks([]), []);
+  assert.deepEqual(
+    collectTasks([{ thumbnail: '/og/x.png', relativeDir: '' }]),
+    [],
+  );
+});
+
+// ── thumbnailContentHash ─────────────────────────────────────────────────────
+
+test('thumbnailContentHash: 같은 바이트면 같은 해시', () => {
+  const a = thumbnailContentHash(Buffer.from('image-bytes'));
+  const b = thumbnailContentHash(Buffer.from('image-bytes'));
+  assert.equal(a, b);
+});
+
+test('thumbnailContentHash: 바이트가 다르면 해시도 다르다', () => {
+  assert.notEqual(
+    thumbnailContentHash(Buffer.from('a')),
+    thumbnailContentHash(Buffer.from('b')),
+  );
+});
+
+test('thumbnailContentHash: 인코딩 정책이 해시에 반영된다', () => {
+  // 정책 상수가 해시 입력에 들어가므로, 값이 바뀌면 전체 재생성이 유도된다.
+  const hash = thumbnailContentHash(Buffer.from('x'));
+  assert.equal(typeof hash, 'string');
+  assert.equal(hash.length, 40); // sha1 hex
+  assert.ok(MAX_WIDTH > 0 && WEBP_QUALITY > 0);
+});
+
+// ── findOrphanWebps ──────────────────────────────────────────────────────────
+
+test('findOrphanWebps: 기대 목록에 없는 webp만 정리 대상', () => {
+  const orphans = findOrphanWebps(
+    ['a.webp', 'dir/b.webp', 'dir/keep.webp'],
+    new Set(['dir/keep.webp']),
+  );
+  assert.deepEqual(orphans.sort(), ['a.webp', 'dir/b.webp']);
+});
+
+test('findOrphanWebps: webp가 아닌 파일은 건드리지 않는다', () => {
+  const orphans = findOrphanWebps(
+    ['note.txt', 'dir', 'x.png'],
+    new Set<string>(),
+  );
+  assert.deepEqual(orphans, []);
+});
+
+test('findOrphanWebps: 전부 기대 목록에 있으면 빈 배열', () => {
+  const orphans = findOrphanWebps(['a.webp'], new Set(['a.webp']));
+  assert.deepEqual(orphans, []);
+});

--- a/apps/blog/web/scripts/generate-thumbnails.ts
+++ b/apps/blog/web/scripts/generate-thumbnails.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import sharp from 'sharp';
+import { getAllPosts } from '../domain/post/service';
+import { thumbnailWebpRelPath } from '../domain/post/thumbnail';
+import type { PostData } from '../domain/post/types';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const POSTS_SOURCE_DIR = resolve(ROOT, '..', 'posts');
+
+/**
+ * 생성물은 public/posts/가 아니라 public/thumbs/에 둡니다.
+ *
+ * sync-posts.mjs는 public/posts/ 안에서 posts/에 원본이 없는 미디어를 orphan으로
+ * 삭제하고(.webp도 대상), build-content의 phase 2에서 두 단계가 병렬로 돌기 때문에
+ * 같은 디렉터리를 쓰면 생성물이 지워질 수 있습니다. 디렉터리를 분리해 서로의
+ * 산출물에 손대지 않도록 합니다.
+ */
+const THUMBS_DIR = join(ROOT, 'public', 'thumbs');
+const MANIFEST_PATH = join(ROOT, '.cache', 'thumbnails.json');
+
+/** 표시 최대 폭(FeaturedPost가 컨테이너 전체 폭). 이보다 작은 원본은 확대하지 않습니다. */
+export const MAX_WIDTH = 1200;
+export const WEBP_QUALITY = 80;
+
+/** 인코딩 정책을 바꾸면 올려서 전체 재생성하게 합니다. */
+export const ENCODE_VERSION = 1;
+
+export interface ThumbnailTask {
+  /** posts/ 기준 원본 상대 경로 */
+  sourceRel: string;
+  /** public/thumbs/ 기준 출력 상대 경로 */
+  outputRel: string;
+}
+
+/**
+ * 발행 글 목록에서 변환 대상을 뽑습니다. thumbnail이 posts/ 안의 png/jpg를
+ * 가리키는 글만 대상이고, /og/* 생성 카드와 외부 URL은 제외됩니다.
+ */
+export function collectTasks(
+  posts: Pick<PostData, 'thumbnail' | 'relativeDir'>[],
+): ThumbnailTask[] {
+  const tasks = new Map<string, ThumbnailTask>();
+  for (const post of posts) {
+    const outputRel = thumbnailWebpRelPath(post);
+    if (!outputRel) continue;
+    const sourceRel = post.relativeDir
+      ? `${post.relativeDir}/${post.thumbnail}`
+      : String(post.thumbnail);
+    // 같은 이미지를 여러 글이 쓰면 한 번만 변환합니다.
+    tasks.set(outputRel, { sourceRel, outputRel });
+  }
+  return [...tasks.values()];
+}
+
+/** 원본 바이트 + 인코딩 정책으로 계산 — 둘 다 그대로면 재인코딩을 skip합니다. */
+export function thumbnailContentHash(sourceBytes: Buffer): string {
+  return createHash('sha1')
+    .update(`v${ENCODE_VERSION}:${MAX_WIDTH}:${WEBP_QUALITY}:`)
+    .update(sourceBytes)
+    .digest('hex');
+}
+
+/** 기대 목록에 없는 webp = 삭제/이름변경/썸네일 교체된 글의 잔여물 */
+export function findOrphanWebps(
+  existingRelPaths: string[],
+  expectedRelPaths: Set<string>,
+): string[] {
+  return existingRelPaths.filter(
+    p => p.endsWith('.webp') && !expectedRelPaths.has(p),
+  );
+}
+
+export async function encodeWebp(sourcePath: string): Promise<Buffer> {
+  return sharp(sourcePath)
+    .resize({ width: MAX_WIDTH, withoutEnlargement: true })
+    .webp({ quality: WEBP_QUALITY })
+    .toBuffer();
+}
+
+function readManifest(): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // 없거나 깨진 manifest는 전체 재생성으로 처리
+  }
+  return {};
+}
+
+function listExistingWebps(): string[] {
+  if (!existsSync(THUMBS_DIR)) return [];
+  return readdirSync(THUMBS_DIR, { recursive: true }).map(p => String(p));
+}
+
+async function main() {
+  const tasks = collectTasks(getAllPosts());
+  mkdirSync(THUMBS_DIR, { recursive: true });
+
+  const expectedRel = new Set(tasks.map(t => t.outputRel));
+  const orphans = findOrphanWebps(listExistingWebps(), expectedRel);
+  for (const orphan of orphans) {
+    rmSync(join(THUMBS_DIR, orphan));
+  }
+
+  const manifest = readManifest();
+  const nextManifest: Record<string, string> = {};
+  let encoded = 0;
+  let skipped = 0;
+  let savedBytes = 0;
+  const missing: string[] = [];
+
+  for (const task of tasks) {
+    const sourcePath = join(POSTS_SOURCE_DIR, task.sourceRel);
+    if (!existsSync(sourcePath)) {
+      // 존재하지 않는 썸네일은 validate-posts가 broken-image로 잡습니다.
+      // 여기서는 빌드를 막지 않고 건너뛰고, 목록만 보고합니다.
+      missing.push(task.sourceRel);
+      continue;
+    }
+    const sourceBytes = readFileSync(sourcePath);
+    const hash = thumbnailContentHash(sourceBytes);
+    const outPath = join(THUMBS_DIR, task.outputRel);
+    nextManifest[task.outputRel] = hash;
+
+    if (manifest[task.outputRel] === hash && existsSync(outPath)) {
+      skipped++;
+      continue;
+    }
+
+    const webp = await encodeWebp(sourcePath);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, webp);
+    savedBytes += sourceBytes.length - webp.length;
+    encoded++;
+  }
+
+  mkdirSync(dirname(MANIFEST_PATH), { recursive: true });
+  writeFileSync(MANIFEST_PATH, JSON.stringify(nextManifest, null, 2));
+
+  const savedKb = Math.round(savedBytes / 1024);
+  console.log(
+    `✓ thumbnails: ${encoded} 생성, ${skipped} 스킵, ${orphans.length} 정리` +
+      ` (대상 ${tasks.length}개, 이번 실행 절감 ${savedKb}KB)`,
+  );
+  if (missing.length > 0) {
+    console.warn(
+      `  ⚠ 원본이 없어 건너뛴 썸네일 ${missing.length}개: ${missing.join(', ')}`,
+    );
+  }
+}
+
+// 스크립트로 직접 실행될 때만 main()을 호출합니다.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((e: unknown) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+/** 테스트에서 실제 파일 크기를 확인할 때 쓰는 헬퍼 */
+export function fileSize(path: string): number {
+  return statSync(path).size;
+}

--- a/apps/blog/web/src/components/blog/FeaturedPost.tsx
+++ b/apps/blog/web/src/components/blog/FeaturedPost.tsx
@@ -3,8 +3,12 @@ import { css } from '@design-system/ui-lib/css';
 import { tagPillStyle } from './tagPillStyle';
 import type { PostSummary } from '@/domain/post';
 import { encodePostSlug } from '@/domain/post/utils';
-import { resolveThumbnailUrl } from '@/domain/post/thumbnail';
+import { resolveThumbnailSrc } from '@/domain/post/thumbnail';
 import { fmtDate } from '@/lib/format';
+
+/** CSS가 실제 크기를 정하므로 종횡비 힌트로만 쓰입니다(표시 폭 전체 × 320). */
+const THUMB_WIDTH = 1200;
+const THUMB_HEIGHT = 320;
 
 interface FeaturedPostProps {
   post: PostSummary;
@@ -12,8 +16,8 @@ interface FeaturedPostProps {
 
 export const FeaturedPost = ({ post }: FeaturedPostProps) => {
   const href = `/posts/${encodePostSlug(post.slug)}/`;
-  // thumbnail 없으면 빌드 시 생성된 글별 OG 카드로 fallback (resolveThumbnailUrl).
-  const thumb = resolveThumbnailUrl(post);
+  // thumbnail 없으면 빌드 시 생성된 글별 OG 카드로 fallback (resolveThumbnailSrc).
+  const thumb = resolveThumbnailSrc(post);
   const readMin = post.readMin;
 
   return (
@@ -38,6 +42,12 @@ export const FeaturedPost = ({ post }: FeaturedPostProps) => {
       <img
         src={thumb}
         alt={post.title}
+        width={THUMB_WIDTH}
+        height={THUMB_HEIGHT}
+        // 홈 최상단 카드라 항상 LCP 후보 — lazy를 걸면 안 된다.
+        loading="eager"
+        fetchPriority="high"
+        decoding="async"
         className={css({
           display: 'block',
           w: 'full',

--- a/apps/blog/web/src/components/blog/PostGridCard.tsx
+++ b/apps/blog/web/src/components/blog/PostGridCard.tsx
@@ -2,19 +2,28 @@ import Link from 'next/link';
 import { css } from '@design-system/ui-lib/css';
 import type { PostSummary } from '@/domain/post';
 import { encodePostSlug } from '@/domain/post/utils';
-import { resolveThumbnailUrl } from '@/domain/post/thumbnail';
+import { resolveThumbnailSrc } from '@/domain/post/thumbnail';
 import { fmtDate } from '@/lib/format';
 import { Label } from './Label';
 import { tagPillStyle } from './tagPillStyle';
 
+/** CSS가 실제 크기를 정하므로 이 값들은 종횡비 힌트로만 쓰입니다(표시 346×160). */
+const THUMB_WIDTH = 692;
+const THUMB_HEIGHT = 320;
+
 interface PostGridCardProps {
   post: PostSummary;
+  /**
+   * 첫 화면에 들어오는 카드. LCP 후보이므로 lazy 대신 우선 로드합니다.
+   * 목록 전체에 걸면 화면 밖 이미지까지 한꺼번에 받아 오히려 LCP가 밀립니다.
+   */
+  priority?: boolean;
 }
 
-export const PostGridCard = ({ post }: PostGridCardProps) => {
-  // resolveThumbnailUrl은 thumbnail이 없으면 빌드 시 생성된 글별 OG 카드
-  // (/og/{slug}.png)로 fallback합니다.
-  const thumb = resolveThumbnailUrl(post);
+export const PostGridCard = ({ post, priority = false }: PostGridCardProps) => {
+  // resolveThumbnailSrc는 posts/ 안의 png/jpg면 빌드 시 만든 WebP 최적화본을,
+  // 아니면 원본(생성 OG 카드 /og/{slug}.png 포함)을 돌려줍니다.
+  const thumb = resolveThumbnailSrc(post);
   const readMin = post.readMin;
   return (
     <Link
@@ -37,6 +46,11 @@ export const PostGridCard = ({ post }: PostGridCardProps) => {
       <img
         src={thumb}
         alt={post.title}
+        width={THUMB_WIDTH}
+        height={THUMB_HEIGHT}
+        loading={priority ? 'eager' : 'lazy'}
+        fetchPriority={priority ? 'high' : 'auto'}
+        decoding="async"
         // 실제 썸네일이 있는 글만 hero 모핑 대상(목록=exit-key). 상세 헤더 이미지의
         // data-hero-enter-key와 같은 키로 매칭돼 카드↔헤더 이미지가 모핑한다.
         // 썸네일 없는 글은 키를 안 붙이고 상세 id도 /posts-plain/*이라 fade로 폴백.

--- a/apps/blog/web/src/components/blog/PostsArchive.tsx
+++ b/apps/blog/web/src/components/blog/PostsArchive.tsx
@@ -287,8 +287,10 @@ export const PostsArchiveView = ({
                 gap: '6',
               })}
             >
-              {filtered.map(p => (
-                <PostGridCard key={p.slug} post={p} />
+              {/* 첫 행(데스크톱 3열)만 우선 로드하고 나머지는 lazy — 목록 전체를
+                  한꺼번에 받으면 첫 화면 이미지가 대역폭을 뺏겨 LCP가 밀린다. */}
+              {filtered.map((p, i) => (
+                <PostGridCard key={p.slug} post={p} priority={i < 3} />
               ))}
             </div>
           ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       satori:
         specifier: ^0.26.0
         version: 0.26.0
+      sharp:
+        specifier: 0.35.3
+        version: 0.35.3(@types/node@25.9.1)
       supabase:
         specifier: ^2.110.0
         version: 2.110.0
@@ -5140,11 +5143,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
@@ -6529,8 +6527,7 @@ snapshots:
       '@iconify/types': 2.0.0
       mlly: 1.8.0
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
@@ -7840,7 +7837,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -9689,7 +9686,7 @@ snapshots:
 
   is-bun-module@1.3.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -10154,7 +10151,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   markdown-table@3.0.4: {}
 
@@ -11265,12 +11262,9 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4: {}
-
   semver@7.8.4: {}
 
-  semver@7.8.5:
-    optional: true
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -11353,7 +11347,6 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 25.9.1
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## 배경

`https://blog.sangwook.dev/posts/`에 Lighthouse 모바일(Lighthouse 13.4.1, 412×823, CPU 4x, Slow 4G)을 돌린 결과입니다.

| 카테고리 | 이슈 #165 (7-30) | 이번 측정 | 임계 |
| :--- | ---: | ---: | ---: |
| Performance | 54 | **69** | 90 |
| Accessibility | 94 | 100 | 95 |
| Best Practices | 77 | 77 | 95 |
| SEO | 100 | 100 | 95 |

Performance만 임계 미달이고, 지표를 보면 원인이 한 곳에 몰려 있습니다.

```
FCP  1.4s      Speed Index  2.6s      TBT  140ms      CLS  0.116
LCP  10.4s  ← 이것만 점수 0 (가중치 25)
```

FCP는 1.4초인데 LCP가 10.4초입니다. 네트워크 상위 5개가 전부 포스트 썸네일 PNG(합 2.5MB)였고, `image-delivery-insight`가 절감 여지 2,714KiB로 잡혔습니다. 원본은 1024×1024인데 카드 표시는 346×160이고, `images.unoptimized: true`(GitHub Pages 정적 호스팅) 때문에 Next.js 이미지 최적화가 꺼져 있습니다.

여기에 `lcp-discovery-insight`가 세 항목 모두 미충족이었습니다.

```
fetchpriority=high should be applied .......... false
Request is discoverable in initial document ... false
LCP resources should not use lazy loading ..... 미충족
```

`PostGridCard.tsx`와 `FeaturedPost.tsx`의 `<img>`에 `loading`·`fetchpriority`·`width`·`height`가 하나도 없어서, 화면 밖 카드까지 **44개 이미지 3.8MB를 한꺼번에** 받고 있었습니다.

## 변경 1 — 빌드 시 WebP 변환 (`6c295ee`)

리사이즈와 인코딩 중 무엇이 효과적인지 실제 파일로 측정했습니다.

| 방식 | 합계(썸네일 5개) | 절감 |
| :--- | ---: | ---: |
| 원본 PNG | 2593KB | — |
| **WebP q80 (원본 해상도)** | **237KB** | **90.9%** |
| WebP q75 w800 | 144KB | 94.4% |
| AVIF q60 w1200 | 179KB | 93.1% |

원본이 1024px라 리사이즈는 거의 효과가 없고, 800으로 줄이면 `FeaturedPost`(컨테이너 전체 폭, 최대 1200)에서 오히려 흐려집니다. **WebP q80 + 폭 1200 상한**(현재 원본에는 no-op, 큰 원본 대비)으로 정했습니다.

- `scripts/generate-thumbnails.ts` — `getAllPosts()`에서 posts/ 안의 png/jpg를 가리키는 썸네일만 변환. `og-images`와 같은 content-hash 매니페스트(`.cache/thumbnails.json`)로 incremental, orphan 정리 포함
- **생성물을 `public/thumbs/`에 둡니다.** `sync-posts.mjs`는 `public/posts/` 안에서 원본 없는 미디어를 orphan으로 삭제하고(`.webp`도 대상), build-content의 phase 2에서 두 단계가 병렬로 돕니다. 같은 디렉터리를 쓰면 생성물이 지워집니다
- `domain/post/thumbnail.ts`에 `resolveThumbnailSrc` 추가. 기존 `resolveThumbnailUrl`은 그대로 둬서 **OG·Schema.org 메타는 PNG를 유지**합니다 — 일부 소셜 크롤러가 WebP를 렌더링하지 못합니다

실측: 발행 글 9개 대상, **2819KB → 332KB (88% 절감)**.

## 변경 2 — 로딩 힌트 (`f110c8e`)

- `PostGridCard`에 `priority` prop 추가. 첫 행(데스크톱 3열)만 `eager` + `fetchpriority=high`, 나머지는 `lazy`. 목록 전체에 우선순위를 걸면 지금과 같아지므로 첫 행으로 제한했습니다
- `FeaturedPost`는 홈 최상단이라 항상 LCP 후보 — `eager` + `high` 고정
- 둘 다 `width`/`height`로 종횡비를 알려 레이아웃을 예약하고, `decoding="async"`로 디코딩이 메인 스레드를 잡지 않게 했습니다

## 검증

- `test:node` 504개 통과 (신규 테스트 포함: `generate-thumbnails.test.ts` 11개, `thumbnail.test.ts` +10개)
- `test:vitest` 96개 통과
- `check-types`, `lint` 통과
- 프로덕션 빌드 성공 — `out/thumbs/`에 webp 9개(380KB) 생성 확인, `out/index.html`에 `loading="eager" fetchPriority="high"`와 `/thumbs/*.webp` 반영 확인
- `build-content.test.ts`의 단계 목록에 `thumbnails` 추가 (하드코딩된 기대값이라 함께 갱신)

## 범위 밖으로 남긴 것

**`/posts/` 목록은 여전히 CSR입니다.** `PostsArchiveView`가 nuqs(`useSearchParams`)를 써서 `output: 'export'`의 프리렌더에서 빠지고(`page.tsx:144-151`의 BAILOUT 주석), `out/posts/index.html`에 구워지는 건 Suspense fallback인 `PostListRow`(이미지 없는 텍스트 행)뿐입니다. 초기 HTML의 `<img>`가 0개인 이유이고, `requestDiscoverable: false`의 원인입니다.

따라서 이 PR의 로딩 힌트는 목록 페이지에서는 하이드레이션 이후에 적용됩니다. 홈의 `FeaturedPost`는 SSG로 구워져 초기 HTML에 그대로 들어갑니다. CSR bail-out 해소는 필터/정렬 URL 상태 관리 방식을 바꾸는 별도 작업이라 분리했습니다.

Best Practices 77점(Microsoft Clarity 서드파티 쿠키 8개)도 GTM 콘솔 쪽 문제라 이 PR 범위 밖입니다.
