### PR TITLE
chore(pnpm): unrs-resolver 설치 스크립트를 allowBuilds에서 거부로 등록

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,10 @@ allowBuilds:
   supabase: true
   lefthook: true
   msw: false
+  # unrs-resolver(eslint-import-resolver-typescript 경유)의 postinstall은
+  # 플랫폼 네이티브 바이너리 폴백 체크다. 바이너리는 optionalDependencies로
+  # 이미 설치되므로 스크립트 없이도 동작한다 - 공급망 보수 원칙대로 거부.
+  unrs-resolver: false
 
 catalog:
   '@pandacss/dev': 1.12.0


### PR DESCRIPTION
#249(lockfile maintenance)의 CI 실패 원인 해소용 선행 PR입니다.

## 원인

lockfile 갱신이 `unrs-resolver@1.12.2`(`eslint-import-resolver-typescript` 경유, `eslint-config-next`의 간접 의존성)를 새로 끌어오는데, `allowBuilds`에 결정이 없는 패키지의 설치 스크립트를 pnpm 11이 fail-closed로 막아 CI `pnpm install`이 `ERR_PNPM_IGNORED_BUILDS`로 즉시 실패합니다.

## 조치

`allowBuilds`에 `unrs-resolver: false`(**거부**)를 추가합니다 — 이 postinstall은 네이티브 바이너리 폴백 체크이고, 바이너리 자체는 optionalDependencies로 이미 설치되므로 스크립트 없이 동작합니다. `msw: false`와 같은 보수적 처리입니다.

갱신된 lockfile(#249의 head)로 로컬에서 `pnpm install --frozen-lockfile` + 전체 워크스페이스 lint/check-types/test 17개 태스크 통과를 확인했습니다.

머지 후 #249를 리베이스시키면 automerge로 마무리됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf

---
_Generated by [Claude Code](https://claude.ai/code/session_019AWth5Ka6ad7p6QTrx9kcf)_