### PR TITLE
fix(react): useWebSocket stale connect 수정 + eslint-plugin-react 중복 의존성 제거

### DIFF
--- a/apps/next.js/eslint.config.mjs
+++ b/apps/next.js/eslint.config.mjs
@@ -1,9 +1,34 @@
+import { createRequire } from 'node:module';
+
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 import nextTypescript from 'eslint-config-next/typescript';
+
+// eslint-config-next는 `settings.react.version: 'detect'`를 넣는데, 그 자동 감지
+// 경로(eslint-plugin-react `util/version.js`의 resolveBasedir)가 ESLint 10에서
+// 제거된 `context.getFilename()`을 폴백 없이 호출해 린트가 통째로 죽습니다.
+// 버전을 문자열로 주면 'detect' 분기 자체를 타지 않아 크래시를 피합니다.
+// eslint-plugin-react가 ESLint 10을 지원하면 이 블록은 제거 가능.
+// (apps/blog/web/eslint.config.mjs와 같은 워크어라운드)
+const reactVersion = createRequire(import.meta.url)(
+  'react/package.json',
+).version;
+
+// flat config의 settings 병합은 최상위 키 단위라, 상속값을 모아 version만 덮어씁니다.
+const inheritedReactSettings = [...nextCoreWebVitals, ...nextTypescript].reduce(
+  (acc, config) => ({ ...acc, ...(config.settings?.react ?? {}) }),
+  {},
+);
 
 const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypescript,
+  // 위 두 설정이 넣은 `react.version: 'detect'`를 덮어씁니다. 순서 의존적이라
+  // nextCoreWebVitals 뒤에 와야 합니다.
+  {
+    settings: {
+      react: { ...inheritedReactSettings, version: reactVersion },
+    },
+  },
   {
     rules: {
       '@typescript-eslint/consistent-type-imports': [

--- a/apps/next.js/package.json
+++ b/apps/next.js/package.json
@@ -35,7 +35,6 @@
     "@vitejs/plugin-react": "^5.2.0",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.3.0",
-    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^27.4.0",
     "next-router-mock": "^1.0.5",

--- a/apps/react/src/hooks/useWebSocket.test.ts
+++ b/apps/react/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,201 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWebSocket } from './useWebSocket';
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close(code = 1000) {
+    this.simulateClose(code);
+  }
+
+  // 테스트 헬퍼 — 서버 쪽 이벤트를 흉내낸다
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  simulateClose(code: number) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code } as CloseEvent);
+  }
+}
+
+const lastSocket = () =>
+  MockWebSocket.instances[MockWebSocket.instances.length - 1];
+
+describe('useWebSocket', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('마운트 시 소켓을 하나 연다', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test' }));
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(lastSocket().url).toBe('ws://test');
+    expect(result.current.isConnected).toBe(false);
+
+    act(() => lastSocket().simulateOpen());
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  test('자동 재연결 시 소켓이 정확히 하나만 새로 열린다 (이중 오픈 회귀 방지)', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test' }));
+    act(() => lastSocket().simulateOpen());
+
+    // 비정상 종료 → 백오프(1000ms) 후 재연결 예약
+    act(() => lastSocket().simulateClose(1006));
+    expect(result.current.isReconnecting).toBe(true);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // 타이머 경과 + 그로 인한 리렌더까지 지나도 새 소켓은 딱 하나여야 한다.
+    // (과거 구조: reconnectAttempt가 connect deps에 있어 마운트 effect가
+    // 재실행되며 소켓이 2개 열렸다)
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(result.current.reconnectAttempt).toBe(1);
+  });
+
+  test('재연결 백오프가 시도 횟수에 따라 늘어난다', () => {
+    renderHook(() =>
+      useWebSocket({
+        url: 'ws://test',
+        reconnectInterval: 1000,
+        reconnectBackoffMultiplier: 1.5,
+      }),
+    );
+
+    act(() => lastSocket().simulateClose(1006));
+    act(() => {
+      vi.advanceTimersByTime(1000); // attempt 0 → 1000ms
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    act(() => lastSocket().simulateClose(1006));
+    act(() => {
+      vi.advanceTimersByTime(1499); // attempt 1 → 1500ms — 아직
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  test('최대 재연결 횟수를 넘으면 더 이상 시도하지 않는다', () => {
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://test',
+        maxReconnectAttempts: 2,
+        reconnectInterval: 1000,
+        reconnectBackoffMultiplier: 1,
+      }),
+    );
+
+    for (let i = 0; i < 2; i += 1) {
+      act(() => lastSocket().simulateClose(1006));
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    // 3번째 실패 — attempt(2) >= max(2)라 예약 없음
+    act(() => lastSocket().simulateClose(1006));
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3);
+    expect(result.current.isReconnecting).toBe(false);
+    expect(
+      result.current.messages.some(m => m.includes('최대 재연결 시도 횟수')),
+    ).toBe(true);
+  });
+
+  test('정상 종료(1000)는 재연결하지 않는다', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test' }));
+    act(() => lastSocket().simulateOpen());
+
+    act(() => lastSocket().simulateClose(1000));
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(result.current.isReconnecting).toBe(false);
+  });
+
+  test('수동 reconnect는 시도 횟수를 리셋하고 새로 연결한다', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test' }));
+    act(() => lastSocket().simulateOpen());
+
+    act(() => result.current.reconnect());
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(result.current.reconnectAttempt).toBe(0);
+  });
+
+  test('재연결 대기 중 url이 바뀌면 새 url로 연결한다', () => {
+    const { rerender } = renderHook(({ url }) => useWebSocket({ url }), {
+      initialProps: { url: 'ws://a' },
+    });
+    act(() => lastSocket().simulateClose(1006)); // 재연결 예약된 상태
+
+    rerender({ url: 'ws://b' });
+    expect(lastSocket().url).toBe('ws://b');
+
+    // 이전 예약이 살아남아 ws://a로 추가 연결하지 않는다
+    const count = MockWebSocket.instances.length;
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(
+      MockWebSocket.instances.slice(count).every(s => s.url === 'ws://b'),
+    ).toBe(true);
+  });
+
+  test('sendMessage는 연결된 소켓으로 보낸다', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test' }));
+    act(() => lastSocket().simulateOpen());
+
+    act(() => result.current.sendMessage('hello'));
+    expect(lastSocket().sent).toEqual(['hello']);
+    const lastMessage =
+      result.current.messages[result.current.messages.length - 1];
+    expect(lastMessage).toBe('전송: hello');
+  });
+});

--- a/apps/react/src/hooks/useWebSocket.ts
+++ b/apps/react/src/hooks/useWebSocket.ts
@@ -52,6 +52,10 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const shouldReconnectRef = useRef(true);
+  // connect가 자기 자신을 setTimeout에서 참조하면 그 시점의 stale한 인스턴스가
+  // 잡힌다(react-hooks v7 immutability 위반). 항상 최신 connect를 부르도록
+  // ref를 경유한다.
+  const connectRef = useRef<(() => void) | null>(null);
 
   const addSystemMessage = useCallback((message: string) => {
     setMessages(prev => [...prev, `[시스템] ${message}`]);
@@ -101,7 +105,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
 
           reconnectTimeoutRef.current = setTimeout(() => {
             setReconnectAttempt(prev => prev + 1);
-            connect();
+            connectRef.current?.();
           }, delay);
         } else if (reconnectAttempt >= maxReconnectAttempts) {
           addSystemMessage(
@@ -127,6 +131,10 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
     reconnectAttempt,
     addSystemMessage,
   ]);
+
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   const disconnect = useCallback(() => {
     shouldReconnectRef.current = false;
@@ -164,6 +172,11 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
 
   useEffect(() => {
     shouldReconnectRef.current = true;
+    // 마운트에 소켓을 여는 것이 이 훅의 본질. connect는 생성 실패(catch)에서만
+    // 동기 setState를 하므로 렌더 루프 위험이 없다. (react-hooks v7의
+    // set-state-in-effect 대응 — v5에는 이 룰이 없어 이름을 특정하면 오히려
+    // "룰 없음" 에러가 나므로 이름 없이 끈다)
+    // eslint-disable-next-line
     connect();
 
     return () => {

--- a/apps/react/src/hooks/useWebSocket.ts
+++ b/apps/react/src/hooks/useWebSocket.ts
@@ -56,6 +56,11 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
   // 잡힌다(react-hooks v7 immutability 위반). 항상 최신 connect를 부르도록
   // ref를 경유한다.
   const connectRef = useRef<(() => void) | null>(null);
+  // 시도 횟수가 connect의 deps에 들어가면 재연결마다 connect identity가 바뀌어
+  // 마운트 effect가 재실행되고, 타임아웃 쪽 connect와 합쳐져 소켓이 이중으로
+  // 열린다. 판정·백오프는 ref로 읽고 state(reconnectAttempt)는 UI 표시용으로만
+  // 쓴다.
+  const reconnectAttemptRef = useRef(0);
 
   const addSystemMessage = useCallback((message: string) => {
     setMessages(prev => [...prev, `[시스템] ${message}`]);
@@ -69,6 +74,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
         console.log('WebSocket connected');
         setIsConnected(true);
         setIsReconnecting(false);
+        reconnectAttemptRef.current = 0;
         setReconnectAttempt(0);
         addSystemMessage('서버에 연결되었습니다.');
       };
@@ -89,25 +95,26 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
         wsRef.current = null;
 
         // 정상 종료(코드 1000)가 아니고 재연결이 활성화된 경우
+        const attempt = reconnectAttemptRef.current;
         if (
           event.code !== 1000 &&
           shouldReconnectRef.current &&
           autoReconnect &&
-          reconnectAttempt < maxReconnectAttempts
+          attempt < maxReconnectAttempts
         ) {
           setIsReconnecting(true);
           const delay =
-            reconnectInterval *
-            Math.pow(reconnectBackoffMultiplier, reconnectAttempt);
+            reconnectInterval * Math.pow(reconnectBackoffMultiplier, attempt);
           addSystemMessage(
-            `연결이 끊어졌습니다. ${Math.round(delay / 1000)}초 후 재연결 시도... (${reconnectAttempt + 1}/${maxReconnectAttempts})`,
+            `연결이 끊어졌습니다. ${Math.round(delay / 1000)}초 후 재연결 시도... (${attempt + 1}/${maxReconnectAttempts})`,
           );
 
           reconnectTimeoutRef.current = setTimeout(() => {
-            setReconnectAttempt(prev => prev + 1);
+            reconnectAttemptRef.current += 1;
+            setReconnectAttempt(reconnectAttemptRef.current);
             connectRef.current?.();
           }, delay);
-        } else if (reconnectAttempt >= maxReconnectAttempts) {
+        } else if (attempt >= maxReconnectAttempts) {
           addSystemMessage(
             `최대 재연결 시도 횟수(${maxReconnectAttempts}회)를 초과했습니다. 수동으로 재연결해주세요.`,
           );
@@ -128,7 +135,6 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
     maxReconnectAttempts,
     reconnectInterval,
     reconnectBackoffMultiplier,
-    reconnectAttempt,
     addSystemMessage,
   ]);
 
@@ -151,6 +157,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
   const reconnect = useCallback(() => {
     disconnect();
     shouldReconnectRef.current = true;
+    reconnectAttemptRef.current = 0;
     setReconnectAttempt(0);
     setIsReconnecting(true);
     addSystemMessage('수동으로 재연결을 시도합니다...');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       eslint-config-next:
         specifier: 16.3.0
         version: 16.3.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
-      eslint-plugin-react:
-        specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.5(jiti@2.4.2))
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.39.5(jiti@2.4.2))


### PR DESCRIPTION
renovate 메이저 PR 두 건(#241, #245)의 CI를 막고 있던 원인을 이쪽에서 미리 정리합니다.

## 변경 내용

### 1. `useWebSocket` 재연결의 stale `connect` 참조 수정 (#241 선행 작업)

`connect` useCallback이 재연결 `setTimeout` 안에서 자기 자신을 직접 참조하고 있었습니다. 그 시점 렌더의 인스턴스가 클로저에 잡혀 이후 재연결이 갱신 전 상태로 돌고, eslint-plugin-react-hooks v7의 `immutability` 룰이 이걸 에러로 잡아 #241 CI가 깨졌습니다. 최신 `connect`를 ref(`connectRef`)에 담아 호출하도록 바꿨습니다.

마운트 effect의 `connect()` 직접 호출도 v7 `set-state-in-effect`에 걸리는데(생성 실패 catch에서만 동기 setState), 마운트에 소켓을 여는 것이 훅의 본질이라 사유 주석과 함께 disable 처리했습니다. v5에는 이 룰이 없어 이름을 특정하면 "룰 없음" 에러가 나므로 이름 없는 disable을 씁니다.

### 2. `apps/next.js`의 `eslint-plugin-react` 직접 의존성 제거 (#245 선행 작업)

- `eslint-plugin-react`는 커뮤니티(jsx-eslint) 플러그인으로 React 팀 공식이 아니며, `eslint.config.mjs`가 직접 import하지 않고 `eslint-config-next`가 자체 dependencies로 내장합니다. 직접 의존성은 중복이라 제거했습니다. **완전 제거는 불가** — Next 공식 lint 구성(`eslint-config-next`)의 내부 의존성이라 그쪽을 버리지 않는 한 남습니다.
- `eslint-plugin-react-hooks`는 React Compiler 활성화용이므로 그대로 둡니다.
- ESLint 10에서 `eslint-plugin-react`의 React 버전 자동 감지가 제거된 `context.getFilename()`을 호출해 크래시하는 문제(#245의 실패 원인)에 대해, blog와 동일한 `settings.react.version` 고정 워크어라운드를 적용했습니다.

## 검증

세 조합 모두 로컬에서 lint/타입/테스트 통과 확인:

| 조합 | react lint | next.js lint | 테스트 |
| --- | --- | --- | --- |
| 현행 (eslint 9 + hooks v5) | ✅ (경고 1: 미사용 disable — v7 머지 시 해소) | ✅ | react 80, next.js 9 통과 |
| #241 시나리오 (hooks v7) | ✅ | — | react 80 통과 |
| #245 시나리오 (eslint 10) | ✅ | ✅ (blog도 ✅) | — |

머지 후 renovate가 #241을 리베이스하면 CI가 통과할 것이고, #245는 `eslint-plugin-react`가 ESLint 10 지원을 낼 때까지 대기입니다(크래시는 워크어라운드로 해소되지만 peer 의존성 경고가 남을 수 있음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf

---
_Generated by [Claude Code](https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf)_