### PR TITLE
ci(claude): 베이스라인 제안본을 잡 로그에도 찍는다

### DIFF
--- a/.github/scripts/lighthouse-collect.py
+++ b/.github/scripts/lighthouse-collect.py
@@ -487,6 +487,17 @@ def main() -> int:
         )
         print(f"  {page['url']}: {rendered} img={page['raw_html']['img_tag_count']}")
 
+    # 베이스라인이 없으면 제안본을 **잡 로그에도** 찍는다. Step Summary와
+    # 아티팩트에도 들어가지만, 둘 다 접근이 막힌 환경(사내 프록시 등)에서는
+    # 로그가 유일한 통로다. 이게 없으면 델타 판정이 영영 잠들어 있게 된다.
+    if not facts["deltas"]["available"]:
+        print()
+        print("베이스라인이 없습니다. 아래를 .github/lighthouse-baseline.json 으로")
+        print("커밋하면 다음 회차부터 델타로 판정합니다.")
+        print("----- BEGIN lighthouse-baseline.json -----")
+        print(json.dumps(facts["baseline_suggestion"], ensure_ascii=False, indent=2))
+        print("----- END lighthouse-baseline.json -----")
+
     failed = [p for p in pages if p.get("error")]
     if len(failed) == len(pages):
         print("모든 URL 측정에 실패했습니다.", file=sys.stderr)


### PR DESCRIPTION
## 문제

lighthouse 베이스라인(`.github/lighthouse-baseline.json`)이 없으면 `deltas.available: false`, `scores_comparable: null`이 되어 **판정 설계의 절반이 잠깁니다.**

첫 베이스라인을 만들려면 사실표 JSON이 필요한데, 현재 통로가 둘뿐입니다.

| 통로 | 문제 |
| :--- | :--- |
| Step Summary | GitHub API로 읽을 수 없음 |
| 아티팩트 (#197에서 추가) | 다운로드 URL이 Azure 블롭이라 프록시 환경에서 403 |

실제로 #197 머지 후 실행한 run 5(`30963315271`)에서 아티팩트가 정상 생성됐지만(1,815 B), 다운로드가 막혀 베이스라인을 만들지 못했습니다.

## 변경

베이스라인이 없을 때만 제안본 JSON을 stdout에 구분선과 함께 출력합니다.

```
----- BEGIN lighthouse-baseline.json -----
{ ... }
----- END lighthouse-baseline.json -----
```

잡 로그는 어디서든 읽히므로 이게 마지막 통로가 됩니다. 베이스라인이 생기면 출력은 사라집니다.

## 검증

합성 리포트로 `main()`을 돌려 stdout을 캡처하고, 구분선 사이를 잘라 `json.loads`가 통과하는 것과 `audits_median`·`raw_html`·`url`이 모두 들어있는 것을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd)_