### PR TITLE
chore(deps): Renovate가 pnpm 공급망 정책에 걸릴 업데이트를 제안하지 않게 한다

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":dependencyDashboard",
     ":semanticCommits",
+    "security:minimumReleaseAgeNpm",
     "group:definitelyTyped",
     "group:jsUnitTest",
     "group:nextjsMonorepo"


### PR DESCRIPTION
## 요약

열려 있던 PR 3건을 점검하다(#191 머지, #190 클로즈) 발견한 **재발성 문제**를
설정에서 막습니다. `renovate.json`의 `extends`에 공식 프리셋
`security:minimumReleaseAgeNpm` 한 줄을 추가하는 변경입니다.

pnpm과 Renovate가 서로 다른 릴리스 나이 정책 위에서 돌고 있어서, 주말에 나온
릴리스는 월요일 아침 PR로 올라와 **반드시 CI가 한 번 실패**하고 automerge까지
막힙니다. 두 정책을 같은 방향으로 맞춥니다.

## 무엇을, 왜 바꿨나

### 문제

pnpm 11은 `minimumReleaseAge` 1440분(24시간)을 기본으로 강제합니다. 공개된 지
24시간이 안 된 패키지가 lockfile에 들어가면 install 단계에서 죽습니다 — #187의
CI 로그가 그대로입니다:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  globals@17.9.0 was published at 2026-08-02T15:24:47Z,
  within the minimumReleaseAge cutoff (2026-08-02T08:04:54Z)
```

반면 Renovate 쪽에는 나이 제한이 없어서(`minimumReleaseAge` 기본값 `null`)
공개 16시간짜리 릴리스로 PR을 만듭니다. 이 저장소는 브랜치 생성이
`before 10am on monday` 스케줄이라, **주말 릴리스는 구조적으로 이 실패에
걸립니다.** 한 번 빨간불이 나면 devDependency minor라 automerge 대상인데도
멈춰 서고, 사람이 컷오프가 지난 뒤 재실행해줘야 합니다.

### 고친 방법

```diff
     "config:recommended",
     ":dependencyDashboard",
     ":semanticCommits",
+    "security:minimumReleaseAgeNpm",
     "group:definitelyTyped",
```

프리셋이 npm datasource에 `minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"`를
겁니다. 핵심은 **업데이트를 통째로 건너뛰지 않는다**는 점입니다 — 최신 릴리스가
너무 새로우면 나이 조건을 만족하는 직전 릴리스를 대신 제안합니다. #187이었다면
`17.9.0` 대신 `17.8.0`(2026-07-01 공개)이 올라와 CI를 통과하고 automerge된 뒤,
다음 주에 `17.9.0`으로 올라갑니다.

### 왜 옵션을 직접 쓰지 않고 프리셋인가

처음에는 `minimumReleaseAge`만 직접 넣으려 했는데, **그것만으로는 문제가 안
고쳐집니다.** Renovate 문서 원문:

> If you enable `automerge` _and_ `minimumReleaseAge`, Renovate will create PRs
> immediately, but only automerge them when the `minimumReleaseAge` time-duration
> has passed.

즉 PR은 그대로 생성되고 "pending" 상태 체크만 붙어서, 빨간 CI는 그대로 남습니다.
브랜치 생성 자체를 막으려면 `internalChecksFilter: "strict"`가 함께 필요합니다.
프리셋은 이 조합에 더해, 릴리스 타임스탬프가 없어 나이 검사가 불가능한
updateType 4종(`lockFileMaintenance`·`replacement`·`pin`·`bump`/`lockfileUpdate`/`rollback`)의
예외 처리까지 이미 담고 있습니다. 손으로 재현하면 틀리기 쉬운 부분이라 프리셋을
그대로 씁니다.

`lockFileMaintenance` 예외에 프리셋이 붙이는 경고문은 "패키지 매니저가 자체
검증을 하는지 확인하라"인데, 이 저장소는 **pnpm이 바로 그 검증을 하고 있으므로**
그대로 맞습니다.

## 검증

### 프리셋이 실제로 존재하고 해석되는가

`renovate-config-validator`는 통과했지만 **이 검증은 무의미했습니다** — 가짜
이름(`security:minimumReleaseAgeNpmXXX`)을 넣어도 똑같이 통과합니다(네거티브
컨트롤). validator는 프리셋 존재 여부를 검사하지 않습니다.

그래서 릴리스된 `renovate@44.8.0`을 설치해 Renovate 자체 코드로 해석했습니다:

| 확인 | 결과 |
| :--- | :--- |
| `isInternal('security:minimumReleaseAgeNpm')` | `true` |
| `isInternal('security:minimumReleaseAgeNpmXXX')` | `false` (네거티브 컨트롤) |
| `getPreset({repo:'security', presetName:'minimumReleaseAgeNpm'})` | `minimumReleaseAge: "3 days"`, `internalChecksFilter: "strict"` 포함 |

### `rangeStrategy: "bump"`와 충돌하지 않는가 — 가장 위험했던 지점

이 저장소는 `rangeStrategy: "bump"`인데, 프리셋에는 `matchUpdateTypes: ["bump", ...]`를
`minimumReleaseAge: null`로 되돌리는 예외 규칙이 있습니다. Renovate 룰 엔진은
`isBump`가 참이면 매칭 후보에 `"bump"`를 **추가**하므로(`UpdateTypesMatcher`),
자칫 프리셋 전체가 무력화될 수 있는 구조입니다.

룰 엔진을 직접 실행해 확인했습니다:

| 단계 | `isBump` | `minimumReleaseAge` |
| :--- | :--- | :--- |
| 릴리스 **필터링** (후보 버전 선택) | 아직 미설정 | **`3 days` 적용** ✅ |
| 최종 update (PR 생성 이후) | `true` | `null` (중복 상태체크만 꺼짐) |

너무 새 버전을 후보에서 빼는 일은 필터링 단계(`filterInternalChecks`)에서
일어나고, 그 시점엔 `isBump`가 아직 채워지지 않아 예외 규칙이 발동하지 않습니다.
의도대로 동작합니다.

### 기존 automerge/라벨 정책이 그대로인가

변경 전/후 설정을 각각 프리셋까지 해석한 뒤 대표 시나리오로 대조했습니다.
**automerge와 labels는 전 시나리오에서 변화 없음:**

| 시나리오 | automerge | labels | minimumReleaseAge |
| :--- | :--- | :--- | :--- |
| globals devDep minor (#187) | `true` → `true` | 변화 없음 | → `null`\* |
| node engines major (#191) | `false` → `false` | `deps-major` 유지 | → `3 days` |
| prod dep patch | `true` → `true` | 변화 없음 | → `null`\* |
| catalog minor | `true` → `true` | 변화 없음 | → `3 days` |
| github-actions minor | `true` → `true` | 변화 없음 | 영향 없음 |

<sub>\*최종 단계 값이며, 필터링 단계에서는 모두 `3 days`가 적용됩니다. github-actions는
datasource가 `github-tags`라 애초에 pnpm lockfile 정책과 무관합니다.</sub>

### 그 외

- `python3 -c json.load` → JSON 유효
- `prettier --check renovate.json` → 통과
- `renovate-config-validator` → 통과 (단, 위 한계 있음)

### 돌리지 않은 것

`pnpm lint` / `check-types` / `test`는 실행하지 않았습니다. `renovate.json`을
소비하는 코드가 저장소에 없고(워크플로 주석의 언급뿐), 빌드·타입·테스트 경로와
접점이 없습니다. #182와 같은 판단으로 앱 스모크 테스트는 생략했습니다.

## 채택하지 않은 것

- **`minimumReleaseAge`를 1일로 직접 지정** — pnpm 기준선(24시간)과 정확히
  같게 맞추면 지연이 최소지만, 경계 근처 레이스에 여유가 없습니다. 프리셋의
  3일은 npm의 72시간 unpublish 창과도 맞아떨어져 그대로 씁니다.
- **`prCreation: "not-pending"` 추가** — 문서가 함께 권장하지만,
  `internalChecksFilter: "strict"`가 pending 릴리스를 후보에서 이미 걸러내므로
  이 저장소에선 더해지는 게 없습니다.
- **`schedule` 완화** — 이번 문제와 별개인 정책 결정이라 건드리지 않았습니다.

## 알려진 트레이드오프

3일 대기 때문에 버전이 가끔 두 단계로 나뉘어 올라옵니다(`17.8.0` → 다음 주
`17.9.0`). 대신 각각이 초록불 automerge PR이라, 지금처럼 빨간불로 멈춰 사람 손을
기다리는 것보다 낫다고 판단했습니다.

## 다음 회차에 재확인할 것

- pnpm이 `minimumReleaseAge` 기본값을 바꾸면(현재 1440분) 3일 여유가 여전히
  충분한지 확인
- Renovate가 `bump`/`lockfileUpdate` updateType에 릴리스 타임스탬프를 연결하면
  (프리셋 주석의 TODO) 예외 규칙이 사라지는지 확인
- github-actions 업데이트는 이 정책 밖이므로, 필요해지면
  `security:minimumReleaseAge*` 계열에 해당 datasource 프리셋이 생겼는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQZTuk4AEoyf8sFhPxnAuZ)_