### PR TITLE
fix(blog): 썸네일 PR 리뷰 지적 6건을 반영한다

### DIFF
--- a/apps/blog/web/domain/post/thumbnail.ts
+++ b/apps/blog/web/domain/post/thumbnail.ts
@@ -33,22 +33,29 @@ const OPTIMIZABLE_EXT = /\.(?:png|jpe?g)$/i;
  * 외부 URL(http)과 절대 경로(`/og/*` 생성 카드 포함)는 제외합니다. 생성 OG
  * 카드는 satori가 이미 적정 크기로 만들고, 외부 URL은 우리가 변환할 수 없습니다.
  */
-export function isOptimizableThumbnail(thumbnail?: string): boolean {
+export function isOptimizableThumbnail(
+  thumbnail?: string,
+): thumbnail is string {
   if (!thumbnail) return false;
   if (thumbnail.startsWith('http') || thumbnail.startsWith('/')) return false;
   return OPTIMIZABLE_EXT.test(thumbnail);
 }
 
+/** 확장자 치환 규칙의 단일 출처 — 아래 두 함수가 공유합니다. */
+function toWebpName(thumbnail: string): string {
+  return thumbnail.replace(OPTIMIZABLE_EXT, '.webp');
+}
+
 /**
  * 최적화본의 `public/thumbs/` 기준 상대 경로(인코딩 전). 대상이 아니면 null.
- * scripts/generate-thumbnails.ts와 이 모듈이 같은 규칙을 공유하기 위한 단일 출처입니다.
+ * generate-thumbnails.ts가 파일을 쓸 위치를 정할 때 씁니다.
  */
 export function thumbnailWebpRelPath(
   post: Pick<PostData, 'thumbnail' | 'relativeDir'>,
 ): string | null {
   const { thumbnail, relativeDir } = post;
   if (!isOptimizableThumbnail(thumbnail)) return null;
-  const name = thumbnail!.replace(OPTIMIZABLE_EXT, '.webp');
+  const name = toWebpName(thumbnail);
   return relativeDir ? `${relativeDir}/${name}` : name;
 }
 
@@ -68,9 +75,10 @@ export function resolveThumbnailSrc(
   if (!isOptimizableThumbnail(post.thumbnail)) {
     return resolveThumbnailUrl(post);
   }
-  const name = post.thumbnail!.replace(OPTIMIZABLE_EXT, '.webp');
+  // 디렉터리는 세그먼트별(구분자 보존), 파일명은 통째로 인코딩 —
+  // resolveThumbnailUrl과 같은 규칙이라 경로 형태가 어긋나지 않습니다.
   const dir = post.relativeDir ? `${encodePostSlug(post.relativeDir)}/` : '';
-  return `/thumbs/${dir}${encodeURIComponent(name)}`;
+  return `/thumbs/${dir}${encodeURIComponent(toWebpName(post.thumbnail))}`;
 }
 
 /**

--- a/apps/blog/web/scripts/generate-thumbnails.ts
+++ b/apps/blog/web/scripts/generate-thumbnails.ts
@@ -5,10 +5,9 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import sharp from 'sharp';
 import { getAllPosts } from '../domain/post/service';
@@ -103,7 +102,11 @@ function readManifest(): Record<string, string> {
 
 function listExistingWebps(): string[] {
   if (!existsSync(THUMBS_DIR)) return [];
-  return readdirSync(THUMBS_DIR, { recursive: true }).map(p => String(p));
+  // readdirSync는 OS 구분자를 쓰지만 outputRel은 항상 '/'로 조립되므로,
+  // Windows에서 모든 파일이 orphan으로 오판되지 않도록 정규화해서 비교합니다.
+  return readdirSync(THUMBS_DIR, { recursive: true }).map(p =>
+    String(p).split(sep).join('/'),
+  );
 }
 
 async function main() {
@@ -172,9 +175,4 @@ if (
     console.error(e);
     process.exit(1);
   });
-}
-
-/** 테스트에서 실제 파일 크기를 확인할 때 쓰는 헬퍼 */
-export function fileSize(path: string): number {
-  return statSync(path).size;
 }

--- a/apps/blog/web/src/components/blog/PostsArchive.tsx
+++ b/apps/blog/web/src/components/blog/PostsArchive.tsx
@@ -287,10 +287,14 @@ export const PostsArchiveView = ({
                 gap: '6',
               })}
             >
-              {/* 첫 행(데스크톱 3열)만 우선 로드하고 나머지는 lazy — 목록 전체를
-                  한꺼번에 받으면 첫 화면 이미지가 대역폭을 뺏겨 LCP가 밀린다. */}
+              {/* 앞의 2개만 우선 로드하고 나머지는 lazy — 목록 전체를 한꺼번에 받으면
+                  첫 화면 이미지가 대역폭을 뺏겨 LCP가 밀린다. loading/fetchPriority는
+                  정적 속성이라 브레이크포인트별로 달리 줄 수 없는데, 그리드는 모바일
+                  1열 / sm 2열 / lg 3열이다. 가장 좁은 화면에 맞춰 잡아야 "안 보이는
+                  이미지를 high로 요청"하는 일이 없다. 나머지도 뷰포트에 들어오면
+                  lazy가 곧바로 로드하므로 손해가 아니다. */}
               {filtered.map((p, i) => (
-                <PostGridCard key={p.slug} post={p} priority={i < 3} />
+                <PostGridCard key={p.slug} post={p} priority={i < 2} />
               ))}
             </div>
           ) : (

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,10 @@ overrides:
   # 빼면 postcss가 8.4.31/8.5.14/8.5.18 세 벌로 갈라진다. 한 벌로 dedupe하기 위해 유지.
   postcss: 8.5.18
   # GHSA-f88m-g3jw-g9cj(high)가 0.35.0에서만 패치됐는데 next가 ^0.34.5로 optional 핀.
-  # next가 0.35 라인을 허용하면 제거할 것. 블로그는 unoptimized라 sharp 미사용.
+  # next가 0.35 라인을 허용하면 제거할 것.
+  # 블로그의 Next Image Optimization은 images.unoptimized로 꺼져 있지만, 그것과 별개로
+  # apps/blog/web/scripts/generate-thumbnails.ts가 빌드 타임 썸네일 WebP 변환에 sharp를
+  # 직접 쓴다 — 실사용 의존성이므로 이 override와 allowBuilds.sharp를 함부로 지우지 말 것.
   sharp: 0.35.3
 
 auditConfig:


### PR DESCRIPTION
## 배경

#170에 `claude-review`가 남긴 지적 6건을 반영합니다. 전부 타당해서 그대로 수용했고, 확인한 근거를 함께 적습니다.

## medium 1건

**`pnpm-workspace.yaml` — sharp override 주석이 사실과 어긋남**

주석이 "블로그는 unoptimized라 sharp 미사용"이라고 단언하는데, #170이 `generate-thumbnails.ts`에서 sharp를 빌드 타임에 직접 쓰게 만들었습니다. `images.unoptimized`는 Next Image Optimization 이야기이고 이 sharp 사용은 별개 경로입니다.

주석만 보고 override나 `allowBuilds.sharp`를 정리하면 next가 optional로 핀한 `^0.34.5`(GHSA-f88m-g3jw-g9cj, high)가 끼어들 수 있고, 이제는 실사용 의존성이라 영향이 더 큽니다. 주석을 갱신하고 "함부로 지우지 말 것"을 명시했습니다.

## low 5건

| 파일 | 지적 | 반영 |
| :--- | :--- | :--- |
| `thumbnail.ts` | `resolveThumbnailSrc`가 확장자 치환을 중복 구현 (주석은 "단일 출처"라고 주장) | `toWebpName`으로 규칙을 모음 |
| `PostsArchive.tsx` | `priority={i<3}`이 데스크톱 3열만 가정 | `i<2`로 좁힘 |
| `thumbnail.ts` | `thumbnail!` non-null assertion 2곳 | 타입 가드(`thumbnail is string`)로 제거 |
| `generate-thumbnails.ts` | `readdirSync` 결과와 POSIX `/` 경로 비교 | `sep`을 `/`로 정규화 |
| `generate-thumbnails.ts` | 미사용 export `fileSize` | 삭제 |

`priority` 축소가 가장 실질적입니다. 그리드는 모바일 1열 / `sm` 2열 / `lg` 3열인데 `loading`·`fetchPriority`는 정적 속성이라 브레이크포인트별로 줄 수 없습니다. 가장 좁은 화면에 맞춰야 화면에 없는 이미지를 `high`로 동시 요청하지 않습니다 — #170이 잡으려던 대역폭 경쟁을 목록에서 재현하던 부분입니다. 나머지는 뷰포트에 들어오면 lazy가 곧바로 로드하므로 손해가 아닙니다.

## 검증

- `check-types` / `lint` 통과
- `test:node` 504개, `test:vitest` 96개 통과
- `generate-thumbnails.ts` 재실행 — `0 생성, 9 스킵, 0 정리`로 incremental 정상, 경로 정규화 후에도 orphan 오판 없음(파일 9개 유지)
