### PR TITLE
ci(claude): claude-code-action v1 옵션을 재검토해 리뷰 워크플로를 보강한다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -424,21 +424,6 @@ jobs:
             무엇이 왜 기준에 미달하는지에 집중하세요.
             </output_format>
 
-            <final_output>
-            코멘트를 다 남긴 뒤, 마지막 메시지로 --json-schema 스키마에 맞는
-            JSON만 출력하세요. 이건 Actions 요약에 찍히는 집계용이고
-            사람이 읽는 리뷰는 위의 PR 코멘트가 전부입니다. JSON에 지적
-            본문을 옮겨 적지 마세요.
-
-            - modes: 실제로 수행한 모드 ("code" / "writing" / "deps")
-            - critical / high / medium / low: 요약 코멘트에 실제로 올린
-              심각도별 건수. 인라인으로만 올린 것도 포함해 셉니다.
-            - inline_suggestions: create_inline_comment를 호출한 횟수
-            - ci_status: get_ci_status로 본 상태를 "pass" / "fail" /
-              "running" / "unknown" 중 하나로
-            - headline: 가장 중요한 발견 한 줄. 지적이 없으면 왜 없는지 한 줄
-            </final_output>
-
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # Write는 요약 코멘트 --body-file 작성용.
@@ -453,38 +438,6 @@ jobs:
           # Bash(gh api:*)는 뺐다. 인라인 suggestion을 직접 POST할 때만 필요했는데
           # 이제 전용 MCP 도구가 그 일을 하고, gh api는 사실상 모든 write 엔드포인트를
           # 여는 와일드카드라 리뷰 전용 잡에 남겨둘 이유가 없다.
-          #
-          # --json-schema는 마지막 메시지를 스키마로 검증해 structured_output
-          # 출력으로 내보낸다. 아래 "리뷰 결과 요약" 스텝이 이걸 Step Summary에
-          # 찍는다. required를 비워 둔 것은 의도적이다 — 집계는 부수적이고,
-          # 필드 하나가 빠졌다고 리뷰 잡이 실패하면 본말이 전도된다.
           claude_args: >-
             --allowed-tools
             "Read,Grep,Glob,Write,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
-            --json-schema
-            '{"type":"object","properties":{"modes":{"type":"array","items":{"type":"string","enum":["code","writing","deps"]}},"critical":{"type":"integer"},"high":{"type":"integer"},"medium":{"type":"integer"},"low":{"type":"integer"},"inline_suggestions":{"type":"integer"},"ci_status":{"type":"string","enum":["pass","fail","running","unknown"]},"headline":{"type":"string"}},"required":[]}'
-
-      # structured_output은 모델이 만든 문자열이다. run 스크립트에 ${{ }}로
-      # 직접 박으면 셸 인젝션이 되므로 env로 넘겨 jq에 파이프한다.
-      # 값이 비어 있거나(스키마 미준수) 리뷰 스텝이 실패해도 이 스텝이
-      # 잡을 빨갛게 만들지 않도록 always() + 빈 값 가드를 둔다.
-      - name: 리뷰 결과 요약
-        if: always() && steps.claude-review.outputs.structured_output != ''
-        env:
-          REVIEW_RESULT: ${{ steps.claude-review.outputs.structured_output }}
-        run: |
-          set -euo pipefail
-          if ! printf '%s' "$REVIEW_RESULT" | jq -e . >/dev/null 2>&1; then
-            echo "structured_output이 JSON이 아니라 요약을 건너뜁니다." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          printf '%s' "$REVIEW_RESULT" | jq -r '
-            "## 리뷰 집계",
-            "",
-            "- 모드: \(([(.modes // [])[]] | join(", ") | if . == "" then "-" else . end))",
-            "- CI: \(.ci_status // "unknown")",
-            "- critical \(.critical // 0) / high \(.high // 0) / medium \(.medium // 0) / low \(.low // 0)",
-            "- 인라인 suggestion: \(.inline_suggestions // 0)건",
-            "",
-            "> \(.headline // "-")"
-          ' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -424,6 +424,21 @@ jobs:
             무엇이 왜 기준에 미달하는지에 집중하세요.
             </output_format>
 
+            <final_output>
+            코멘트를 다 남긴 뒤, 마지막 메시지로 --json-schema 스키마에 맞는
+            JSON만 출력하세요. 이건 Actions 요약에 찍히는 집계용이고
+            사람이 읽는 리뷰는 위의 PR 코멘트가 전부입니다. JSON에 지적
+            본문을 옮겨 적지 마세요.
+
+            - modes: 실제로 수행한 모드 ("code" / "writing" / "deps")
+            - critical / high / medium / low: 요약 코멘트에 실제로 올린
+              심각도별 건수. 인라인으로만 올린 것도 포함해 셉니다.
+            - inline_suggestions: create_inline_comment를 호출한 횟수
+            - ci_status: get_ci_status로 본 상태를 "pass" / "fail" /
+              "running" / "unknown" 중 하나로
+            - headline: 가장 중요한 발견 한 줄. 지적이 없으면 왜 없는지 한 줄
+            </final_output>
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # Write는 요약 코멘트 --body-file 작성용.
@@ -438,6 +453,38 @@ jobs:
           # Bash(gh api:*)는 뺐다. 인라인 suggestion을 직접 POST할 때만 필요했는데
           # 이제 전용 MCP 도구가 그 일을 하고, gh api는 사실상 모든 write 엔드포인트를
           # 여는 와일드카드라 리뷰 전용 잡에 남겨둘 이유가 없다.
+          #
+          # --json-schema는 마지막 메시지를 스키마로 검증해 structured_output
+          # 출력으로 내보낸다. 아래 "리뷰 결과 요약" 스텝이 이걸 Step Summary에
+          # 찍는다. required를 비워 둔 것은 의도적이다 — 집계는 부수적이고,
+          # 필드 하나가 빠졌다고 리뷰 잡이 실패하면 본말이 전도된다.
           claude_args: >-
             --allowed-tools
             "Read,Grep,Glob,Write,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --json-schema
+            '{"type":"object","properties":{"modes":{"type":"array","items":{"type":"string","enum":["code","writing","deps"]}},"critical":{"type":"integer"},"high":{"type":"integer"},"medium":{"type":"integer"},"low":{"type":"integer"},"inline_suggestions":{"type":"integer"},"ci_status":{"type":"string","enum":["pass","fail","running","unknown"]},"headline":{"type":"string"}},"required":[]}'
+
+      # structured_output은 모델이 만든 문자열이다. run 스크립트에 ${{ }}로
+      # 직접 박으면 셸 인젝션이 되므로 env로 넘겨 jq에 파이프한다.
+      # 값이 비어 있거나(스키마 미준수) 리뷰 스텝이 실패해도 이 스텝이
+      # 잡을 빨갛게 만들지 않도록 always() + 빈 값 가드를 둔다.
+      - name: 리뷰 결과 요약
+        if: always() && steps.claude-review.outputs.structured_output != ''
+        env:
+          REVIEW_RESULT: ${{ steps.claude-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$REVIEW_RESULT" | jq -e . >/dev/null 2>&1; then
+            echo "structured_output이 JSON이 아니라 요약을 건너뜁니다." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          printf '%s' "$REVIEW_RESULT" | jq -r '
+            "## 리뷰 집계",
+            "",
+            "- 모드: \(([(.modes // [])[]] | join(", ") | if . == "" then "-" else . end))",
+            "- CI: \(.ci_status // "unknown")",
+            "- critical \(.critical // 0) / high \(.high // 0) / medium \(.medium // 0) / low \(.low // 0)",
+            "- 인라인 suggestion: \(.inline_suggestions // 0)건",
+            "",
+            "> \(.headline // "-")"
+          ' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,9 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+      # mcp__github_ci__* 서버는 설치 전에 워크플로 토큰의 actions:read를 실제로
+      # 검증한다. 없으면 경고만 남기고 서버를 조용히 빼므로 여기서 함께 켠다.
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -50,6 +53,34 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 위 if의 deps-major 예외를 실제로 동작하게 만드는 설정.
+          # 액션은 actor의 type이 User가 아니면 allowed_bots에 있는지부터 보고,
+          # 없으면 "Workflow initiated by non-human actor" 로 그 자리에서 죽는다.
+          # 즉 지금까지 deps-major PR은 if는 통과하고 액션에서 실패했다.
+          # 이름은 소문자화 + `[bot]` 접미사 제거 후 비교하므로 renovate만 써도 되지만,
+          # PR에 표시되는 이름 그대로 두는 편이 대조하기 쉽다.
+          # '*'는 쓰지 않는다 — 아무 App이나 이 워크플로를 돌릴 수 있게 된다.
+          allowed_bots: 'renovate[bot]'
+
+          # CI 결과(mcp__github_ci__*)를 읽기 위해 필요. 리뷰가 "빨간 체크가 왜
+          # 빨간지"까지 보고 판단할 수 있게 된다.
+          additional_permissions: |
+            actions: read
+
+          # 인라인 코멘트를 발견 즉시 던지지 않고 버퍼에 모아 분류한 뒤 게시한다.
+          # 기본값이 true라 없어도 동작은 같지만, 이 워크플로가 인라인 코멘트를
+          # 쓰기 시작했으므로 의존하는 동작을 명시해 둔다.
+          classify_inline_comments: true
+
+          # 인라인 지적에 "Fix this" 링크를 붙인다. 작성자가 링크만 눌러도
+          # 그 지적에 대한 후속 수정 작업이 걸린다. (기본값 true, 명시)
+          include_fix_links: true
+
+          # 실행 리포트를 Actions Step Summary에 남긴다. 리뷰가 왜 짧게 끝났는지
+          # /어디서 막혔는지를 raw 로그를 뒤지지 않고 확인하기 위한 것.
+          display_report: true
+
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -62,6 +93,25 @@ jobs:
             diff는 반드시 `gh pr diff`로 가져오세요.
             저장소 파일은 Read/Grep/Glob으로 직접 읽어 변경의 실제 사용처와
             기존 문서의 컨벤션을 확인하세요.
+
+            <ci_results>
+            리뷰를 쓰기 전에 `mcp__github_ci__get_ci_status`로 이 PR의 CI 상태를
+            확인하세요. 실패한 잡이 있으면 `mcp__github_ci__get_workflow_run_details`
+            와 `mcp__github_ci__download_job_log`로 로그를 받아 실패 원인이 이번
+            diff에 있는지 판단하세요.
+
+            - 원인이 diff에 있으면 파일:라인과 함께 지적으로 올리세요.
+              CI가 이미 빨갛다는 사실만 반복하지 말고, 어느 줄이 왜 그 실패를
+              만들었는지를 쓰세요.
+            - 원인이 diff 밖(플래키 테스트, 인프라, base 브랜치 선행 실패)이면
+              지적 대신 요약에 한 줄로만 적으세요.
+            - CI가 아직 실행 중이면 기다리지 말고 그대로 리뷰하되, 요약에
+              "CI 진행 중"이라고 적으세요.
+
+            CI가 전부 통과했다는 것은 "테스트가 커버하는 범위에서" 통과했다는
+            뜻입니다. 이번 변경으로 생긴 분기에 테스트가 없다면 그건 여전히
+            <review_dimensions> 7번의 지적 대상입니다.
+            </ci_results>
 
             <mode_selection>
             변경된 파일 목록을 보고 아래 모드를 고르세요. 여러 모드가 해당되면
@@ -280,11 +330,28 @@ jobs:
 
             ────────────────────────────────────────
             <output_format>
-            `gh pr comment`의 Bash 도구로 PR에 코멘트를 남기세요.
-            여러 번 나눠 달지 말고 한 번에 하나의 코멘트로 작성합니다.
-            본문에 백틱과 따옴표가 들어가므로 셸 해석을 피하기 위해
-            `gh pr comment <번호> --body-file -` 형태로 stdin을 쓰거나
-            인용부호로 감싼 heredoc(<<'EOF')을 사용하세요.
+            요약 코멘트는 PR당 하나만 유지합니다. 이 워크플로는 synchronize에도
+            돌기 때문에 매번 새 코멘트를 달면 push할 때마다 리뷰가 쌓입니다.
+            Write 도구로 본문을 파일(review.md)에 먼저 쓰세요. 본문에 백틱과
+            따옴표가 들어가므로 `--body`로 셸에 직접 넘기지 말고 반드시
+            `--body-file`을 쓰세요.
+
+            게시 전에 `gh pr view <번호> --json comments`로 이 PR의 코멘트를 보고,
+            **claude[bot]이 마지막으로 남긴 코멘트**가 무엇인지 확인하세요.
+
+            - 그 코멘트가 이 워크플로의 리뷰(본문이 `## 리뷰 요약`으로 시작)이면
+              덮어씁니다:
+                gh pr comment <번호> --edit-last --create-if-none --body-file review.md
+            - claude[bot] 코멘트가 아예 없으면 위 명령이 `--create-if-none`으로
+              새로 만들어 주므로 그대로 쓰면 됩니다.
+            - 마지막 claude[bot] 코멘트가 리뷰가 아니면(@claude 호출에 답한
+              코멘트 등) `--edit-last`를 쓰지 마세요. 그걸 덮어쓰게 됩니다.
+              이 경우에만 새 코멘트를 남깁니다:
+                gh pr comment <번호> --body-file review.md
+
+            덮어쓰는 경우 요약 코멘트는 항상 이번 실행 기준의 전체 상태여야
+            합니다. 이전 실행에서 지적했다가 이번에 고쳐진 항목은 빼고,
+            "이전 리뷰에서 언급했듯이" 같은 이전 코멘트 참조도 쓰지 마세요.
 
             수행한 모드의 섹션만 포함하세요.
 
@@ -332,17 +399,26 @@ jobs:
             - 대상: 이번 PR diff에 존재하는 라인(RIGHT side)만. diff 밖 라인이나
               설계 차원의 지적은 suggestion 없이 요약 코멘트로만 남기세요.
             - 기준: 확신도 high이고 대체 내용이 자명한 지적만. 취향 교정은 금지.
-            - 방법: 인라인 코멘트들을 리뷰 하나로 모아 제출하세요. Write 도구로
-              review.json을 만든 뒤:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews -X POST --input review.json
-              review.json 형식:
-              {"event":"COMMENT","body":"인라인 수정 제안 N건",
-               "comments":[{"path":"파일경로","line":42,"side":"RIGHT",
-                 "body":"왜 바꾸는지 한 줄\n\n```suggestion\n42행 전체를 대체할 내용\n```"}]}
-              여러 줄을 교체하려면 start_line(범위 시작)과 start_side("RIGHT")를
-              추가하고 suggestion 블록에 그 범위 전체의 대체 내용을 넣으세요.
-            - suggestion 블록 안에는 대체할 코드/문장만 넣고, 설명은 body에 쓰세요.
-              들여쓰기는 원본 라인과 정확히 일치해야 합니다.
+            - 방법: `mcp__github_inline_comment__create_inline_comment`를 지적마다
+              한 번씩 호출하세요. 이 도구는 호출을 즉시 게시하지 않고 모았다가
+              분류 후 한 번에 올리므로, 여러 번 나눠 불러도 코멘트가 흩어지지
+              않습니다. `gh api ... /pulls/*/reviews`를 직접 치지 마세요.
+              파라미터:
+                path       — 파일 경로
+                line       — 코멘트를 붙일 라인 (한 줄일 때)
+                startLine  — 여러 줄을 교체할 때 범위 시작 (line이 범위 끝)
+                side       — "RIGHT" (기본값)
+                body       — 설명 한 줄 + suggestion 블록
+            - body 형식:
+              왜 바꾸는지 한 줄
+
+              ```suggestion
+              line(또는 startLine~line) 범위 전체를 대체할 내용
+              ```
+            - suggestion 블록 안에는 대체할 코드/문장만 넣고, 설명은 블록 밖에
+              쓰세요. 들여쓰기는 원본 라인과 정확히 일치해야 합니다.
+            - 같은 지적을 인라인과 요약 양쪽에 전부 옮겨 적지 마세요. 인라인으로
+              올린 것은 요약에서는 파일:라인과 한 줄 제목까지만 남깁니다.
 
             어조는 건설적으로. 다만 칭찬으로 코멘트를 채우지 말고
             무엇이 왜 기준에 미달하는지에 집중하세요.
@@ -350,6 +426,18 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # Write는 리뷰 코멘트 body-file·suggestion용 review.json 작성에,
-          # Bash(gh api:*)는 인라인 suggestion 리뷰 제출에 필요하다.
-          claude_args: '--allowed-tools "Read,Grep,Glob,Write,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'
+          # Write는 요약 코멘트 --body-file 작성용.
+          #
+          # 이 워크플로는 prompt가 있고 @claude 멘션이 없으므로 agent 모드로 붙는다.
+          # agent 모드에서 액션은 여기 적힌 --allowed-tools를 파싱해서, 실제로
+          # 나열된 MCP 서버만 설치한다. 즉 mcp__github_inline_comment__* /
+          # mcp__github_ci__* 는 아래에 이름을 적어야 서버 자체가 켜진다.
+          # (tag 모드는 기본으로 붙지만, 그러면 이 프롬프트가 tag 모드 기본
+          #  프롬프트 뒤에 custom_instructions로 밀려들어가 출력 규약이 흔들린다)
+          #
+          # Bash(gh api:*)는 뺐다. 인라인 suggestion을 직접 POST할 때만 필요했는데
+          # 이제 전용 MCP 도구가 그 일을 하고, gh api는 사실상 모든 write 엔드포인트를
+          # 여는 와일드카드라 리뷰 전용 잡에 남겨둘 이유가 없다.
+          claude_args: >-
+            --allowed-tools
+            "Read,Grep,Glob,Write,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude-deps-audit.yml
+++ b/.github/workflows/claude-deps-audit.yml
@@ -56,6 +56,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 예약 실행 잡은 "아무것도 만들지 않음"이 정상 종료라 성공 로그만
+          # 남는다. 실행 리포트를 Step Summary에 찍어 두면 무엇을 확인하고
+          # 왜 만들지 않았는지를 raw 로그를 펼치지 않고 볼 수 있다.
+          display_report: true
+
           prompt: |
             당신은 이 저장소의 의존성 위생 유지보수 담당입니다. 커밋 d0fd236(PR #160)과
             같은 종류의 작업을 정기 수행합니다: 죽은 pnpm overrides 정리 + pnpm audit

--- a/.github/workflows/claude-lighthouse.yml
+++ b/.github/workflows/claude-lighthouse.yml
@@ -39,6 +39,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 예약 실행 잡은 "아무것도 만들지 않음"이 정상 종료라 성공 로그만
+          # 남는다. 실행 리포트를 Step Summary에 찍어 두면 무엇을 확인하고
+          # 왜 만들지 않았는지를 raw 로그를 펼치지 않고 볼 수 있다.
+          display_report: true
+
           prompt: |
             당신은 배포된 블로그(https://blog.sangwook.dev)의 성능 감시 담당입니다.
             주 1회 Lighthouse를 돌려 회귀가 있을 때만 이슈를 만듭니다.

--- a/.github/workflows/claude-link-rot.yml
+++ b/.github/workflows/claude-link-rot.yml
@@ -33,6 +33,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 예약 실행 잡은 "아무것도 만들지 않음"이 정상 종료라 성공 로그만
+          # 남는다. 실행 리포트를 Step Summary에 찍어 두면 무엇을 확인하고
+          # 왜 만들지 않았는지를 raw 로그를 펼치지 않고 볼 수 있다.
+          display_report: true
+
           prompt: |
             당신은 블로그 발행 글의 외부 링크 건강 검사 담당입니다. 월 1회
             실행됩니다. 모든 산출물(커밋, PR, 코멘트)은 한글로 작성하세요.

--- a/.github/workflows/claude-post-inventory.yml
+++ b/.github/workflows/claude-post-inventory.yml
@@ -33,6 +33,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 예약 실행 잡은 "아무것도 만들지 않음"이 정상 종료라 성공 로그만
+          # 남는다. 실행 리포트를 Step Summary에 찍어 두면 무엇을 확인하고
+          # 왜 만들지 않았는지를 raw 로그를 펼치지 않고 볼 수 있다.
+          display_report: true
+
           prompt: |
             당신은 블로그 초안·예약글 인벤토리 담당입니다. 월 1회, 현황을
             사실만 기록합니다. 모든 산출물은 한글로 작성하세요.

--- a/.github/workflows/claude-site-smoke.yml
+++ b/.github/workflows/claude-site-smoke.yml
@@ -34,6 +34,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # 예약 실행 잡은 "아무것도 만들지 않음"이 정상 종료라 성공 로그만
+          # 남는다. 실행 리포트를 Step Summary에 찍어 두면 무엇을 확인하고
+          # 왜 만들지 않았는지를 raw 로그를 펼치지 않고 볼 수 있다.
+          display_report: true
+
           prompt: |
             당신은 배포된 블로그(https://blog.sangwook.dev)의 헬스체커입니다.
             빌드 성공 여부가 아니라 배포 결과물 자체를 검사합니다. SSG 산출물의

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,9 @@ on:
   pull_request_review_comment:
     types: [ created ]
   issues:
-    types: [ opened, assigned ]
+    # labeled: 본문을 고쳐 @claude를 끼워 넣지 않고 라벨 하나로 부르기 위한 것.
+    # 이미 열려 있는 이슈(특히 남이 연 이슈)를 넘길 때 쓴다.
+    types: [ opened, assigned, labeled ]
   pull_request_review:
     types: [ submitted ]
 
@@ -16,7 +18,8 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
+      (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,9 +39,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # 이슈에 이 라벨이 붙으면 트리거로 인정한다. 액션 기본값도 'claude'지만,
+          # 위 on.issues.types의 labeled와 짝이 되는 값이라 명시해 둔다.
+          # (라벨명을 바꾸려면 여기와 위 if의 label.name을 함께 고칠 것)
+          label_trigger: 'claude'
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          # 실행 리포트를 Actions Step Summary에 남긴다.
+          display_report: true
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           prompt: '사용자의 요청을 수행하되, 모든 답변과 설명은 반드시 한글로 작성해주세요. ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}'


### PR DESCRIPTION
`anthropics/claude-code-action@v1`의 입력을 `action.yml` 기준으로 전부 훑고, 이 저장소에서 실제로 값이 나오는 것만 반영했습니다.

> **이 PR은 리뷰 워크플로 자신을 수정하므로 claude-review가 돌지 않습니다.** 액션은 워크플로 파일이 기본 브랜치 버전과 다르면 OIDC 토큰 교환 단계에서 스스로 스킵합니다(`Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch`). 체크는 초록이지만 14초 만에 끝난 스킵입니다. 아래 변경의 런타임 동작은 **머지 이후 첫 일반 PR이 첫 검증**이 됩니다.

## 가장 중요한 것: 지금까지 동작하지 않던 기능이 하나 있었습니다

`claude-code-review.yml`의 `if`는 `deps-major` 라벨이 붙은 봇 PR을 리뷰 대상으로 통과시키고 있었습니다. 그런데 액션은 actor의 type이 `User`가 아니면 **`allowed_bots` 목록을 먼저 보고, 없으면 `Workflow initiated by non-human actor`로 그 자리에서 실패**합니다.

즉 renovate의 major 업데이트 PR은 `if`를 통과한 뒤 액션에서 죽어, 리뷰 대신 실패한 체크만 붙고 있었습니다. 워크플로 주석이 이 동작을 이미 알고 있었는데(`claude-code-action은 non-human actor를 거부한다`) 정작 예외를 살리는 설정이 빠져 있었습니다.

`allowed_bots: 'renovate[bot]'`로 해결했습니다. `'*'`는 쓰지 않았습니다 — 아무 App이나 이 워크플로를 돌릴 수 있게 됩니다.

## 추가한 기능

### 1. 리뷰가 CI 결과를 읽고 판단합니다 (`additional_permissions` + `mcp__github_ci__*`)

`additional_permissions`와 잡 `permissions` 양쪽에 `actions: read`를 켰습니다. 액션은 CI 서버를 설치하기 전에 워크플로 토큰의 `actions:read`를 실제로 검증하고, 없으면 경고만 남기고 서버를 조용히 빼기 때문에 양쪽 모두 필요합니다.

프롬프트에는 실패 원인이 diff 안인지 밖인지 가르는 기준을 넣었습니다. 안이면 파일:라인과 함께 지적, 밖(플래키·인프라·base 선행 실패)이면 지적 대신 요약 한 줄. CI 초록이 테스트 부재를 면제하지 않는다는 것도 못박았습니다.

### 2. 인라인 suggestion을 전용 도구로 올립니다 (`classify_inline_comments`, `include_fix_links`)

기존에는 `Write`로 `review.json`을 만들어 `gh api .../pulls/*/reviews`를 직접 치고 있었습니다. `mcp__github_inline_comment__create_inline_comment`로 바꿨습니다:

- `classify_inline_comments`(기본 true)가 호출을 버퍼에 모아 분류한 뒤 한 번에 올리므로, 지적마다 나눠 불러도 코멘트가 흩어지지 않습니다
- `include_fix_links`(기본 true)가 각 지적에 "Fix this" 링크를 붙여, 작성자가 링크만 눌러도 후속 수정이 걸립니다

두 입력 모두 기본값이지만 이제 동작이 여기에 의존하므로 명시했습니다.

**그리고 `Bash(gh api:*)`를 뺐습니다.** 인라인 suggestion을 직접 POST할 때만 필요했는데 이제 전용 도구가 그 일을 하고, `gh api`는 사실상 모든 write 엔드포인트를 여는 와일드카드라 리뷰 전용 잡에 남길 이유가 없습니다.

### 3. 요약 코멘트를 PR당 하나로 유지합니다

이 워크플로는 `synchronize`에도 돌기 때문에 push마다 새 리뷰 코멘트가 쌓이고 있었습니다. `gh pr comment --edit-last --create-if-none`으로 직전 리뷰를 덮어씁니다.

다만 덮어쓰기 전에 **claude[bot]의 마지막 코멘트가 실제로 이 워크플로의 리뷰인지**(`## 리뷰 요약`으로 시작) 확인하게 했습니다. 확인 없이 `--edit-last`를 쓰면 같은 App이 남긴 `@claude` 응답 코멘트를 덮어씁니다.

### 4. `claude` 라벨로도 @claude를 부를 수 있습니다 (`label_trigger`)

지금은 이슈 본문·제목에 `@claude`가 있어야만 트리거됩니다. 이미 열린 이슈, 특히 남이 연 이슈를 넘기려면 본문을 고쳐 멘션을 끼워 넣어야 했습니다. `on.issues.types`에 `labeled`를 추가하고 `label_trigger: 'claude'`를 명시했습니다.

기존 `@claude` 절에는 `action != 'labeled'` 조건을 넣었습니다. 없으면 본문에 `@claude`가 있는 이슈에 아무 라벨이나 붙일 때마다 잡이 다시 돕니다.

### 5. 예약 워크플로 5종에 `display_report`

이 5종은 "변경·회귀가 없으면 아무것도 만들지 않는" 설계라 정상 동작할 때 남는 것이 초록 체크뿐입니다. 무엇을 확인했고 왜 만들지 않았는지를 보려면 raw 로그를 펼쳐야 했습니다. 동작에는 영향이 없고 출력만 늘어납니다.

## 넣었다가 되돌린 것: `--json-schema` + `structured_output`

리뷰 결과를 스키마로 받아 Step Summary에 집계표로 찍는 기능을 넣었다가([55e1176](https://github.com/Han5991/fe-lab/commit/55e1176)) 되돌렸습니다([9cb6eb5](https://github.com/Han5991/fe-lab/commit/9cb6eb5)). `--json-schema`의 알려진 실패 양상 두 가지가 이 워크플로에서는 감당할 수 없는 쪽으로 걸립니다.

- [claude-code#23265](https://github.com/anthropics/claude-code/issues/23265) — `--json-schema`를 준 **첫 실행**이 null 출력 + exit code 1로 실패하고 재실행하면 성공하는 cold-start 패턴. not planned로 닫혔고 권장 우회는 재시도인데, Actions 실행은 매번 cold start라 "두 번째 실행"이 없습니다
- [claude-code-action#852](https://github.com/anthropics/claude-code-action/issues/852) — agent-sdk 0.2.15에서 AJV `dependencies` 키워드 검증 오류로 Claude Code Review 실행이 turn 1, API 비용 0으로 즉시 죽습니다. 열려 있고 수정 버전이 없습니다

두 경우 모두 집계 필드가 비는 게 아니라 **리뷰 실행 자체가 통째로 날아갑니다.** `required: []`로는 막을 수 없는 층위고, 위에 적은 대로 이 PR에서는 실측으로 판별할 수도 없습니다. 부수적인 집계표를 위해 리뷰를 걸 수는 없다고 판단했습니다. 두 이슈가 닫히면 되살릴 수 있게 커밋을 남겨 뒀습니다.

## 검토했으나 채택하지 않은 옵션

| 옵션 | 판단 |
| :--- | :--- |
| `track_progress` | tag 모드를 강제합니다. 그러면 이 저장소의 긴 리뷰 프롬프트가 tag 모드 기본 프롬프트 뒤에 `<custom_instructions>`로 밀려들어가 출력 규약(모드 선택·보고 기준·코멘트 형식)이 흔들립니다. 진행률 체크박스 값보다 손실이 큽니다 |
| `use_sticky_comment` | 액션이 만드는 tracking comment에만 적용되는데, agent 모드에는 tracking comment가 없어 **no-op**입니다. 같은 목적을 위 3번(`--edit-last`)으로 달성했습니다 |
| `use_commit_signing` | PR을 만드는 deps-audit·link-rot에 Verified 배지가 붙지만, `Bash(git commit)`이 `mcp__github_file_ops__commit_files`로 바뀌면서 두 워크플로의 커밋 절차와 허용 도구를 다시 짜야 합니다. 매주 도는 자동화를 배지 하나로 흔들 이유가 없다고 봤습니다 |
| `allowed_non_write_users` | write 권한 없는 사용자가 액션을 돌릴 수 있게 됩니다. 공개 저장소에서 켤 것이 아닙니다 |
| `assignee_trigger` | 담당자 지정만으로 트리거하려면 `claude` 계정이 필요한데 이 저장소에는 없습니다 |
| `branch_name_template` | 브랜치 이름을 각 워크플로 프롬프트가 직접 정하고 있어 겹칩니다 |
| `plugins` / `plugin_marketplaces` | 이 저장소의 `.claude/` 스킬은 체크아웃으로 이미 로드됩니다 |
| `bot_id` / `bot_name`, `path_to_*_executable`, `use_bedrock` / `use_vertex` / `use_foundry`, federation 입력 | 기본값·현재 인증 방식으로 충분합니다 |

`anthropics/claude-code-action@v1`의 `@v1` 표기는 #162에서 정한 대로 공급자 권장 표기라 SHA 핀 예외로 그대로 뒀습니다.

## 검증

정적 검증만 가능했습니다(위 워크플로 validation 때문에 런타임 검증 불가):

- 워크플로 9종 YAML 파싱 확인
- `claude_args` 폴딩(`>-`) 결과가 한 줄 CLI 인자로 합쳐지는지 확인
- MCP 도구명을 액션 소스에서 대조 — `create_inline_comment`(파라미터 `path`/`line`/`startLine`/`side`/`body`), `get_ci_status`/`get_workflow_run_details`/`download_job_log`
- agent 모드가 `--allowed-tools`를 파싱해 거기 나열된 MCP 서버만 설치한다는 점을 소스에서 확인 — 그래서 도구명을 명시적으로 나열했습니다
- `gh pr comment`의 `--edit-last` / `--create-if-none` 존재 및 조합 조건 확인 (`--create-if-none`은 `--edit-last`와만 함께 사용 가능)
- `allowed_bots` 매칭 규칙 확인 (소문자화 + `[bot]` 접미사 제거 후 비교)