### PR TITLE
blog(series): 시리즈 판정을 읽는 시점 한 곳으로 모은다

### DIFF
--- a/apps/blog/web/domain/post/aggregate.ts
+++ b/apps/blog/web/domain/post/aggregate.ts
@@ -1,5 +1,5 @@
 import { getAllPosts } from './service';
-import { getSeriesMeta, isSeriesFolder } from './series';
+import { getSeriesMeta } from './series';
 import type { PostSummary } from './types';
 
 export interface SeriesSummary {
@@ -33,6 +33,10 @@ const COLOR_FALLBACK: SeriesSummary['colorKey'][] = [
 
 /**
  * 모든 시리즈를 최근 글 기준 내림차순으로 반환합니다.
+ *
+ * `post.series`는 `_series.yml`로 선언된 폴더에만 붙습니다(`repository.ts`).
+ * 그래서 여기서 시리즈 여부를 다시 거를 필요가 없습니다 — 걸러내는 조건을
+ * 두면 항상 참이라 "여기서도 판정한다"는 오해만 남습니다.
  */
 export function getAllSeries(): SeriesSummary[] {
   const posts = getAllPosts();
@@ -53,11 +57,8 @@ export function getAllSeries(): SeriesSummary[] {
     map.set(post.series, entry);
   }
 
-  // 색 배정은 걸러낸 뒤에 한다 — 시리즈가 아닌 폴더가 round-robin 순번을
-  // 잡아먹으면 남은 시리즈 색이 이유 없이 건너뛴다.
-  const series: SeriesSummary[] = Array.from(map.entries())
-    .filter(([id]) => isSeriesFolder(id))
-    .map(([id, { posts: ps, updated }], idx) => {
+  const series: SeriesSummary[] = Array.from(map.entries()).map(
+    ([id, { posts: ps, updated }], idx) => {
       const meta = getSeriesMeta(id);
       const colorKey = SERIES_COLOR_MAP[id] ?? COLOR_FALLBACK[idx % 3];
       return {
@@ -68,7 +69,8 @@ export function getAllSeries(): SeriesSummary[] {
         updated,
         colorKey,
       };
-    });
+    },
+  );
 
   return series.sort((a, b) => {
     if (a.updated && b.updated) return b.updated.localeCompare(a.updated);

--- a/apps/blog/web/domain/post/contract.test.ts
+++ b/apps/blog/web/domain/post/contract.test.ts
@@ -9,9 +9,14 @@
  */
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { getAllPosts, getAllPostsIncludingHidden } from './service';
+import {
+  getAllPosts,
+  getAllPostsIncludingHidden,
+  getSeriesAdjacentPosts,
+} from './service';
 import { isPostVisible } from './visibility';
-import { buildSitemapXml } from '@/scripts/generate-sitemap';
+import { isSeriesFolder } from './series';
+import { buildSitemapXml, getPostPriority } from '@/scripts/generate-sitemap';
 import { buildRssXml } from '@/scripts/generate-rss';
 import {
   buildAdminPostsIndex,
@@ -212,4 +217,71 @@ test('llms-full: Total posts 카운트가 실제 공개 글 수와 일치', () =
   const posts = getAllPosts();
   const text = buildLlmsFullText(posts);
   assert.ok(text.includes(`Total posts: ${posts.length}+ articles`));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 시리즈 단일 출처
+//
+// `series`는 `_series.yml`로 선언된 폴더에만 붙는다(`repository.ts`). 판정이 읽는
+// 시점 한 곳에서 끝나므로, 아래 불변식이 깨지면 배지·네비게이션뿐 아니라 검색·
+// OG 카드·llms까지 한꺼번에 어긋난다.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('contract: series는 _series.yml로 선언된 폴더에만 붙는다', () => {
+  const violations = getAllPostsIncludingHidden()
+    .filter((p): p is typeof p & { series: string } => Boolean(p.series))
+    .filter(p => !isSeriesFolder(p.series))
+    .map(p => `${p.slug} (series=${p.series})`);
+  assert.deepEqual(violations, []);
+});
+
+test('contract: 선언되지 않은 폴더의 글은 시리즈 네비게이션이 없다', () => {
+  // relativeDir은 있는데 series가 없는 글 = 폴더에는 있지만 시리즈가 아닌 글.
+  const grouped = getAllPosts().filter(p => p.relativeDir && !p.series);
+  assert.ok(
+    grouped.length > 0,
+    '검증이 공허하지 않으려면 시리즈가 아닌 폴더의 공개 글이 최소 1편은 있어야 함',
+  );
+  for (const p of grouped) {
+    const nav = getSeriesAdjacentPosts(p.slug);
+    assert.equal(nav.seriesName, null, `${p.slug}: seriesName`);
+    assert.equal(nav.prev, null, `${p.slug}: prev`);
+    assert.equal(nav.next, null, `${p.slug}: next`);
+  }
+});
+
+test('contract: 선언된 시리즈의 글은 시리즈 네비게이션이 있다 (대조군)', () => {
+  const seriesPosts = getAllPosts().filter(p => p.series);
+  assert.ok(seriesPosts.length > 0, '시리즈 글이 최소 1편은 있어야 함');
+  for (const p of seriesPosts) {
+    assert.ok(
+      getSeriesAdjacentPosts(p.slug).seriesName,
+      `${p.slug}: 시리즈인데 seriesName이 없음`,
+    );
+  }
+});
+
+test('contract: 검색 인덱스의 series는 선언된 시리즈만', () => {
+  // 예전엔 폴더에 글을 모아 두는 것만으로 검색 결과에 "📚 폴더명"이 붙었다.
+  for (const e of buildPublicSearchIndex(getAllPosts())) {
+    if (e.series) {
+      assert.ok(
+        isSeriesFolder(e.series),
+        `검색 인덱스에 비시리즈: ${e.series}`,
+      );
+    }
+  }
+});
+
+test('contract: sitemap 우선순위는 시리즈가 아니라 폴더 기준이다', () => {
+  // `typescript` 폴더에는 `_series.yml`이 없다. series로 판정하면 이 글의
+  // 우선순위가 조용히 0.6으로 떨어진다.
+  const post = getAllPosts().find(p => p.relativeDir === 'typescript');
+  if (!post) return; // 콘텐츠가 바뀌어 폴더가 사라지면 이 계약은 무의미해진다
+  assert.equal(
+    post.series,
+    undefined,
+    'typescript 폴더는 시리즈가 아니어야 함',
+  );
+  assert.equal(getPostPriority(post), '0.75');
 });

--- a/apps/blog/web/domain/post/repository.ts
+++ b/apps/blog/web/domain/post/repository.ts
@@ -5,6 +5,7 @@ import { estimateReadMin } from '@/lib/format';
 import { SEO_DESCRIPTION_MAX_LENGTH as EXCERPT_FALLBACK_LENGTH } from '@/lib/constants';
 import { collectMarkdownFiles, hasFrontmatter } from '@/lib/postFiles';
 import { isPostFile } from './visibility';
+import { isSeriesFolder } from './series';
 import type { PostData, RawFrontmatter } from './types';
 
 const postsDirectory = join(process.cwd(), '..', 'posts');
@@ -150,13 +151,40 @@ export function parsePost(
  *
  * 파일 I/O(collectMarkdownFiles + readFileSync)만 담당하고, 내용 → PostData
  * 변환은 순수 함수 parsePost에 위임합니다(null이면 메타 파일이므로 제외).
+ *
+ * **`series`를 붙일지 말지는 여기서 한 번에 끝냅니다.** parsePost는 경로만 보는
+ * 순수 함수라 폴더에 `_series.yml`이 있는지 알 수 없고, 디스크를 읽는 쪽은
+ * 여기입니다. 판정을 소비처마다 두면(`isSeriesFolder`를 검색·OG·llms에서 각각
+ * 부르면) 언젠가 한 곳을 빠뜨리고, 그게 정확히 예전 구조의 문제였습니다.
+ *
+ * 물리적 폴더는 `relativeDir`에 그대로 남습니다 — 시리즈가 아닌 폴더를 알아야
+ * 하는 쪽(sitemap 우선순위, JSON-LD articleSection)은 그쪽을 봅니다.
  */
 function collectPosts(dirPath: string): PostData[] {
   const results: PostData[] = [];
+  // 스캔 한 번 동안만 사는 메모. 모듈 수준 캐시로 올리지 않는 이유는
+  // getSeriesMeta가 dev에서 캐시를 우회하는 것과 같습니다 — `_series.yml`을
+  // 새로 만들거나 지우면 다음 요청에 바로 반영돼야 합니다.
+  const declaredSeries = new Map<string, boolean>();
+
   for (const fullPath of collectMarkdownFiles(dirPath)) {
     const fileContents = readFileSync(fullPath, 'utf8');
     const post = parsePost(fileContents, relative(dirPath, fullPath));
-    if (post) results.push(post);
+    if (!post) continue;
+
+    if (post.series) {
+      let declared = declaredSeries.get(post.series);
+      if (declared === undefined) {
+        declared = isSeriesFolder(post.series);
+        declaredSeries.set(post.series, declared);
+      }
+      if (!declared) {
+        results.push({ ...post, series: undefined });
+        continue;
+      }
+    }
+
+    results.push(post);
   }
 
   return results;

--- a/apps/blog/web/domain/post/service.ts
+++ b/apps/blog/web/domain/post/service.ts
@@ -1,10 +1,6 @@
 import { readAllPosts } from './repository';
 import { isPostVisible } from './visibility';
-import {
-  getSeriesMeta,
-  isSeriesFolder,
-  sortPostsBySeriesOrder,
-} from './series';
+import { getSeriesMeta, sortPostsBySeriesOrder } from './series';
 import type {
   PostData,
   PostNavItem,
@@ -159,9 +155,8 @@ export function getAdjacentPosts(
  * `_series.yml`의 `order` 필드가 있으면 그 순서대로 정렬하고,
  * 시리즈 표시명도 메타의 `title`로 대체합니다.
  *
- * 시리즈가 아닌 폴더(= `_series.yml`이 없다)는 전부 null입니다. 배지는
- * `isSeriesFolder`로 막으면서 이 네비게이션만 폴더 경로로 판정하면, 배지 없는
- * 글 아래에 "시리즈 이전 글"이 남습니다 — 판정은 한 곳에서만 합니다.
+ * 시리즈가 아닌 폴더(= `_series.yml`이 없다)의 글은 애초에 `series`가 비어
+ * 있으므로(`repository.ts`) 아래 첫 분기에서 전부 null로 나갑니다.
  */
 export function getSeriesAdjacentPosts(currentSlug: string): {
   prev: PostNavItem | null;
@@ -175,10 +170,6 @@ export function getSeriesAdjacentPosts(currentSlug: string): {
   }
 
   const meta = getSeriesMeta(currentPost.series);
-  if (!isSeriesFolder(currentPost.series, meta)) {
-    return { prev: null, next: null, seriesName: null };
-  }
-
   const displayName = meta?.title ?? currentPost.series;
 
   if (meta?.order && meta.order.length > 0) {

--- a/apps/blog/web/scripts/generate-sitemap.test.ts
+++ b/apps/blog/web/scripts/generate-sitemap.test.ts
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 import {
   buildSitemapXml,
   getPostPriority,
-  HIGH_PRIORITY_SERIES,
+  HIGH_PRIORITY_FOLDERS,
   HIGH_PRIORITY_SLUGS,
 } from './generate-sitemap';
 import type { SitemapPost } from './generate-sitemap';
@@ -21,7 +21,8 @@ function makePost(over: Partial<SitemapPost> = {}): SitemapPost {
     slug: 'hello-world',
     date: '2026-05-09',
     updatedAt: null,
-    series: undefined,
+    // 루트 글은 빈 문자열이다(`repository.ts`의 currentPath) — optional이 아니다.
+    relativeDir: '',
     ...over,
   };
 }
@@ -208,19 +209,32 @@ test('getPostPriority: 고우선 slug는 0.8 (HIGH_PRIORITY_SLUGS 전부 0.8)', 
   }
 });
 
-test('getPostPriority: 고우선 시리즈는 0.75 (HIGH_PRIORITY_SERIES 전부 0.75)', () => {
-  for (const series of HIGH_PRIORITY_SERIES) {
+test('getPostPriority: 고우선 폴더는 0.75 (HIGH_PRIORITY_FOLDERS 전부 0.75)', () => {
+  for (const relativeDir of HIGH_PRIORITY_FOLDERS) {
     assert.equal(
-      getPostPriority({ slug: 'arbitrary', series }),
+      getPostPriority({ slug: 'arbitrary', relativeDir }),
       '0.75',
-      `${series} series priority`,
+      `${relativeDir} folder priority`,
     );
   }
 });
 
+test('getPostPriority: 시리즈가 아닌 고우선 폴더도 0.75', () => {
+  // `typescript` 폴더에는 `_series.yml`이 없어 글의 series가 비어 있다.
+  // 우선순위를 series로 판정하면 이 글이 조용히 0.6으로 떨어진다.
+  assert.ok(HIGH_PRIORITY_FOLDERS.has('typescript'));
+  assert.equal(
+    getPostPriority({ slug: 'arbitrary', relativeDir: 'typescript' }),
+    '0.75',
+  );
+});
+
 test('getPostPriority: 그 외는 0.6', () => {
   assert.equal(getPostPriority({ slug: 'x' }), '0.6');
-  assert.equal(getPostPriority({ slug: 'x', series: 'random-series' }), '0.6');
+  assert.equal(
+    getPostPriority({ slug: 'x', relativeDir: 'random-folder' }),
+    '0.6',
+  );
 });
 
 test('sitemap: URL 절대 경로 형식 (loc은 https://...로 시작)', () => {

--- a/apps/blog/web/scripts/generate-sitemap.ts
+++ b/apps/blog/web/scripts/generate-sitemap.ts
@@ -5,9 +5,14 @@ import { SITE_URL, ABOUT_PAGE_MODIFIED } from '../lib/constants';
 import { parseScheduledDateKST, getKSTDateISO } from '../lib/dates';
 import { getAllPosts, encodePostSlug, type PostSummary } from '@/domain/post';
 
-// 시리즈별 고가치 포스트는 우선순위 높게 설정.
+// 고가치 주제 폴더의 글은 우선순위를 높게 설정.
 // 테스트에서 self-describing 패턴으로 참조하기 위해 export.
-export const HIGH_PRIORITY_SERIES = new Set([
+//
+// **시리즈가 아니라 폴더 기준이다.** 여기 있는 `typescript`에는 `_series.yml`이
+// 없어서 시리즈가 아니고, `post.series`로 비교하면 이 글의 우선순위가 조용히
+// 0.6으로 떨어진다. 우선순위는 "이 주제가 중요한가"의 문제라 연재 여부와
+// 무관하므로, 물리적 폴더(`relativeDir`)를 본다.
+export const HIGH_PRIORITY_FOLDERS = new Set([
   'bundler',
   'typescript',
   'open-source',
@@ -21,16 +26,18 @@ export const HIGH_PRIORITY_SLUGS = new Set([
 
 export function getPostPriority(post: {
   slug: string;
-  series?: string;
+  relativeDir?: string;
 }): string {
   if (HIGH_PRIORITY_SLUGS.has(post.slug)) return '0.8';
-  if (post.series && HIGH_PRIORITY_SERIES.has(post.series)) return '0.75';
+  if (post.relativeDir && HIGH_PRIORITY_FOLDERS.has(post.relativeDir)) {
+    return '0.75';
+  }
   return '0.6';
 }
 
 export type SitemapPost = Pick<
   PostSummary,
-  'slug' | 'series' | 'date' | 'updatedAt'
+  'slug' | 'relativeDir' | 'date' | 'updatedAt'
 >;
 
 /**

--- a/apps/blog/web/src/app/page.tsx
+++ b/apps/blog/web/src/app/page.tsx
@@ -5,7 +5,6 @@ import type { Metadata } from 'next';
 import {
   getAllPostSummaries,
   getSeriesMeta,
-  isSeriesFolder,
   sortPostsBySeriesOrder,
   type PostSummary,
 } from '@/domain/post';
@@ -132,10 +131,9 @@ function buildSeriesLabel(
   post: PostSummary,
   allPosts: PostSummary[],
 ): string | undefined {
+  // `series`는 `_series.yml`로 선언된 폴더에만 붙는다(`repository.ts`).
+  // 주제별로 모아 둔 폴더의 글은 여기서 그대로 빠진다.
   if (!post.series) return undefined;
-  // `_series.yml`이 없는 폴더는 시리즈가 아니다 — 주제별로 모아 둔 폴더에까지
-  // 배지가 붙는 것을 막는다(`isSeriesFolder`).
-  if (!isSeriesFolder(post.series)) return undefined;
   const siblings = allPosts.filter(p => p.series === post.series);
   const meta = getSeriesMeta(post.series);
   const ordered = sortPostsBySeriesOrder(siblings, meta?.order);

--- a/apps/blog/web/src/app/posts/[...slug]/page.tsx
+++ b/apps/blog/web/src/app/posts/[...slug]/page.tsx
@@ -5,11 +5,7 @@ import {
   getSeriesAdjacentPosts,
   getAllPosts,
 } from '@/domain/post';
-import {
-  getSeriesMeta,
-  isSeriesFolder,
-  sortPostsBySeriesOrder,
-} from '@/domain/post/series';
+import { getSeriesMeta, sortPostsBySeriesOrder } from '@/domain/post/series';
 import { resolveThumbnailUrl } from '@/domain/post/thumbnail';
 import { isPostVisible } from '@/domain/post/visibility';
 import { notFound } from 'next/navigation';
@@ -74,13 +70,11 @@ export default async function PostPage({ params }: Props) {
   // 시리즈 내 위치 계산 (헤더 라벨용)
   let seriesIndex:
     { current: number; total: number; displayName: string } | undefined;
-  // `_series.yml`이 없는 폴더는 시리즈가 아니다 — 주제별로 모아 둔 폴더까지
-  // 배지를 달면 `아키텍처 1/3`처럼 저자가 의도하지 않은 연재가 생긴다
-  // (`isSeriesFolder` 참고).
-  const seriesPosts =
-    post.series && isSeriesFolder(post.series)
-      ? getAllPosts().filter(p => p.series === post.series)
-      : [];
+  // `series`는 `_series.yml`로 선언된 폴더에만 붙는다(`repository.ts`). 주제별로
+  // 모아 둔 폴더의 글은 series가 비어 있어 배지가 생기지 않는다.
+  const seriesPosts = post.series
+    ? getAllPosts().filter(p => p.series === post.series)
+    : [];
   if (post.series && seriesPosts.length > 0) {
     const meta = getSeriesMeta(post.series);
     const orderedPosts = sortPostsBySeriesOrder(seriesPosts, meta?.order);

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.test.ts
@@ -233,13 +233,23 @@ describe('buildPostJsonLd (Schema.org BlogPosting)', () => {
     );
   });
 
-  test('articleSection: series 있으면 반영, 없으면 키 없음', () => {
+  test('articleSection: 폴더(relativeDir) 기준, 루트 글은 키 없음', () => {
+    // 섹션은 "이 글이 어디에 속하는가"라서 연재 여부와 무관하다. series로
+    // 잡으면 _series.yml을 두지 않은 주제 폴더의 글만 이 필드를 잃는다.
     expect(
-      buildPostJsonLd(makePost({ series: '번들러' }), 'x').articleSection,
+      buildPostJsonLd(makePost({ relativeDir: '번들러' }), 'x').articleSection,
     ).toBe('번들러');
     expect(
-      'articleSection' in buildPostJsonLd(makePost({ series: undefined }), 'x'),
+      'articleSection' in buildPostJsonLd(makePost({ relativeDir: '' }), 'x'),
     ).toBe(false);
+  });
+
+  test('articleSection: 시리즈가 아닌 폴더의 글에도 남는다', () => {
+    const jsonLd = buildPostJsonLd(
+      makePost({ relativeDir: 'typescript', series: undefined }),
+      'x',
+    );
+    expect(jsonLd.articleSection).toBe('typescript');
   });
 
   test('wordCount는 countWords 결과', () => {

--- a/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
+++ b/apps/blog/web/src/app/posts/[...slug]/postSeo.ts
@@ -145,7 +145,10 @@ export function buildPostJsonLd(
     wordCount: countWords(post.content),
     ...(post.tags &&
       post.tags.length > 0 && { keywords: post.tags.join(', ') }),
-    ...(post.series && { articleSection: post.series }),
+    // articleSection은 "이 글이 속한 섹션"이지 연재 여부가 아니다. 시리즈로
+    // 선언하지 않은 주제 폴더도 섹션이므로 물리적 폴더(`relativeDir`)를 쓴다
+    // — `series`로 쓰면 선언되지 않은 폴더의 글에서만 이 필드가 사라진다.
+    ...(post.relativeDir && { articleSection: post.relativeDir }),
     mainEntityOfPage: { '@type': 'WebPage', '@id': postUrl },
     url: postUrl,
     author: {


### PR DESCRIPTION
#256 후속. 리뷰 봇이 잡은 두 건([high] 검색·OG 미적용, [medium] 미커버 분기)을 함께 처리한다.

## 문제

#256에서 "**`_series.yml`이 있는 폴더만 시리즈**"로 규칙을 바꿨는데, 판정을 **소비처마다 부르는 구조는 그대로** 뒀다. 그래서 게이트가 걸린 곳과 안 걸린 곳이 갈렸다.

| | 판정 | |
| :--- | :--- | :--- |
| 홈 배지 · 글 상세 배지/네비 · 시리즈 목록 · `llms.txt` | `isSeriesFolder` | ✅ |
| 검색 결과 · OG 카드 · `llms-full` · admin 인덱스 | 없음 (`post.series` 직접 사용) | ❌ |

```
generate-search-index.ts:61   series: p.series || null
SearchDialog.tsx:432          📚 {post.series}
generate-og-images.ts:151     series pill + contentHash
```

게이트를 세 곳에 더 다는 방법도 있지만, 그러면 다음에 소비처가 하나 늘 때 또 빠뜨린다. 애초에 그게 이 리팩터가 없애려던 구조다.

## 근원에서 끊는다

`collectPosts`가 **읽는 시점에** `_series.yml`이 없는 폴더의 글에서 `series`를 떼어 낸다. 하류 전체가 손대지 않고 따라온다.

```ts
// repository.ts — collectPosts
if (post.series && !isSeriesFolder(post.series)) {
  results.push({ ...post, series: undefined });
  continue;
}
```

축이 둘로 갈린다.

| 필드 | 뜻 | 쓰는 곳 |
| :--- | :--- | :--- |
| `post.series` | 저자가 선언한 **연재** | 배지 · 네비 · 시리즈 목록 · 검색 라벨 · OG pill |
| `post.relativeDir` | 물리적 **폴더** | sitemap 우선순위 · JSON-LD `articleSection` |

## 조용한 회귀를 하나 막았다

`HIGH_PRIORITY_SERIES`에 있는 **`typescript` 폴더에는 `_series.yml`이 없다.** `series`로 비교한 채 근원에서 끊었다면 그 글의 sitemap 우선순위가 **0.75 → 0.6으로 소리 없이 떨어졌다.**

원래 "폴더"를 뜻하던 두 자리를 `relativeDir`로 옮겨 동작을 보존했다.

```diff
- export const HIGH_PRIORITY_SERIES = new Set([...])
- if (post.series && HIGH_PRIORITY_SERIES.has(post.series)) return '0.75';
+ export const HIGH_PRIORITY_FOLDERS = new Set([...])
+ if (post.relativeDir && HIGH_PRIORITY_FOLDERS.has(post.relativeDir)) return '0.75';

- ...(post.series && { articleSection: post.series }),
+ ...(post.relativeDir && { articleSection: post.relativeDir }),
```

`articleSection`도 "이 글이 속한 섹션"이지 연재 여부가 아니다 — 폴더가 맞다.

## 중복 게이트 정리

판정이 한 곳에서 끝나므로 소비처의 `isSeriesFolder` 호출은 걷어냈다(`aggregate.ts`, `service.ts`, 페이지 2곳). 항상 참인 조건을 남겨 두면 "여기서도 거른다"는 오해만 남는다.

`generate-llms.ts`는 주입된 meta로 단위 테스트되는 **순수 함수 경계**라 게이트를 유지한다.

## 실측 영향

```
series를 잃는 공개 글        5편  (전부 원래도 시리즈가 아니던 1편짜리 폴더)
  testing/getbyrole-performance            priority 0.6   og재생성 Y
  typescript/typescript-6-migration…       priority 0.75  og재생성 N  ← 보존됨
  design-system-lib-deploy/npm-deploy…     priority 0.6   og재생성 Y
  feconf/feconf-2025-lightning-speaker     priority 0.6   og재생성 Y
  회고/2024/2024-retrospect                 priority 0.6   og재생성 Y

검색 인덱스 series 값   34/43건, 전부 선언된 8개 시리즈
OG 카드 재생성          4편 (폴더명 pill 제거)
```

`public/og/`는 `.gitignore`라 저장소 diff는 없다 — 빌드 때 재생성된다.

## 테스트 7개

`contract.test.ts` 5개는 **실제 콘텐츠**로 불변식을 잠근다.

- `series`는 `_series.yml`로 선언된 폴더에만 붙는다
- 선언되지 않은 폴더의 글은 시리즈 네비게이션이 없다 ← *리뷰 봇이 지적한 미커버 분기*
- 선언된 시리즈의 글은 네비게이션이 있다 (대조군)
- 검색 인덱스의 `series`는 선언된 시리즈만
- sitemap 우선순위는 시리즈가 아니라 폴더 기준

나머지 2개는 `generate-sitemap.test.ts`·`postSeo.test.ts`에 폴더 기준 판정을 못 박는다.

```
node 625 pass · vitest 349 pass · tsc 0 · eslint 0
```
