### PR TITLE
ci(claude): lighthouse 베이스라인을 심어 델타 판정을 켠다

### DIFF
--- a/.github/lighthouse-baseline.json
+++ b/.github/lighthouse-baseline.json
@@ -1,0 +1,36 @@
+{
+  "_note": "claude-lighthouse의 델타 판정 기준값. lighthouse-collect.py가 읽는다. 갱신하려면 이 파일을 지우고 워크플로우를 한 번 돌린 뒤, 잡 로그의 'BEGIN lighthouse-baseline.json' 블록(또는 lighthouse-facts 아티팩트의 baseline_suggestion)을 그대로 붙여넣으면 된다. 의도적으로 번들을 늘린 변경 뒤에는 반드시 갱신할 것 — 안 그러면 다음 회차부터 계속 회귀로 잡힌다.",
+  "_source": "run 30964244974 (2026-08-05T00:47:02Z, URL당 3회 중앙값, Lighthouse 13.4.1, mobile/simulate)",
+  "_caveat": "세 번째 항목은 '최근 발행 글'이라 새 글이 나오면 URL이 바뀐다. 그때는 그 페이지만 델타가 비고 나머지는 그대로 동작한다.",
+  "collected_at_utc": "2026-08-05T00:47:02Z",
+  "benchmark_index": 2861,
+  "pages": [
+    {
+      "url": "https://blog.sangwook.dev/",
+      "audits_median": {
+        "unused_javascript": { "savings_bytes": 400035 },
+        "total_byte_weight": { "numeric_value": 1332528 },
+        "third_party_cookies": { "item_count": 8 }
+      },
+      "raw_html": { "img_tag_count": 0 }
+    },
+    {
+      "url": "https://blog.sangwook.dev/posts/",
+      "audits_median": {
+        "unused_javascript": { "savings_bytes": 384088 },
+        "total_byte_weight": { "numeric_value": 1784184 },
+        "third_party_cookies": { "item_count": 8 }
+      },
+      "raw_html": { "img_tag_count": 0 }
+    },
+    {
+      "url": "https://blog.sangwook.dev/posts/getbyrole-performance/",
+      "audits_median": {
+        "unused_javascript": { "savings_bytes": 264521 },
+        "total_byte_weight": { "numeric_value": 1760330 },
+        "third_party_cookies": { "item_count": 8 }
+      },
+      "raw_html": { "img_tag_count": 1 }
+    }
+  ]
+}


### PR DESCRIPTION
베이스라인이 없어 `deltas.available: false`, `scores_comparable: null` 상태였습니다. 판정 설계의 절반 — **증감 비교**와 **"이 점수를 믿어도 되는가"** — 가 잠들어 있었습니다.

## 값의 출처

run [30964244974](https://github.com/Han5991/fe-lab/actions/runs/30964244974) (2026-08-05T00:47:02Z, URL당 3회 중앙값, Lighthouse 13.4.1, mobile/simulate)의 실측값입니다.

직전 회차(23:57:33Z)와 대조해 신뢰성을 확인했습니다.

| 지표 | 23:57 회차 | 00:47 회차 | 차이 |
| :--- | ---: | ---: | ---: |
| `/` 미사용 JS | 400,521 B | 400,035 B | 0.12% |
| `/posts/` 미사용 JS | 384,597 B | 384,088 B | 0.13% |
| 글 상세 미사용 JS | 264,508 B | 264,521 B | 0.005% |
| `img_tag_count` (3개 URL) | 0 / 0 / 1 | 0 / 0 / 1 | 동일 |
| `third_party_cookies` | 8 / 8 / 8 | 8 / 8 / 8 | 동일 |

호스트 독립 지표가 **회차 간 0.2% 안에서 일치**합니다. 같은 회차 안에서 Performance 점수가 0.43~0.91로 요동친 것과 대조적이고, 이게 판정 축을 이쪽으로 옮긴 이유 그대로입니다.

## 담은 것

`compute_deltas`가 실제로 보는 필드만 담았습니다 — 미사용 JS 절감 바이트, 총 전송량, 서드파티 쿠키 개수, 정적 HTML `<img>` 개수, 그리고 `benchmarkIndex`. 나머지 audit은 델타 비교에 쓰이지 않아 넣지 않았습니다.

갱신 방법과 함정은 파일 안 `_note`/`_caveat`에 적었습니다.

- **의도적으로 번들을 늘린 변경 뒤에는 반드시 갱신**해야 합니다. 안 그러면 다음 회차부터 계속 회귀로 잡힙니다
- 세 번째 항목은 "최근 발행 글"이라 새 글이 나오면 URL이 바뀝니다. 그때는 그 페이지만 델타가 비고 나머지는 정상 동작합니다

## 검증

| 시나리오 | 결과 |
| :--- | :--- |
| 변화 없음 | 델타 0, `scores_comparable: true` |
| 번들 회귀 | 미사용 JS **+80,000 B** (임계 +50KB 초과) 검출 |
| 서드파티 쿠키 증가 | 8 → 9, 델타 +1 검출 |
| 정적 이미지 유실 | `img_tag_count` 1 → 0 검출 |
| 느린 러너 (2861 → 2100, **-26.6%**) | `scores_comparable: false` — 점수가 회귀 근거에서 자동 제외 |

## 한 가지 투명하게

이 값들은 **아티팩트 원본 JSON이 아니라 실행이 보고한 수치에서 옮겨 적었습니다.** 아티팩트 다운로드 URL이 Azure 블롭이라 이 환경 프록시가 막고(403), 잡 로그는 Claude 액션이 프롬프트를 세 번 에코해 수집 스텝 출력까지 tail로 닿지 않았습니다.

위 회차 간 교차 대조로 값의 신뢰성은 확인했고, 혹시 어긋나더라도 다음 회차 델타 리포트에 바로 드러나며 파일을 지우고 한 번 돌리면 정확한 값으로 재생성됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiYwK8Kq4v12T6GZ4JKefd)_