### PR TITLE
chore(renovate): @ssgoi/react 업데이트 제안 비활성화

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,11 @@
       "enabled": false
     },
     {
+      "description": "@ssgoi/react는 업데이트 제안을 막는다. v7이 PageTransition의 API(paths·preserveScroll, AnyTransitionConfig 형태 등)와 비호환이라 마이그레이션 없이는 빌드가 깨진다(#246). 마이그레이션을 마치면 이 규칙을 지울 것",
+      "matchPackageNames": ["@ssgoi/react"],
+      "enabled": false
+    },
+    {
       "description": "major는 자동 머지하지 않고 deps-major 라벨을 붙인다 — 이 라벨이 붙은 PR만 claude-code-review.yml이 리뷰한다",
       "matchUpdateTypes": ["major"],
       "addLabels": ["deps-major"],


### PR DESCRIPTION
## 변경 내용

renovate `packageRules`에 `@ssgoi/react`의 업데이트 제안을 막는 규칙을 추가합니다.

- v7이 `PageTransition.tsx`의 API(`paths`·`preserveScroll`, `AnyTransitionConfig` 형태 등)와 비호환이라 마이그레이션 없이는 빌드가 깨집니다 — #246은 클로즈했습니다.
- 기존 `brace-expansion`·`js-yaml` 차단 규칙과 같은 방식(`enabled: false`)이고, 설명에 해제 조건(마이그레이션 완료 시 규칙 삭제)을 남겼습니다.
- 참고: minor/patch 제안까지 함께 막힙니다. 6.x 패치는 계속 받고 싶으시면 규칙에 `"matchUpdateTypes": ["major"]` 한 줄만 추가하면 major만 막힙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf

---
_Generated by [Claude Code](https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf)_