### PR TITLE
ci(claude): 리뷰 3건을 반영하고 측정 원값을 아티팩트로 남긴다

### DIFF
--- a/.github/scripts/lighthouse-collect.py
+++ b/.github/scripts/lighthouse-collect.py
@@ -38,6 +38,7 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -66,17 +67,30 @@ AUDIT_ALIASES = {
 }
 
 
-def fetch_text(url: str) -> tuple[int | None, str]:
-    """원문을 그대로 가져온다. 실패해도 예외를 던지지 않는다."""
-    try:
-        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return response.status, response.read().decode("utf-8", errors="replace")
-    except urllib.error.HTTPError as error:
-        body = error.read() or b""
-        return error.code, body.decode("utf-8", errors="replace")
-    except Exception:
-        return None, ""
+def fetch_text(url: str, retries: int = 2, retry_delay: float = 3.0) -> tuple[int | None, str]:
+    """원문을 그대로 가져온다. 실패해도 예외를 던지지 않는다.
+
+    호출부는 **반드시 status를 확인하고 본문을 쓸 것.** 실패 시 빈 문자열이
+    돌아오는데, 그걸 그대로 세면 `img_tag_count`가 0이 되어 프롬프트의 1순위
+    회귀 신호("0 → CSR bailout")로 오판된다. 단발 네트워크 오류가 곧바로
+    critical 판정이 되지 않도록 여기서 한 번 더 시도하고, 그래도 안 되면
+    호출부가 "측정 못 함"으로 구분할 수 있게 status를 None으로 남긴다.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return response.status, response.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as error:
+            body = error.read() or b""
+            return error.code, body.decode("utf-8", errors="replace")
+        except Exception:
+            if attempt < retries:
+                time.sleep(retry_delay)
+                continue
+            return None, ""
 
 
 def pick_recent_post_path(base_url: str) -> str | None:
@@ -237,8 +251,12 @@ def measure_url(url: str, runs: int) -> dict:
         "raw_html": {
             "status": status,
             "bytes": len(raw_html.encode("utf-8")),
-            # 0이면 정적 HTML에 LCP 후보 이미지가 없다는 뜻이다.
-            "img_tag_count": len(IMG_TAG_RE.findall(raw_html)),
+            # 0이면 정적 HTML에 LCP 후보 이미지가 없다는 뜻이다. 단, 200이 아니면
+            # 본문을 신뢰할 수 없으므로 0이 아니라 null(= 측정 못 함)로 남긴다.
+            # 그러지 않으면 단발 네트워크 오류가 1순위 회귀 신호로 둔갑한다.
+            "img_tag_count": (
+                len(IMG_TAG_RE.findall(raw_html)) if status == 200 else None
+            ),
         },
         "environment": summaries[0]["environment"],
         "settings": summaries[0]["settings"],
@@ -375,7 +393,7 @@ def write_step_summary(facts: dict) -> None:
             f"{kib(audits['unused_javascript']['savings_bytes'])} | "
             f"{kib(audits['total_byte_weight']['numeric_value'])} | "
             f"{audits['third_party_cookies']['item_count'] or 0} | "
-            f"{page['raw_html']['img_tag_count']} |"
+            f"{'측정불가' if page['raw_html']['img_tag_count'] is None else page['raw_html']['img_tag_count']} |"
         )
 
     if not facts["deltas"]["available"]:

--- a/.github/scripts/post-inventory-collect.py
+++ b/.github/scripts/post-inventory-collect.py
@@ -208,7 +208,12 @@ def main() -> int:
 
     scanned = 0
     posts = []
-    for path in sorted(posts_dir.rglob("*.md")):
+    # `.md`만 훑으면 `.mdx` 글이 조용히 빠진다 — 이 스크립트가 없애려던 실패
+    # 모드 그대로다. 미러링 대상인 lib/postFiles.ts의 collectMarkdownFiles가
+    # 둘 다 수집하고, 아래 파일명 정규식도 이미 `.mdx`를 상정하고 있다.
+    for path in sorted(
+        p for pattern in ("*.md", "*.mdx") for p in posts_dir.rglob(pattern)
+    ):
         scanned += 1
         data = parse_frontmatter(path.read_text(encoding="utf-8", errors="replace"))
         # frontmatter가 없거나 status가 enum 밖이면 메타 노트다 (isPostFile).

--- a/.github/workflows/claude-lighthouse.yml
+++ b/.github/workflows/claude-lighthouse.yml
@@ -60,6 +60,18 @@ jobs:
           # 러너에 설치된 Chrome을 lighthouse(chrome-launcher)가 찾도록 지정
           CHROME_PATH: /usr/bin/google-chrome
 
+      # 측정 원값을 남긴다. 베이스라인(.github/lighthouse-baseline.json)을 처음
+      # 만들 때 여기서 받아 커밋하고, 이후에는 회차별 실측을 직접 열어볼 수 있다.
+      # 측정이 실패해도 사실표는 올라가야 원인을 볼 수 있으므로 always().
+      - name: Upload lighthouse facts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: lighthouse-facts
+          path: lighthouse-facts.json
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Run Claude lighthouse report
         uses: anthropics/claude-code-action@v1
         with:
@@ -86,7 +98,10 @@ jobs:
               - `audits_median`: 미사용 JS 절감 바이트, 총 전송량, 서드파티 쿠키
                 개수, LCP/FCP/TBT/CLS
               - `raw_html.img_tag_count`: **정적 HTML의 `<img>` 개수.** 0이면
-                서버 HTML에 LCP 후보 이미지가 없다는 뜻(CSR bailout 신호)
+                서버 HTML에 LCP 후보 이미지가 없다는 뜻(CSR bailout 신호).
+                **null이면 원문을 못 가져온 것(측정 실패)이지 0이 아닙니다** —
+                회귀로 판정하지 말고 `raw_html.status`를 근거로 "확인 불가"라고
+                적으세요
             - `comparability`: benchmarkIndex와 베이스라인 대비 델타,
               `scores_comparable`
             - `deltas`: 베이스라인 대비 변화량
@@ -103,7 +118,8 @@ jobs:
             - `deltas`의 `unused_javascript` 증가가 +50KB 또는 +20% 이상
             - `total_byte_weight` 증가가 +15% 이상
             - `third_party_cookies` 개수 증가
-            - `img_tag_count`가 베이스라인보다 감소 (특히 1 이상 → 0)
+            - `img_tag_count`가 베이스라인보다 감소 (특히 1 이상 → 0).
+              **null은 감소가 아니라 측정 실패**이므로 제외합니다
 
             2순위(조건부):
             - 카테고리 점수(performance<0.90, accessibility<0.95,

--- a/.github/workflows/claude-site-smoke.yml
+++ b/.github/workflows/claude-site-smoke.yml
@@ -83,8 +83,8 @@ jobs:
             2. `posts_index.post_anchor_count`가 1 이상인지 — 0이면 CSR bail-out
                회귀(과거 PR #133에서 잡은 버그)로 critical
             3. `sitemap`: xml_valid가 true인지, 그리고 저장소의 발행 글이 loc에
-               누락 없이 들어있는지. 저장소 쪽 발행 글은 `apps/blog/posts/**/*.md`의
-               frontmatter로 판정하며, 규칙은
+               누락 없이 들어있는지. 저장소 쪽 발행 글은 `apps/blog/posts/**`의
+               마크다운(`.md`·`.mdx` 둘 다) frontmatter로 판정하며, 규칙은
                `apps/blog/web/domain/post/visibility.ts`가 단일 출처입니다
                (status: published, 또는 공개 시각이 지난 scheduled. status 키가
                없으면 포스트가 아님). Grep/Glob/Read로 확인하세요.


### PR DESCRIPTION
#193·#196에 달린 리뷰 3건을 반영하고, 잠들어 있던 델타 판정을 깨우기 위한 준비를 합니다.

## 리뷰 반영

### 1. 단발 네트워크 오류가 critical 회귀로 둔갑하던 문제 (#196 리뷰)

`lighthouse-collect.py`의 `fetch_text`는 예외를 삼키고 빈 문자열을 돌려주는데, 호출부가 `status`를 확인하지 않고 `img_tag_count`를 세고 있었습니다. 프롬프트의 **1순위 회귀 신호가 "`img_tag_count` 0 → CSR bailout"** 이라, 한 번의 네트워크 오류가 그대로 최상위 회귀 판정이 됩니다.

- 200이 아니면 0이 아니라 **`null`(측정 못 함)** 로 남깁니다
- 그전에 한 번 더 시도합니다 (단발 오류로 신호 자체를 잃지 않도록)
- 프롬프트에도 "null은 감소가 아니라 측정 실패이므로 제외"를 명시했습니다

site-smoke에서 쿼리스트링 링크를 배제했다가 앵커를 과소집계할 뻔한 것과 같은 계열의 버그입니다 — **판정 임계가 0인 지표는 측정 실패와 0을 반드시 구분해야 합니다.**

### 2. `.mdx` 글이 인벤토리에서 조용히 빠지던 문제 (#193 리뷰)

`post-inventory-collect.py`가 `*.md`만 훑고 있었습니다. 이 스크립트가 미러링한다고 명시한 `apps/blog/web/lib/postFiles.ts`의 `collectMarkdownFiles`는 `.md`/`.mdx`를 모두 수집하고(확인함), 같은 파일의 파일명 정규식 `\.(md|mdx)$`도 이미 `.mdx`를 상정하고 있었습니다.

현재 `.mdx` 파일이 0개라 증상은 없지만, 이건 **이 스크립트가 없애려던 "초록인데 조용히 빠짐" 실패 모드의 재발 경로**입니다.

### 3. site-smoke 프롬프트의 같은 사각지대 (#193 리뷰)

sitemap 누락 대조 대상이 `apps/blog/posts/**` → `apps/blog/posts/**/*.md`로 좁아져 있던 것을 되돌리고, `.md`·`.mdx` 둘 다임을 명시했습니다.

## 측정 원값 아티팩트

lighthouse 베이스라인(`.github/lighthouse-baseline.json`)이 아직 없어 `deltas.available: false`, `scores_comparable: null` 상태입니다. **설계의 절반이 잠들어 있는데**, 첫 베이스라인을 만들려면 사실표 JSON이 필요하고 그건 지금 Step Summary에만 있습니다.

`lighthouse-facts.json`을 아티팩트로 올립니다. 측정이 실패해도 원인을 봐야 하므로 `if: always()`입니다. 이후에는 회차별 실측을 직접 열어볼 수도 있습니다.

`actions/upload-artifact`의 SHA는 `git ls-remote`로 v4.6.2를 실측 확인했습니다 (저장소의 SHA 핀 관례).

## 검증

- 접속 불가(재시도 2회 후) → `img_tag_count: null`, 3.0s 소요
- HTTP 200 + `<img>` 2개 → `2`
- HTTP 404 + 본문에 `<img>` 1개 → `null` (본문을 신뢰하지 않음)
- `.mdx` draft 1건 임시 추가 → 인벤토리 draft 4 → **5**로 잡힘
- YAML 파싱 / py_compile / prettier 전부 통과

작업 중 `time` import 누락(재시도 로직을 넣으며 유입)이 있었는데 위 첫 테스트가 잡았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd)_